### PR TITLE
Clarify public status table headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ arXiv, conference, or original working-paper year. Public status tables use the
 published citation title and year.
 
 <!-- BEGIN GENERATED PAPER STATUS TABLE -->
-| Paper | Status | Review | Interface | Human summary |
+| Paper | Status | Human review | PaperInterface size | Public note |
 |---|---:|---:|---:|---|
 | [GS62 College Admissions](papers/GS62CollegeAdmissions) | Formalized | 0/7 | OK: 116 lines | This only uses a few lines of code as its infrastructure has largely been elevated to the shared matching library. |
 | [Roth82 Stable Matching](papers/Roth82StableMatching) | Formalized | 0/27 | OK: 468 lines |  |

--- a/docs/PAPER_STATUS.md
+++ b/docs/PAPER_STATUS.md
@@ -17,7 +17,7 @@ Paper IDs and folder names are stable artifact identifiers and may track
 an arXiv, conference, or original working-paper year. The table below uses
 the published citation title and year.
 
-| Paper info | Status | Human review | Lean LOC | Note |
+| Paper, authors, publication | Status | Human review | Lean LOC | Public note |
 |---|---|---:|---:|---|
 | [College Admissions and the Stability of Marriage](http://www.jstor.org/stable/2312726) by D. Gale and L. S. Shapley; American Mathematical Monthly, 1962. | [Formalized](../papers/GS62CollegeAdmissions/FINAL_VALIDATION_REPORT.md) | 0/7 | 388 | This only uses a few lines of code as its infrastructure has largely been elevated to the shared matching library. |
 | [The Economics of Matching: Stability and Incentives](https://pubsonline.informs.org/doi/epdf/10.1287/moor.7.4.617) by Alvin E. Roth; Mathematics of Operations Research, 1982. | [Formalized](../papers/Roth82StableMatching/FINAL_VALIDATION_REPORT.md) | 0/27 | 8,877 |  |

--- a/scripts/audit_repository.py
+++ b/scripts/audit_repository.py
@@ -137,7 +137,7 @@ README_STATUS_DETAIL_RE = re.compile(
     r"DependencyDAG\.tex|MainTheorems\.lean",
     re.I,
 )
-README_STATUS_HEADER = ["Paper", "Status", "Review", "Interface", "Human summary"]
+README_STATUS_HEADER = ["Paper", "Status", "Human review", "PaperInterface size", "Public note"]
 README_REVIEW_COUNT_RE = re.compile(r"^\d+/\d+$")
 README_MAX_STATUS_ROWS = 20
 MARKDOWN_LINK_RE = re.compile(r"\[([^\]]+)\]\([^)]+\)")
@@ -1016,7 +1016,7 @@ def check_root_human_status_table(readme: Path) -> list[Finding]:
             Finding(
                 "ERROR",
                 readme,
-                "top-level README should include a concise human status table: `Paper | Status | Review | Interface | Human summary`",
+                "top-level README should include a concise human status table: `Paper | Status | Human review | PaperInterface size | Public note`",
             )
         )
         return findings
@@ -1027,9 +1027,9 @@ def check_root_human_status_table(readme: Path) -> list[Finding]:
     header, rows = matching_tables[0]
     paper_idx = header.index("Paper")
     status_idx = header.index("Status")
-    review_idx = header.index("Review")
-    interface_idx = header.index("Interface")
-    summary_idx = header.index("Human summary")
+    review_idx = header.index("Human review")
+    interface_idx = header.index("PaperInterface size")
+    summary_idx = header.index("Public note")
     seen: set[str] = set()
 
     if len(rows) > README_MAX_STATUS_ROWS:
@@ -1294,7 +1294,7 @@ def check_human_facing_readme() -> list[Finding]:
             Finding(
                 "ERROR",
                 readme,
-                "top-level README should use the concise `Paper | Status | Review | Interface | Human summary` table, not the full paper ledger",
+                "top-level README should use the concise `Paper | Status | Human review | PaperInterface size | Public note` table, not the full paper ledger",
             )
         )
     findings.extend(check_root_human_status_table(readme))

--- a/scripts/sync_paper_status.py
+++ b/scripts/sync_paper_status.py
@@ -628,7 +628,7 @@ def render_readme_status_block(records: list[tuple[Path, dict[str, Any]]]) -> st
     by_id = {payload["id"]: payload for _folder, payload in records}
     lines = [
         README_STATUS_BEGIN,
-        "| Paper | Status | Review | Interface | Human summary |",
+        "| Paper | Status | Human review | PaperInterface size | Public note |",
         "|---|---:|---:|---:|---|",
     ]
     for row in human_status_rows(records):
@@ -685,7 +685,7 @@ def render_paper_status_md(payload: dict[str, Any]) -> str:
         "an arXiv, conference, or original working-paper year. The table below uses",
         "the published citation title and year.",
         "",
-        "| Paper info | Status | Human review | Lean LOC | Note |",
+        "| Paper, authors, publication | Status | Human review | Lean LOC | Public note |",
         "|---|---|---:|---:|---|",
     ]
     for row in payload["papers"]:

--- a/site/index.html
+++ b/site/index.html
@@ -168,8 +168,8 @@
               <tr>
                 <th>Paper</th>
                 <th>Status</th>
-                <th>Lines of code</th>
-                <th>Note</th>
+                <th>Lean LOC</th>
+                <th>Public note</th>
                 <th>Human review</th>
                 <th>LLM-as-judge statement translation</th>
               </tr>


### PR DESCRIPTION
## Summary
- rename terse README status-table headers to spell out human review, PaperInterface size, and public notes
- rename Paper Status and site headers for public notes and Lean LOC

## Validation
- python3 scripts/sync_paper_status.py --check