### PR TITLE
Add AI formalization workflow skill

### DIFF
--- a/skills/ai-formalization-workflows/SKILL.md
+++ b/skills/ai-formalization-workflows/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: ai-formalization-workflows
+description: Apply workflow lessons from recent AI-assisted formalization systems to EconCSLib paper formalization. Use when planning or reviewing autoformalization pipelines, proof-DAG or blueprint workflows, retrieval-grounded statement translation, compiler-guided repair loops, semantic-alignment checks, multi-agent scheduling, or human-in-the-loop validation for Lean formalization.
+---
+
+# AI Formalization Workflows
+
+Use this skill when improving an EconCSLib paper-formalization workflow or
+planning automation around statement extraction, dependency ordering,
+proof repair, semantic validation, or multi-agent formalization.
+
+Primary survey source: Garg, *EconCSLib: AI-Assisted Lean Formalization for
+Economics & Computation research*, arXiv:2606.13306, especially the related-work
+discussion of recent LLM-based formalization systems.
+
+For the detailed source ledger and paper-by-paper credits, load
+`references/paper-workflow-insights.md`.
+
+## Workflow Stack
+
+### 1. Split Before Proving
+
+Start with a document-to-project plan:
+
+- extract named results, source definitions, proof dependencies, and notation;
+- decide which results are paper-facing, reusable library candidates, or local
+  helper lemmas;
+- create a dependency DAG or blueprint before deep Lean work;
+- compile declaration skeletons before trying to close proofs.
+
+Credits: M2F for two-stage statement-then-proof project construction;
+ProofFlow and Aria for dependency-graph-driven decomposition; LeanArchitect for
+keeping blueprint metadata synchronized with Lean declarations; MathAtlas for
+the observation that dependency depth is itself a difficulty signal.
+
+### 2. Ground Translation In Existing APIs
+
+Before inventing definitions, retrieve and inspect existing formal concepts:
+
+- search Mathlib, CSLib, and EconCSLib by concept and theorem role;
+- prefer source-compatible library definitions over new local encodings;
+- if a new definition is needed, give it a local paper-facing equivalence test
+  before relying on it downstream;
+- avoid looping on guessed Lean names.
+
+Credits: LeanDojo/ReProver for premise retrieval; CRAMF and Aria for
+concept-level grounding against Mathlib definitions; ProofBridge for retrieving
+semantically similar theorem/proof pairs.
+
+### 3. Use Compiler-Guided Repair Loops
+
+Treat Lean feedback as the central verifier signal:
+
+- generate a candidate statement or proof;
+- run the narrowest Lean check that exercises it;
+- parse the concrete error, goal state, imports, and missing premises;
+- make local repairs under fixed statement signatures where possible;
+- retain successful repairs and useful failed attempts as future retrieval
+  examples.
+
+Credits: Baldur for whole-proof generation plus repair from error context;
+APOLLO for isolating failing subgoals and recombining repaired subproofs;
+OProver for turning verified proofs, failures, and repairs into retrieval memory
+and training data; FMC and FormalScience for iterative Lean error feedback.
+
+### 4. Preserve Proof Structure, Then Deviate Explicitly
+
+Default to a lemma-by-lemma proof route that mirrors the source proof. If this
+is inefficient or the source is underspecified, switch proof strategy only after
+recording the reason:
+
+- mark which source step is being replaced;
+- prove the same paper-facing statement or clearly document a source deviation;
+- keep the dependency graph honest after the route changes.
+
+Credits: ProofFlow for structural fidelity as a first-class objective; Draft,
+Sketch, and Prove for using informal proof sketches to guide formal proving;
+LeanArchitect for exposing blueprint inconsistencies.
+
+### 5. Validate Semantic Alignment Separately
+
+Compilation is necessary but not enough. Run a separate translation-alignment
+layer for paper-facing statements:
+
+- back-translate Lean statements to LaTeX or natural language without source
+  context;
+- compare back-translation against source statements;
+- use human review for final paper-facing claims;
+- flag source deviations, hidden assumptions, and newly introduced axioms;
+- treat alignment scores as review aids, not proof of semantic correctness.
+
+Credits: MerLean and EconCSLib for Lean-to-LaTeX review loops; FormalScience for
+multi-stage human review and proof-boundary extraction; FormalAlign and cycle
+consistency work for automated semantic-alignment checks.
+
+### 6. Schedule Multi-Agent Work By Dependencies
+
+Use subagents only when the task has a stable interface:
+
+- assign read-only source/API scouting before proof edits;
+- split proof work along independent DAG regions or separate files;
+- merge through version control and targeted builds;
+- keep shared-library edits narrow and announce API changes before downstream
+  paper agents depend on them.
+
+Credits: Automatic Textbook Formalization and AutoformBot/Atlas for
+large-scale, version-control-mediated multi-agent formalization; Urban's
+topology report for a cheap long-running LLM/checker feedback loop.
+
+### 7. Keep Human-Facing Artifacts Current At Boundaries
+
+At real proof boundaries, update artifacts that let humans review the result:
+
+- paper-facing interface;
+- dependency DAG or blueprint;
+- validation/audit report;
+- status metadata;
+- source-deviation and remaining-boundary list.
+
+Do not turn active proof loops into constant status churn.
+
+Credits: EconCSLib for paper-facing interfaces, DAGs, validation reports, and
+review dashboards; LeanArchitect for synchronized blueprint metadata; FormalScience
+for explicit audit trails through generated intermediate artifacts.
+
+## EconCSLib Application Checklist
+
+When starting or rescuing a paper formalization:
+
+1. Cache the source PDF/TeX once.
+2. Build a named-result inventory and dependency DAG.
+3. Compile paper-facing declarations and placeholders before proof closure.
+4. Run a retrieval pass over Mathlib, CSLib, and EconCSLib for every nontrivial
+   concept.
+5. Close proofs in dependency order, using compiler-guided repair.
+6. Preserve source proof structure unless a documented deviation is faster and
+   still proves the source claim.
+7. Back-translate and review paper-facing statements at start and closeout.
+8. Promote reusable tools only after they pass the second-paper or future-paper
+   test.
+9. Update human-facing docs only at proof boundaries or closeout.
+
+This skill complements `skills/econcs-formalizer/SKILL.md`; it supplies external
+workflow patterns, while the formalizer skill remains the source of truth for
+EconCSLib-specific paper status, audit, and repository rules.

