### PR TITLE
Guard Pages deploy to public repository

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -19,6 +19,7 @@ concurrency:
 
 jobs:
   deploy:
+    if: github.repository == 'nikhgarg/EconCSLib'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
## Summary
- add a repository guard to the Pages deploy job so the workflow only deploys from nikhgarg/EconCSLib

## Validation
- inspected workflow diff