### PR TITLE
[codex] Add public-safe formalization skill updates

### DIFF
--- a/skills/econcs-formalizer/SKILL.md
+++ b/skills/econcs-formalizer/SKILL.md
@@ -740,6 +740,10 @@ reader-relevant source-version, proof-route, or caveat note. Human-review counts
 mean saved dashboard rows by a human reviewer: `reviewed_rows / total_rows`.
 Agent source audits, validation reports, and compile checks do not increment
 human review.
+Website status tables should expose human review and row-local
+LLM-as-judge statement translation, not paper-level source coverage. Keep
+paper-level source-inventory coverage in validation reports, audit JSON, and
+`docs/PAPER_STATUS.md`; do not surface it as a public website table column.
 For a partial or conditional public entry, make `human_summary` one concise
 sentence: name the paper-facing results already closed and the exact remaining
 external/library/model certificate. Avoid Lean declaration names, helper-layer

--- a/skills/econcs-formalizer/references/proof-markets-social-choice.md
+++ b/skills/econcs-formalizer/references/proof-markets-social-choice.md
@@ -3,6 +3,31 @@
 Use for `EconCSLib/Markets/*`, `EconCSLib/SocialChoice/*`, matching, fair
 division, rankings, Mallows models, and social-choice/ranking papers.
 
+## STV/RCV and Voting Rules
+
+- For ranked-choice voting papers, build reusable semantics under
+  `EconCSLib.SocialChoice.Voting` before paper-local theorem work. Keep ballot
+  primitives, active-set updates, tallies, winners, eliminations, transfers,
+  tie-breakers, and replay/process predicates in the shared layer when they are
+  paper-neutral.
+- Distinguish three objects that are easy to conflate: bare trace or transfer
+  data, the proposition-valued replay/process validity predicate over that
+  data, and the source theorem conclusion. Bare traces can be source-model
+  witness data, but replay validity, surplus-transfer preservation, terminal
+  process claims, and ballot-to-candidate isolation should be proved from the
+  primitive ballots, tie-breaking, and transfer rule, or marked as explicit
+  partial boundaries.
+- Keep empirical election audits, simulations, redistricting experiments, and
+  real-data claims as data/code boundaries unless their data pipeline is also
+  formalized. The Lean target should be the deterministic election semantics,
+  structure-validity theorem, or source theorem reduction that is independent
+  of those empirical artifacts.
+- For strategy or manipulation papers, separate ballot-change vectors and
+  strategy spaces from fixed-trace replay validity and payoff/order
+  consequences. Close fixed-structure replay and validity lemmas first; expose
+  optimization/search or empirical computation as a separate boundary when it
+  is not part of the Lean proof.
+
 ## Matching and Fair Division
 
 - For matching, keep preference, blocking-pair, stability, and algorithmic

--- a/skills/econcs-formalizer/references/proof-mechanism-design.md
+++ b/skills/econcs-formalizer/references/proof-mechanism-design.md
@@ -10,6 +10,13 @@ auctions, combinatorial auctions, and generic mechanism-design wrappers.
   become reusable EC infrastructure. Build the reusable layer during the paper
   proof when it directly helps the active theorem and is likely useful for
   another auction/mechanism paper.
+- For strategic papers with continuous types, endogenous ranks, cutoffs, or
+  null-set tie behavior, include a shared-library reuse checkpoint in the paper
+  plan before adding local equilibrium or distribution interfaces. Inspect the
+  generic optimization, probability, admissions/testing, and mechanism-design
+  modules for the proof shape, then route the paper proof through the matching
+  shared API. If no API fits, document the exact missing abstraction and keep
+  the paper-local replacement narrow enough to extract later.
 - For auction papers, attack the named theorem through the shortest faithful
   model level. Finite bidder models are often right for digital goods, but do
   not build a finite analogue as ritual if the paper statement or proof closes