--- a/skills/ai-formalization-workflows/references/paper-workflow-insights.md
+++ b/skills/ai-formalization-workflows/references/paper-workflow-insights.md
@@ -1,0 +1,216 @@
+# Paper Workflow Insights
+
+Last reviewed through: 2026-06-27.
+
+This ledger records the AI-formalization workflow papers reviewed from the
+related-work discussion in Garg, *EconCSLib: AI-Assisted Lean Formalization for
+Economics & Computation research*, arXiv:2606.13306. It is a credit and source
+map for `../SKILL.md`, not a replacement for the operational EconCSLib
+formalizer skill.
+
+## Core Source
+
+- Garg, *EconCSLib: AI-Assisted Lean Formalization for Economics & Computation
+  research*, arXiv:2606.13306.
+  Contribution: paper-oriented human-AI-Lean loop; compact paper-facing Lean
+  interfaces; DAGs; post-formalization validation reports; review dashboard;
+  LLM-as-judge back-translation; reusable library elevation from papers.
+
+## Project-Scale Formalization
+
+- Wang et al., *M2F: Automated Formalization of Mathematical Literature at
+  Scale*, arXiv:2602.17016.
+  Contribution: split long-form sources into atomic blocks, infer dependency
+  order, compile declaration skeletons first, then repair proofs under fixed
+  signatures. Public generated code: <https://github.com/optsuite/ReasBook.git>.
+
+- Gloeckle et al., *Automatic Textbook Formalization*, arXiv:2604.03071.
+  Contribution: large multi-agent textbook formalization via shared codebase,
+  version control, side-by-side blueprint site, and many agents working in
+  parallel on dependency-compatible regions.
+
+- Rammal et al., *Formalizing Mathematics at Scale*, arXiv:2605.29955.
+  Contribution: AutoformBot/Atlas pattern: dependency-aware task scheduling,
+  collaborative version control, and verifier-equipped LLM agents for
+  large-scale Lean library construction.
+
+- Urban, *130k Lines of Formal Topology in Two Weeks: Simple and Cheap
+  Autoformalization for Everyone?*, arXiv:2601.03298.
+  Contribution: long-running low-overhead LLM/checker loop can scale when the
+  proof checker is fast and the feedback loop is simple.
+
+- Wang et al., *MathAtlas: A Benchmark for Autoformalization in the Wild*,
+  arXiv:2605.14061.
+  Contribution: dependency graphs are evaluation objects, not just planning
+  artifacts; deep dependency trees are a difficulty signal and should guide
+  scheduling and partial-boundary selection.
+
+## Dependency Graphs, Blueprints, and Structural Fidelity
+
+- Cabral et al., *ProofFlow: A Dependency Graph Approach to Faithful Proof
+  Autoformalization*, arXiv:2510.15981.
+  Contribution: build a proof-step DAG, formalize intermediate lemmas, and score
+  syntactic correctness, semantic faithfulness, and structural fidelity.
+  Public code: <https://github.com/Huawei-AI4Math/ProofFlow>.
+
+- Zhu, Monticone, Avigad, and Welleck, *LeanArchitect: Automating Blueprint
+  Generation for Humans and AI*, arXiv:2601.22554.
+  Contribution: keep informal blueprint metadata and formal Lean declarations
+  synchronized from Lean annotations; use generated dependency data to expose
+  blueprint inconsistencies and track progress.
+
+- Wang et al., *Aria: An Agent For Retrieval and Iterative Auto-Formalization
+  via Dependency Graph*, arXiv:2510.04520.
+  Contribution: recursively decompose statements into a dependency graph, then
+  construct formalizations from grounded formal concepts; use term-level
+  grounding/scoring before accepting translations.
+
+- Jiang et al., *Draft, Sketch, and Prove: Guiding Formal Theorem Provers with
+  Informal Proofs*, arXiv:2210.12283.
+  Contribution: informal proof sketches can guide proof search and subgoal
+  decomposition; use source proof structure as guidance, not as unquestioned
+  executable content.
+
+## Retrieval and Grounding
+
+- Yang et al., *LeanDojo: Theorem Proving with Retrieval-Augmented Language
+  Models*, NeurIPS 2023.
+  Contribution: programmatic Lean interaction, accessible-premise extraction,
+  hard-negative premise selection, and retrieval-augmented proving.
+  Public code: <https://github.com/lean-dojo/LeanDojo>.
+
+- Lu et al., *Automated Formalization via Conceptual Retrieval-Augmented LLMs*,
+  arXiv:2508.06931.
+  Contribution: retrieve formal definitions for core mathematical concepts and
+  use domain/application context to disambiguate polymorphic concepts.
+
+- Jana et al., *ProofBridge: Auto-Formalization of Natural Language Proofs in
+  Lean via Joint Embeddings*, arXiv:2510.15681.
+  Contribution: retrieve semantically aligned theorem/proof pairs across
+  natural and formal language; evaluate theorem+proof semantic correctness, not
+  theorem strings alone.
+
+- Song, Yang, and Anandkumar, *Towards Large Language Models as Copilots for
+  Theorem Proving in Lean*, arXiv:2404.12534.
+  Contribution: integrate LLM tools into the Lean workflow for tactic
+  suggestion, proof search, and premise selection, while keeping humans in the
+  loop. Public code: <https://github.com/lean-dojo/LeanCopilot>.
+
+## Compiler-Guided Generation and Repair
+
+- First et al., *Baldur: Whole-Proof Generation and Repair with Large Language
+  Models*, arXiv:2303.04910.
+  Contribution: whole-proof generation plus repair from failed attempt and
+  compiler error context.
+
+- Ospanov, Farnia, and Yousefzadeh, *APOLLO: Automated LLM and Lean
+  Collaboration for Advanced Formal Reasoning*, arXiv:2505.05758.
+  Contribution: modular repair agents isolate syntax errors, failing sublemmas,
+  automated-solver opportunities, and remaining goals before recombining and
+  rechecking proofs.
+
+- Ma et al., *OProver: A Unified Framework for Agentic Formal Theorem Proving*,
+  arXiv:2605.17283.
+  Contribution: failed attempts, compiler feedback, retrieved proofs, and
+  successful repairs should become a persistent retrieval/training memory.
+
+- Xie et al., *FMC: Formalization of Natural Language Mathematical Competition
+  Problems*, arXiv:2507.11275.
+  Contribution: few-shot prompting, Lean error feedback, and multiple samples
+  materially improve formalization; keep generated datasets only after quality
+  filtering.
+
+- Huang et al., *FormaRL: Enhancing Autoformalization with no Labeled Data*,
+  arXiv:2508.18914.
+  Contribution: syntax checks and semantic/consistency checks can be converted
+  into training rewards, even with little labeled data. Public code:
+  <https://github.com/THUNLP-MT/FormaRL>.
+
+## Semantic Alignment and Human Review
+
+- Ren, Li, and Qi, *MerLean: An Agentic Framework for Autoformalization in
+  Quantum Computation*, arXiv:2602.16554.
+  Contribution: extract statements from LaTeX, formalize to Lean, and translate
+  Lean back to human-readable LaTeX so review can focus on new definitions and
+  axioms.
+
+- Meadows, Zhang, and Freitas, *FormalScience: Scalable Human-in-the-Loop
+  Autoformalisation of Science with Agentic Code Generation in Lean*,
+  arXiv:2604.23002.
+  Contribution: staged human review, structured QA extraction, Lean prompts,
+  batch-level compilation, proof-boundary validation, flattened training data,
+  and explicit audit trail for semantic drift. Public code:
+  <https://github.com/jmeadows17/formal-science>.
+
+- Lu et al., *FormalAlign: Automated Alignment Evaluation for
+  Autoformalization*, arXiv:2410.10135.
+  Contribution: automated natural/formal semantic-alignment evaluation can
+  reduce but not replace manual verification. Public code:
+  <https://github.com/rookie-joe/FormalAlign>.
+
+- Shebzukhov, *Improving Lean4 Autoformalization via Cycle Consistency
+  Fine-tuning*, arXiv:2603.24372.
+  Contribution: natural-language-to-Lean-to-natural-language cycle consistency
+  is a useful signal for meaning preservation; treat it as a review heuristic,
+  not a proof of equivalence.
+
+- Meadows et al., FormalScience codebase.
+  Code-specific contribution: retain intermediate artifacts (`qa_data`,
+  `lean_prompt_data`, raw Lean outputs, structured proofs, postprocessed
+  batches) so reviewers can trace how a formal answer was produced.
+
+## Interfaces and External Tooling
+
+- Aniva et al., *Pantograph: A Machine-to-Machine Interaction Interface for
+  Advanced Theorem Proving, High Level Reasoning, and Data Extraction in Lean
+  4*, arXiv:2410.16429.
+  Contribution: programmatic Lean interfaces make proof search, state
+  extraction, and high-level agent reasoning more robust than ad hoc shell
+  parsing.
+
+- Klaus, Tolmach, and Conejero, *A Rust-to-Lean Verification Pipeline with AI
+  Provers: An Experience Report*, arXiv:2605.30106.
+  Contribution: for extracted-code verification, separate source extraction,
+  specification libraries, AI proof generation, and kernel-checked proof
+  obligations; document toolchain drift and missing-lemma friction explicitly.
+
+## Benchmark and Survey Context
+
+- Azerbayev et al., *ProofNet: Autoformalizing and Formally Proving
+  Undergraduate-Level Mathematics*, arXiv:2302.12433.
+  Contribution: pair natural statements/proofs with formal theorem statements
+  and use prompt retrieval/backtranslation baselines.
+
+- Zheng, Han, and Polu, *MiniF2F: a cross-system benchmark for formal
+  olympiad-level mathematics*, arXiv:2109.00110.
+  Contribution: benchmarks must separate statement formalization from proof
+  search and support cross-system comparison.
+
+- Ying et al., *Lean Workbook: A Large-Scale Lean Problem Set Formalized from
+  Natural Language Math Problems*, NeurIPS 2024.
+  Contribution: large curated natural-language/Lean corpora can feed benchmark,
+  retrieval, and training loops.
+
+- Gao et al., *Herald: A natural language annotated Lean 4 dataset*, ICLR 2025.
+  Contribution: natural-language annotations around Lean declarations are useful
+  retrieval and training material.
+
+- Weng et al., *Autoformalization in the Era of Large Language Models: A
+  Survey*, arXiv:2505.23486.
+  Contribution: organize workflow analysis end-to-end: preprocessing, model
+  design, evaluation, applications, datasets, and open challenges.
+
+## Practical Translation Into EconCSLib
+
+- Use dependency graphs both as planning artifacts and as review surfaces.
+- Compile statement skeletons first; proof repair should not keep changing the
+  public theorem signature unless source translation was wrong.
+- Treat concept retrieval as part of translation validation, not just proof
+  search.
+- Keep a durable record of candidate statements, failed proof attempts, Lean
+  errors, repaired proof fragments, and final accepted declarations.
+- Separate semantic-alignment review from kernel proof checking.
+- Use human review at theorem boundaries, new definitions, source deviations,
+  and remaining assumptions.
+- For multi-agent runs, schedule work by DAG region and require each worker to
+  report exact files, declarations, and validation commands.