--- a/skills/econcs-formalizer/templates/FORMALIZATION_PLAN.md
+++ b/skills/econcs-formalizer/templates/FORMALIZATION_PLAN.md
@@ -1,0 +1,94 @@
+# Formalization Plan: {{TITLE}}
+
+This is the paper-local outside-Lean scratchpad. Keep it short enough to guide
+proof work, but complete enough that another agent can see the theorem target,
+source risks, and reusable-library choices before opening Lean files.
+
+- Namespace: `{{NAMESPACE}}`
+
+## Initial Outside-Lean Paper Audit
+
+- Source version / local files inspected:
+  - Official source:
+  - Open/source-of-truth version:
+  - Local PDF/TeX/text caches:
+  - Extraction notes:
+- Source/version mismatch notes:
+  - Publication/source-version differences:
+  - Theorem-level differences found:
+- Complete named-result ledger status:
+  - Source files searched:
+  - Named definitions/results extracted:
+  - Empirical/descriptive material excluded from theorem scope:
+- Formula sanity check:
+  - Signs/constants/domains:
+  - Density vs mass / likelihood-kernel representation issues:
+  - Dependency map between named source results:
+  - Formula-bearing displayed claims that need derivation, not source-row
+    assumptions:
+- Named result sanity check:
+  - Results that look correct as stated:
+  - Suspected bugs, missing assumptions, or ambiguous wording:
+- Shared-library reuse checkpoint:
+  - Mathlib declarations/modules inspected:
+  - Cslib declarations/modules inspected:
+  - Optlib declarations/modules inspected:
+  - Existing `EconCSLib` declarations/modules inspected:
+  - API chosen and near-misses:
+- Proof strategy consequences:
+  - Source proof route to follow:
+  - Cleaner Lean route or reusable library route:
+  - Major issues already reported to the user:
+
+## Source Inventory
+
+- Definitions / formatted paper objects:
+- Named lemmas / propositions / theorems / corollaries:
+- Theorem-like displayed claims that are used later:
+- Algorithms, tables, empirical procedures, or examples that affect theorem
+  interpretation:
+
+## Initial Proof Strategy
+
+- Main theorem chain:
+- Likely reusable `EconCSLib` seams:
+- Paper steps that look underspecified or analytically hard:
+- Formal target map:
+  - Rows to fully prove now:
+  - Empirical/descriptive rows out of formal theorem scope:
+  - Explicit assumption/certificate boundaries, if any:
+- Planned fallback route if the source proof is too informal:
+
+## Reusable-Library TODO
+
+- Library APIs to use directly:
+- Small reusable lemmas to add now:
+- Larger reusable components to defer:
+- Library-audit risks:
+
+## Execution Checklist
+
+- [ ] Download/cache source PDFs and text extracts, with redistribution notes.
+- [ ] Complete named-result and formula-bearing displayed-claim inventory.
+- [ ] Fill the formal target map and declare any intended boundary/certificate.
+- [ ] Build or select reusable library APIs before adding paper-local wrappers.
+- [ ] Replace paper scaffold with source-facing Lean definitions and rows.
+- [ ] Prove all rows marked in-scope, or downgrade them with an explicit
+      boundary note.
+- [ ] Update README, status, DAG, and validation report from the same row list.
+- [ ] Run build, audits, placeholder/provenance checks, and DAG validation.
+- [ ] Record any unresolved source bug, assumption, or library debt.
+
+## Active Scratchpad
+
+- Current Lean endpoint:
+- Exact current mathematical gap:
+- Next bridge lemmas to try:
+- Informal proof sketch / recurrence / construction:
+
+## Deviations And Assumptions
+
+- Source imprecision or proof deviation to report later:
+- Genuine paper assumptions to declare in `Assumptions.lean`:
+- Temporary certificate fields to discharge:
+- Validation/audit checks that must inspect these assumptions:

--- a/skills/lean-community-conventions/SKILL.md
+++ b/skills/lean-community-conventions/SKILL.md
@@ -1,0 +1,186 @@
+---
+name: lean-community-conventions
+description: Apply Lean community and mathlib conventions to EconCSLib Lean code, documentation, proof claims, PRs, and local library work. Use when writing or reviewing Lean declarations, naming theorem APIs, preparing mathlib-style files, auditing proof claims, or planning convention cleanup against Lean community guidelines.
+---
+
+# Lean Community Conventions
+
+Use this skill when EconCSLib work should move toward Lean community and
+mathlib conventions. It is not a full copy of the Lean community guides; it is the
+working checklist for local code review and cleanup.
+
+## Sources
+
+- Lean community, "Did you prove it?":
+  <https://leanprover-community.github.io/did_you_prove_it.html>
+- Lean community, "Contributing to mathlib":
+  <https://leanprover-community.github.io/contribute/index.html>
+- Lean community, "How to contribute to mathlib":
+  <https://leanprover-community.github.io/contribute/how-to-contribute.html>
+- Lean community, "Mathlib's values":
+  <https://leanprover-community.github.io/contribute/values.html>
+- Lean community, "Mathlib naming conventions":
+  <https://leanprover-community.github.io/contribute/naming.html>
+- Lean community, "Library Style Guidelines":
+  <https://leanprover-community.github.io/contribute/style.html>
+- Lean community, "Documentation style":
+  <https://leanprover-community.github.io/contribute/doc.html>
+- Lean community, "Pull request title and description conventions":
+  <https://leanprover-community.github.io/contribute/commit.html>
+- Lean community, "Pull Request Review Guide":
+  <https://leanprover-community.github.io/contribute/pr-review.html>
+
+Scope note: EconCSLib uses these pages as local style and proof-quality
+guidance. AI-written or AI-assisted EconCSLib code should not be contributed
+back to mathlib.
+
+Adoption policy: apply this style to new Lean files, new shared-library APIs,
+new paper-facing declarations, and code that is already being substantially
+rewritten. Do not start broad repository-wide renaming, formatting, import, or
+documentation refactors just to conform existing code. Record old-code
+deviations in a cleanup plan and fix them only at a deliberate cleanup,
+library-extraction, or publication boundary.
+
+Paper-local source-indexed declaration names are allowed when they are the
+clearest audit path back to a source paper. Shared reusable APIs should use
+mathlib-style names.
+
+For the local adoption plan, load
+`references/econcs-adoption-plan.md`.
+
+## Proof-Claim Gate
+
+Before saying a Lean result is verified, check the Lean community proof gate:
+
+1. The code is in a Lean repository, not a standalone file.
+2. The repository or target builds with `lake build`.
+3. The file containing the theorem is imported by the build target.
+4. `#print axioms theorem_name` has only the standard Lean axioms expected for
+   mathlib-style classical mathematics: `propext`, `Classical.choice`, and
+   `Quot.sound`, or a subset.
+5. The formal statement actually matches the mathematical claim.
+
+For EconCSLib paper formalizations, distinguish two claims:
+
+- **Lean-closed theorem:** passes the proof-claim gate for its formal statement.
+- **Paper-derived theorem:** additionally has all nonstandard model,
+  certificate, source-row, and boundary assumptions traced to paper assumptions,
+  earlier derived lemmas, or explicit partial-formalization boundaries.
+
+Do not let a successful Lean proof hide a mismatch between the statement and the
+paper claim.
+
+## Naming Checklist
+
+Use mathlib capitalization conventions for new library-facing declarations:
+
+- Files: `UpperCamelCase.lean` unless there is a rare object-specific exception.
+- Types, structures, classes, inductives, and propositions-as-objects:
+  `UpperCamelCase`.
+- Proofs and theorem/lemma declarations: `snake_case`.
+- Ordinary data and values: `lowerCamelCase`.
+- Functions are named like their return values.
+- Acronyms move as a group, using the case expected by the first character.
+- American English spelling in declaration names.
+
+Theorem names should describe the conclusion first. Use `_of_` to include
+hypotheses when needed, in the order the hypotheses appear. Prefer standard
+tokens:
+
+- `iff`, `not`, `exists`, `forall`, `mem`, `union`, `inter`, `compl`
+- `zero`, `one`, `add`, `mul`, `sub`, `neg`, `inv`, `pow`, `sum`, `prod`
+- `lt`, `le`, `gt`, `ge`, with `gt`/`ge` mainly for swapped argument order
+- `pos`, `neg`, `nonpos`, `nonneg` instead of spelling out `zero_lt`,
+  `lt_zero`, `le_zero`, `zero_le`
+
+Structural lemma patterns:
+
+- Extensionality: `.ext` with `@[ext]`; equivalence form `.ext_iff`.
+- Injectivity: `f_injective` for `Function.Injective f`; `f_inj` for
+  bidirectional equalities such as `f x = f y <-> x = y`.
+- If a lemma is local-only, name or document it as auxiliary, usually with
+  `aux`, and keep it near its use.
+
+## Style Checklist
+
+For new or heavily edited library-facing Lean files:
+
+- Keep lines at or under 100 characters.
+- Use Unicode mathematical symbols when they improve readability, avoiding
+  invisible, direction-changing, or combining-control characters.
+- Put top-level commands flush-left; do not indent the contents of namespaces or
+  sections merely because a namespace/section is open.
+- Put spaces around `:`, `:=`, and infix operators.
+- Put `:= by` at the end of the theorem statement line; do not place `by` on a
+  line by itself.
+- Indent proofs by two spaces; multi-line theorem statement continuations by
+  four spaces.
+- Give explicit argument types and return types for declarations when practical.
+- Prefer arguments left of the colon over quantified/implication conclusions
+  when the proof begins by introducing those variables.
+- Use `where` syntax for structure and instance terms.
+- Give each structure/class field a docstring when it is library-facing.
+- Separate declarations by one blank line, except for tight groups of similar
+  one-line declarations.
+- Prefer one tactic invocation per line unless a short one-line proof or a
+  single mathematical idea is clearer.
+- Use focusing dots for side goals.
+- Avoid `$`; use `<|` or `|>` where needed.
+- Treat repeated `erw`/extra `rfl` after `simp` or `rw` as an API smell: consider
+  adding the missing API lemma.
+
+Performance and API design:
+
+- Think about transparency. Default `def` is usually preferable; use `abbrev`,
+  irreducibility, or structure wrappers only with a clear reason.
+- Benchmark or at least inspect performance for changes to imports, classes,
+  instances, `simp` lemmas, definitions, or nontrivial refactors.
+- Avoid raising heartbeat limits as a long-term fix for fragile code.
+
+## Documentation Checklist
+
+For library-facing files:
+
+- Include copyright header, `module`, grouped `public import`s, grouped
+  `import`s, and a module docstring.
+- Keep imports alphabetized within public/private import blocks when practical.
+- Module docstrings should have a title and summary. Add sections for main
+  definitions/statements, notation, implementation notes, references, and tags
+  when useful.
+- Every definition and major theorem needs a docstring; docstrings on
+  mathematical lemmas are encouraged.
+- Docstrings should explain mathematical meaning and can slightly abstract away
+  implementation details when that helps users.
+- Put Lean declaration names and variables in backticks.
+- Put raw URLs in angle brackets.
+- Use `#lint`, `#lint only docBlame`, or `#lint only docBlame docBlameThm` as a
+  targeted check before mathlib-style cleanup is called complete.
+
+## Local PR Checklist
+
+For EconCSLib PRs that should resemble mathlib-style review:
+
+- Prefer small, self-contained PRs.
+- Make sure the target builds; CI can do full builds, but local targeted builds
+  should be clean.
+- Use conventional PR titles:
+  `<type>(<optional-scope>): <subject>`, with types such as `feat`, `fix`,
+  `doc`, `style`, `refactor`, `test`, `chore`, `perf`, and `ci`.
+- PR subjects and bodies use imperative present tense, no initial capitalization
+  for the subject, and no trailing period.
+- Put discussion/questions after `---` if they should not enter git history.
+
+## Local Review Routine
+
+When reviewing an EconCSLib file for convention alignment:
+
+1. Run the proof-claim gate for paper-facing claims.
+2. Scan filenames, declaration names, theorem names, and namespace placement.
+3. Scan style: line length, theorem indentation, `:= by`, explicit types,
+   structure/instance `where`, and one-blank-line declaration separation.
+4. Scan docs: file module docstring, docstrings for definitions/major theorems,
+   cross references, and warnings for auxiliary or special-use declarations.
+5. Scan API shape: weak hypotheses, strong conclusions, useful simp/ext/inj
+   lemmas, import placement, and performance-sensitive declarations.
+6. Record issues as a cleanup plan instead of mixing broad renaming/refactor
+   churn into active paper proof work.