--- a/skills/econcs-formalizer/SKILL.md
+++ b/skills/econcs-formalizer/SKILL.md
@@ -9,6 +9,12 @@ Use this skill to turn economics-and-computation papers into maintainable Lean
 code. Keep repository-specific status out of this file; in `EconCSLib`, that
 belongs in `docs/ECONCSLEAN_CURRENT_STATUS.md`.
 
+When planning automation-heavy formalization workflows, multi-agent proof
+campaigns, retrieval-grounded statement translation, or compiler-guided repair
+loops, also consult `skills/ai-formalization-workflows/SKILL.md`. That skill is
+a source-credited ledger of external AI-formalization workflow patterns; this
+formalizer skill remains the operational rulebook for EconCSLib.
+
 ## Component 1: Workflow and Organization
 
 ### 1.1 Core Rule
@@ -1237,11 +1243,23 @@ formalization, execute the standard intake before deep proof work:
 - Read the abstract, introduction, model section, and theorem statements first;
   then search the cached text for every named `Definition`, `Lemma`,
   `Proposition`, `Theorem`, `Corollary`, and appendix result.
+- Before deep proof work, build a source-block map: one row per paper-facing
+  definition, displayed formula, named result, and proof-critical appendix
+  claim, with source location, dependencies, intended Lean declaration, status,
+  and likely library APIs. Use this map to drive the DAG, paper-facing skeleton,
+  and review dashboard. Keep public theorem signatures stable once proof work
+  begins; if translation is wrong, repair the statement early rather than
+  letting proof search drift the target.
 - Create the paper folder contract artifacts immediately: `README.md`,
   `DependencyDAG.tex`, `MainTheorems.lean`, and local `.gitignore`.
 - Draft paper-facing theorem signatures before building a helper tower. If the
   direct statement is too hard, create an explicit bridge theorem whose name and
   assumptions describe the remaining gap.
+- Run a retrieval-grounding pass before inventing a new model or helper API:
+  search Mathlib, Cslib, Optlib when present, and existing `EconCSLib/` modules
+  for the source concept and proof role. Prefer existing formal concepts; if a
+  paper-local encoding is necessary, add a small equivalence or sanity theorem
+  before using it downstream.
 - During intake, classify reusable primitives by library area. Upstream only
   seams that pass the second-paper test, such as finite PMF/Markov kernels/MDPs,
   probability inequalities, monotonicity/comparison lemmas, allocation
@@ -1561,6 +1579,15 @@ the Lean statements against the paper.
   proofs around that row. If `--assumption-precheck` reports hidden premises,
   derive them, move true paper assumptions to `Assumptions.lean`, or mark the
   endpoint partial/conditional before calling the target ready.
+  Use automated semantic-alignment checks as triage, not certification. A high
+  match score or `matches` judgment is evidence that a human should inspect the
+  row less urgently; it is not proof that the theorem is source-faithful. A low,
+  stale, or inconsistent alignment result should block deep proof work on that
+  row until the source statement, Lean declaration, or visible assumptions are
+  repaired. Give special attention to quantifier order, implication direction,
+  constants/factors, domains/support assumptions, equivalence-vs-one-way
+  statements, asymptotic notation, and hypotheses moved from definitions into
+  theorem parameters.
   This early pass deliberately skips workflow scaffolding: do not update the
   DAG, final validation report, human-review log, or review-surface audit just
   because the target-setting pass ran. Its purpose is to catch wrong theorem