--- a/skills/lean-community-conventions/references/econcs-adoption-plan.md
+++ b/skills/lean-community-conventions/references/econcs-adoption-plan.md
@@ -1,0 +1,161 @@
+# EconCSLib Lean Community Convention Adoption Plan
+
+This plan applies Lean community and mathlib conventions to EconCSLib without
+turning active paper proof work into broad style churn.
+
+## Source Baseline
+
+Primary Lean community sources:
+
+- "Did you prove it?": <https://leanprover-community.github.io/did_you_prove_it.html>
+- "Contributing to mathlib": <https://leanprover-community.github.io/contribute/index.html>
+- "How to contribute to mathlib": <https://leanprover-community.github.io/contribute/how-to-contribute.html>
+- "Mathlib's values": <https://leanprover-community.github.io/contribute/values.html>
+- "Mathlib naming conventions": <https://leanprover-community.github.io/contribute/naming.html>
+- "Library Style Guidelines": <https://leanprover-community.github.io/contribute/style.html>
+- "Documentation style": <https://leanprover-community.github.io/contribute/doc.html>
+- "Pull request title and description conventions":
+  <https://leanprover-community.github.io/contribute/commit.html>
+- "Pull Request Review Guide": <https://leanprover-community.github.io/contribute/pr-review.html>
+
+## Principles For EconCSLib
+
+1. Mathlib-style cleanup is valuable, but proof correctness and source
+   provenance remain higher priority for active paper work.
+2. Apply strict mathlib conventions first to shared `EconCSLib/` library code.
+   Paper folders may preserve source-facing names when that improves auditability,
+   but exported library APIs should move toward mathlib style.
+3. Do not rename public paper-facing declarations casually. If a paper-facing
+   name is intentionally source-indexed, keep it or add a mathlib-style alias
+   only if it helps reuse.
+4. Every cleanup pass should be small enough to review and should avoid changing
+   theorem statements unless the change is explicitly part of the plan.
+5. Use these conventions for local quality. Do not plan to upstream AI-written
+   or AI-assisted EconCSLib code to mathlib.
+6. Apply conventions forward. New library files, new paper files, new shared
+   APIs, and substantially rewritten code should follow the convention skill.
+   Existing code should not be broadly refactored only for style.
+
+## Phase 1: Forward Convention Gate
+
+Create a lightweight manual checklist for new and substantially touched Lean
+code, then later automate parts of it:
+
+- Proof claim:
+  - target builds with `lake build`;
+  - theorem file is imported by the target;
+  - `#print axioms` for main claims has only expected standard axioms, unless an
+    explicit paper boundary is documented;
+  - statement matches the claimed paper/library theorem.
+- Naming:
+  - file names `UpperCamelCase.lean` for library modules;
+  - theorem names `snake_case`;
+  - structures/classes/types/propositions `UpperCamelCase`;
+  - values/functions `lowerCamelCase`;
+  - theorem names use conclusion-first and `_of_` hypotheses where appropriate.
+- Style:
+  - 100-character line target;
+  - `:= by` on same line;
+  - explicit argument/return types for declarations;
+  - `where` syntax for instances/structures;
+  - docstrings on library-facing fields.
+- Docs:
+  - module docstring present for shared library files;
+  - definitions and major theorems documented;
+  - raw URLs in angle brackets;
+  - declaration names in backticks.
+
+Deliverable: add this checklist to the new-paper, active-proof edit, and
+library-extraction routines after the draft skill has been reviewed. The gate is
+forward-looking; it should not trigger broad refactors of old files.
+
+## Phase 2: Inventory Existing Deviations
+
+Run a non-mutating inventory before refactoring:
+
+- Find library files without module docstrings or with missing copyright/module
+  headers.
+- Find long declaration names that encode paper titles or theorem numbers in
+  shared library code.
+- Find helper lemmas in `EconCSLib/` whose names include paper-specific words.
+- Find files with many lines over 100 characters.
+- Find library-facing structures/classes with undocumented fields.
+- Find repeated `erw`, extra `rfl`, heartbeat bumps, or local transparency
+  hacks that indicate missing API.
+
+Output should be a review report, not an immediate mass rename.
+Inventory findings are backlog items. Do not apply them during active proof work
+unless the affected declaration is already being changed for mathematical
+reasons.
+
+## Phase 3: Apply To New Code First
+
+For new shared library modules and new paper-facing Lean files:
+
+- Start from a mathlib-style file skeleton.
+- Keep imports minimal and alphabetized inside public/private groups.
+- Add a module docstring with main definitions, main statements, implementation
+  notes, references, and tags when relevant.
+- Use mathlib naming conventions from the start.
+- Provide a small API around every new definition: simp lemmas, ext/inj lemmas
+  where natural, monotonicity or measurability lemmas where relevant, and
+  examples of intended use when the API is subtle.
+
+This phase avoids churn and prevents new divergence.
+
+## Phase 4: Refactor Shared Library APIs
+
+Refactor only after inventory identifies high-value targets and the user or
+maintainer has agreed that the current work is a cleanup boundary:
+
+- Rename shared declarations toward mathlib naming.
+- Move paper-facing wrappers out of `EconCSLib/` and into paper folders.
+- Split large files when import placement or compile time would improve.
+- Add docstrings and module docs to shared files that are already reused across
+  multiple papers.
+- Add missing API lemmas rather than relying on repeated unfolding, `erw`, or
+  long local proof scripts.
+
+Each refactor should build affected papers and preserve paper-facing theorem
+statements unless explicitly approved.
+
+## Phase 5: Mathlib-Style Local Review
+
+For any EconCSLib contribution that should be especially close to mathlib style:
+
+- Break into small PRs: single-lemma fixes, doc fixes, or narrow API additions
+  first.
+- Write PR titles using the Lean community convention.
+- Keep the work in EconCSLib as a downstream project.
+- Ensure a human reviewer can understand every statement, definition, proof, and
+  design choice.
+- Do not open mathlib PRs with AI-written or AI-assisted EconCSLib code.
+
+## Automation Candidates
+
+Later scripts can check:
+
+- library `.lean` file names not in `UpperCamelCase`;
+- lines over 100 characters in `EconCSLib/`;
+- missing module docstrings in shared library files;
+- missing docstrings for structures/classes/defs in shared library files;
+- theorem names in library files containing source-paper numbers;
+- `set_option maxHeartbeats` and related performance overrides;
+- new `abbrev`, `irreducible`, or `opaque` declarations for review;
+- uses of `$` in Lean files;
+- whether main paper claims have an associated `#print axioms` audit record.
+
+Automation should report findings first. Do not auto-rename declarations without
+a human-reviewed migration plan.
+
+## Review Cadence
+
+- New code: apply the checklist immediately.
+- Substantially edited code: apply the checklist to the edited declarations and
+  nearby API surface.
+- Active paper proof work: defer broad convention cleanup until a real proof
+  boundary.
+- Library extraction: run the naming/style/doc checklist before publishing or
+  public release.
+- Public PR preparation: include a convention pass for changed shared library
+  files only, unless the PR is explicitly a style cleanup.


### PR DESCRIPTION
## Summary
- Adds the missing formalization-plan template referenced by the public formalizer skill.
- Adds a Lean community conventions skill for local EconCSLib style/proof-claim review.
- Distills newer private skill lessons into generic public guidance for website status columns, STV/RCV replay boundaries, and strategic-model library reuse.

## Scope filtering
- Did not copy private proof-reference updates verbatim.
- Did not include paper-specific proof trails, paper IDs, source caches, or the private session-history ledger.

## Validation
- python3 /home/nkgarg/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/econcs-formalizer
- python3 /home/nkgarg/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/lean-community-conventions
- git diff --cached --check
- staged diff grep for paper IDs/private-source markers