@@ -1894,6 +1921,17 @@ the Lean statements against the paper.
     through certificates, finite analogues, positive-base restrictions,
     two-sided support, or other undisclosed hypotheses, mark the downstream
     theorem conditional/partial rather than green.
+  - **Blueprint/source-map consistency:** Treat the DAG as a human-readable
+    view over the source-block map, not as the source of truth. Before closeout
+    or any public-facing handoff, cross-check three inventories: source-block
+    map, `PaperInterface.lean`/review dashboard rows, and DAG nodes/edges. Every
+    source-named paper result should have exactly one paper-facing row or an
+    explicit reason for omission, every paper-facing row should trace back to a
+    source block, and every required source dependency should either appear as
+    an edge or be documented as an intentionally omitted redundant edge. If a
+    script or table can generate the node/edge inventory, prefer that over
+    maintaining duplicate hand-written lists; still inspect the rendered DAG for
+    readability.
 - **DAG Formatting and Clarity Mandates:**
   - **Visual Iteration Requirement:** After every substantive DAG edit, render the DAG, inspect the visual output, and keep adjusting layout until you can explicitly confirm that it looks clean with no box, legend, note, edge, or label overlap. Do not claim the DAG is done if you have not visually checked it or if any overlap remains.
   - **Minimum Node Spacing:** Keep visible whitespace between neighboring DAG
@@ -2257,6 +2295,10 @@ search.
    handoff documents. Identify the public theorem target and the smallest local
    lemma that moves it forward.
    For a brand-new paper, your *very first task* is to read through the paper to extract the proof roadmap. Produce the comprehensive named-result dependency DAG (capturing every definition, lemma, proposition, theorem, and corollary and their exact relationships) as a TikZ diagram using the shared preamble. This serves as your master plan to understand the paper's architecture. Keep it current through the campaign as results change status.
+   Also create or refresh the source-block map before proof search: named
+   result, source location, dependencies, Lean declaration, proof status, and
+   reusable library candidates. Use it to choose the fastest route to overall
+   completion, not merely the smallest next green lemma.
 
 2. Context Efficiency vs. Edit Accuracy (File Reading Strategy).
    Do not over-optimize context limits by reading tiny chunks of files (e.g., using `sed` to read 15-20 lines) if you are about to use the `replace` tool. Micro-reading frequently drops necessary surrounding whitespace or context, causing the `replace` tool to fail repeatedly with "0 occurrences found". The cost of spinning in a multi-turn failure loop is far higher than the cost of reading the entire file once. Use `read_file` to ingest small-to-medium files completely, or use `grep -C 20` to get substantial context, ensuring you capture exact, copy-pasteable blocks for your `old_string`.
@@ -2265,6 +2307,13 @@ search.
    Run targeted `lake build <module>` commands before making broad changes. Fix
    dependency, import, or cache problems before interpreting downstream proof
    errors.
+   During proof work, use a compiler-guided repair loop: make one candidate
+   statement or proof edit, run the narrowest Lean check that exercises it,
+   inspect the first concrete error and goal state, then repair locally under
+   the fixed paper-facing signature whenever the source translation is already
+   correct. If the same failure recurs, split out the missing lemma, retrieve a
+   similar proof/API, or record the failed route in the handoff rather than
+   repeatedly changing the public theorem target.
 
 3. Choose the model level that closes the theorem fastest.
    EC papers often have useful finite entry points: finite agents, items,
@@ -2318,7 +2367,9 @@ search.
    When stopping mid-proof, record the module, theorem, assumptions still
    missing, commands run, the next lemma to prove, and any closed layers that
    should not be revisited. Future agents should not have to rediscover the
-   proof state. If a paper is plausibly beyond the current model's effective
+   proof state. Include useful failed proof attempts, Lean error patterns, and
+   successful repair lemmas when they would help future retrieval or prevent the
+   same dead end. If a paper is plausibly beyond the current model's effective
    proof-search capacity, make that explicit in the paper README and handoff:
    name the reduced target, record failed/counterexample-search evidence, and
    mark it as a future stronger-model pickup instead of leaving an ambiguous


### PR DESCRIPTION
## Summary
- Add a source-credited AI formalization workflow skill based on the recent literature review.
- Fold practical workflow guidance into the main EconCS formalizer skill: source-block maps, retrieval grounding, semantic-alignment triage, blueprint/source-map consistency, compiler-guided repair, and useful failed-route handoff notes.

## Validation
- git diff --check -- skills/econcs-formalizer/SKILL.md skills/ai-formalization-workflows