### PR TITLE
Publish shared audit and fairness infrastructure

### DIFF
--- a/EconCSLib/Applications/AlgorithmicFairness.lean
+++ b/EconCSLib/Applications/AlgorithmicFairness.lean
@@ -1,0 +1,7 @@
+import EconCSLib.Applications.AlgorithmicFairness.Basic
+
+/-!
+# Algorithmic Fairness
+
+Reusable group-fairness, Pareto-front, and postprocessing interfaces.
+-/

--- a/EconCSLib/Applications/AlgorithmicFairness/Basic.lean
+++ b/EconCSLib/Applications/AlgorithmicFairness/Basic.lean
@@ -1,0 +1,251 @@
+import EconCSLib.Learning.Statistics.Prediction
+import Mathlib.Algebra.BigOperators.Group.Finset.Basic
+import Mathlib.Data.Real.Basic
+import Mathlib.Tactic.Linarith
+
+/-!
+# Algorithmic Fairness Interfaces
+
+Reusable finite interfaces for group fairness objectives, fairness-threshold
+families, Pareto-front statements, and postprocessing guarantees.  Generic
+prediction and loss definitions live in `EconCSLib.Learning.Statistics`.
+-/
+
+namespace EconCSLib
+namespace AlgorithmicFairness
+
+open scoped BigOperators
+
+abbrev Model (X : Type*) := Statistics.Model X
+abbrev Group (X : Type*) := Statistics.Group X
+
+/--
+Abstract group-fairness predicate: each group-specific metric must be within
+`gamma` of the population metric after multiplying by the supplied group
+slack/weight.
+-/
+def GammaFairForMetric {X : Type*} (G : Set (Group X))
+    (groupMetric : Group X → Model X → ℝ) (populationMetric : Model X → ℝ)
+    (slack : Group X → ℝ) (gamma : ℝ) (c : Model X) : Prop :=
+  ∀ g ∈ G, slack g * |groupMetric g c - populationMetric c| ≤ gamma
+
+/-- The max-over-g fairness objective induced by a group metric. -/
+def FairnessObjective {X : Type*} (G : Set (Group X))
+    (groupMetric : Group X → Model X → ℝ) (populationMetric : Model X → ℝ)
+    (slack : Group X → ℝ) (phi : Model X → ℝ) : Prop :=
+  ∀ c, (∀ g ∈ G, slack g * |groupMetric g c - populationMetric c| ≤ phi c) ∧
+    ∀ bound : ℝ,
+      (∀ g ∈ G, slack g * |groupMetric g c - populationMetric c| ≤ bound) →
+        phi c ≤ bound
+
+/-- A max-over-g fairness objective bounded by `gamma` implies gamma-fairness. -/
+theorem gammaFairForMetric_of_fairnessObjective_le {X : Type*}
+    {G : Set (Group X)}
+    {groupMetric : Group X → Model X → ℝ} {populationMetric : Model X → ℝ}
+    {slack : Group X → ℝ} {phi : Model X → ℝ} {gamma : ℝ} {c : Model X}
+    (hphi : FairnessObjective G groupMetric populationMetric slack phi)
+    (hbound : phi c ≤ gamma) :
+    GammaFairForMetric G groupMetric populationMetric slack gamma c := by
+  intro g hg
+  exact le_trans ((hphi c).1 g hg) hbound
+
+/-- Gamma-fairness bounds the associated max-over-g fairness objective. -/
+theorem fairnessObjective_le_of_gammaFairForMetric {X : Type*}
+    {G : Set (Group X)}
+    {groupMetric : Group X → Model X → ℝ} {populationMetric : Model X → ℝ}
+    {slack : Group X → ℝ} {phi : Model X → ℝ} {gamma : ℝ} {c : Model X}
+    (hphi : FairnessObjective G groupMetric populationMetric slack phi)
+    (hfair : GammaFairForMetric G groupMetric populationMetric slack gamma c) :
+    phi c ≤ gamma :=
+  (hphi c).2 gamma hfair
+
+/--
+For a well-specified max-over-g fairness objective, the group-indexed
+`gamma`-fair constraints are equivalent to the scalar objective bound.
+-/
+theorem gammaFairForMetric_iff_fairnessObjective_le {X : Type*}
+    {G : Set (Group X)}
+    {groupMetric : Group X → Model X → ℝ} {populationMetric : Model X → ℝ}
+    {slack : Group X → ℝ} {phi : Model X → ℝ} {gamma : ℝ} {c : Model X}
+    (hphi : FairnessObjective G groupMetric populationMetric slack phi) :
+    GammaFairForMetric G groupMetric populationMetric slack gamma c ↔
+      phi c ≤ gamma :=
+  ⟨fairnessObjective_le_of_gammaFairForMetric hphi,
+    gammaFairForMetric_of_fairnessObjective_le hphi⟩
+
+/-- The four fairness notions used by common threshold-postprocessing formulas. -/
+inductive FairnessKind where
+  | falsePositive
+  | falseNegative
+  | statisticalParity
+  | errorRate
+deriving DecidableEq
+
+/--
+Domain condition under which the threshold boundary formula for a fairness
+notion has no zero denominator. Statistical parity has no denominator.
+-/
+def FairnessKind.ValidThresholdValue : FairnessKind → ℝ → Prop
+  | FairnessKind.falsePositive, v => v ≠ 1
+  | FairnessKind.falseNegative, v => v ≠ 0
+  | FairnessKind.statisticalParity, _ => True
+  | FairnessKind.errorRate, v => v ≠ 1 / 2
+
+/-- Threshold boundary for one of the standard group-fairness notions. -/
+noncomputable def fairnessThresholdBoundary : FairnessKind → ℝ → ℝ
+  | FairnessKind.falsePositive, v => (2 * v - 1) / (1 - v)
+  | FairnessKind.falseNegative, v => (1 - 2 * v) / v
+  | FairnessKind.statisticalParity, v => 2 * v - 1
+  | FairnessKind.errorRate, v => (2 * v - 1) / (1 - 2 * v)
+
+/-- Linear group-membership score `sum_i lambda_i * (g_i x - beta_i)`. -/
+def groupThresholdScore {I X : Type*} [Fintype I]
+    (groups : I → Group X) (lambda beta : I → ℝ) (x : X) : ℝ :=
+  ∑ i, lambda i * (groups i x - beta i)
+
+/-- One thresholding function from a group-threshold family. -/
+noncomputable def fairnessThresholdFunction {I X : Type*} [Fintype I]
+    (kind : FairnessKind) (groups : I → Group X)
+    (lambda beta : I → ℝ) : X → ℝ → ℝ :=
+  fun x v =>
+    if fairnessThresholdBoundary kind v ≤ groupThresholdScore groups lambda beta x then
+      1
+    else
+      0
+
+/-- Membership in a norm-bounded group-threshold function family. -/
+def ThresholdFunctionFamilyMember {I X : Type*} [Fintype I]
+    (kind : FairnessKind) (groups : I → Group X) (Cbound : ℝ)
+    (b : X → ℝ → ℝ) : Prop :=
+  ∃ lambda beta : I → ℝ,
+    (∑ i, |lambda i|) ≤ Cbound ∧
+      b = fairnessThresholdFunction kind groups lambda beta
+
+/--
+Membership in a threshold-function family over a finite set of prediction
+values, including the source-domain condition that every threshold formula
+used on that value set has nonzero denominators.
+-/
+def ThresholdFunctionFamilyMemberOnValues {I X : Type*} [Fintype I]
+    (kind : FairnessKind) (groups : I → Group X) (R : Finset ℝ) (Cbound : ℝ)
+    (b : X → ℝ → ℝ) : Prop :=
+  (∀ v ∈ R, kind.ValidThresholdValue v) ∧
+    ThresholdFunctionFamilyMember kind groups Cbound b
+
+/--
+The finite-value threshold family carries the denominator-domain side
+conditions needed by the threshold boundary formula on every value in `R`.
+-/
+theorem validThresholdValue_of_thresholdFunctionFamilyMemberOnValues
+    {I X : Type*} [Fintype I]
+    {kind : FairnessKind} {groups : I → Group X}
+    {R : Finset ℝ} {Cbound : ℝ} {b : X → ℝ → ℝ}
+    (hb : ThresholdFunctionFamilyMemberOnValues kind groups R Cbound b) :
+    ∀ v ∈ R, kind.ValidThresholdValue v :=
+  hb.1
+
+/--
+The finite-value threshold family is still a member of the underlying
+norm-bounded threshold-function family after forgetting value-domain
+side conditions.
+-/
+theorem thresholdFunctionFamilyMember_of_onValues
+    {I X : Type*} [Fintype I]
+    {kind : FairnessKind} {groups : I → Group X}
+    {R : Finset ℝ} {Cbound : ℝ} {b : X → ℝ → ℝ}
+    (hb : ThresholdFunctionFamilyMemberOnValues kind groups R Cbound b) :
+    ThresholdFunctionFamilyMember kind groups Cbound b :=
+  hb.2
+
+/--
+Build the finite-value threshold family from a threshold-function
+witness and the value-domain side conditions.
+-/
+theorem thresholdFunctionFamilyMemberOnValues_intro
+    {I X : Type*} [Fintype I]
+    {kind : FairnessKind} {groups : I → Group X}
+    {R : Finset ℝ} {Cbound : ℝ} {b : X → ℝ → ℝ}
+    (hvalid : ∀ v ∈ R, kind.ValidThresholdValue v)
+    (hb : ThresholdFunctionFamilyMember kind groups Cbound b) :
+    ThresholdFunctionFamilyMemberOnValues kind groups R Cbound b :=
+  ⟨hvalid, hb⟩
+
+/-- Pareto-front membership for accuracy and fairness objectives. -/
+def ParetoFrontMember {X : Type*} (C : Set (Model X))
+    (err fairness : Model X → ℝ) (c : Model X) : Prop :=
+  c ∈ C ∧
+    ¬ ∃ c' ∈ C,
+      err c' ≤ err c ∧ fairness c' ≤ fairness c ∧
+        (err c' < err c ∨ fairness c' < fairness c)
+
+/-- Approximate Pareto-front membership with error and fairness tolerances. -/
+def ApproxParetoFrontMember {X : Type*} (C : Set (Model X))
+    (err fairness : Model X → ℝ) (errTol fairTol : ℝ) (c : Model X) : Prop :=
+  c ∈ C ∧
+    ¬ ∃ c' ∈ C,
+      err c' + errTol < err c ∧ fairness c' + fairTol < fairness c
+
+/-- Optimality under a hard group-fairness constraint. -/
+def OptimalGammaFairModel {X : Type*} (C : Set (Model X))
+    (err : Model X → ℝ) (fair : Model X → Prop) (c : Model X) : Prop :=
+  c ∈ C ∧ fair c ∧ ∀ c' ∈ C, fair c' → err c ≤ err c'
+
+/--
+The optimal constrained model can be stated either with group-indexed fairness
+constraints or with the associated max-over-g fairness objective bound.
+-/
+theorem optimalGammaFairModel_groupConstraint_iff_objectiveBound {X : Type*}
+    {C : Set (Model X)} {err : Model X → ℝ}
+    {G : Set (Group X)}
+    {groupMetric : Group X → Model X → ℝ} {populationMetric : Model X → ℝ}
+    {slack : Group X → ℝ} {phi : Model X → ℝ} {gamma : ℝ} {c : Model X}
+    (hphi : FairnessObjective G groupMetric populationMetric slack phi) :
+    OptimalGammaFairModel C err
+        (GammaFairForMetric G groupMetric populationMetric slack gamma) c ↔
+      OptimalGammaFairModel C err (fun c => phi c ≤ gamma) c := by
+  constructor
+  · rintro ⟨hcC, hfair, hopt⟩
+    refine ⟨hcC, (gammaFairForMetric_iff_fairnessObjective_le hphi).mp hfair, ?_⟩
+    intro c' hc'C hphi_le
+    exact hopt c' hc'C
+      ((gammaFairForMetric_iff_fairnessObjective_le hphi).mpr hphi_le)
+  · rintro ⟨hcC, hphi_le, hopt⟩
+    refine ⟨hcC, (gammaFairForMetric_iff_fairnessObjective_le hphi).mpr hphi_le, ?_⟩
+    intro c' hc'C hfair
+    exact hopt c' hc'C
+      ((gammaFairForMetric_iff_fairnessObjective_le hphi).mp hfair)
+
+/-- Abstract postprocessing optimum for a predictor-dependent objective. -/
+def OptimalPostprocessingForPredictor {X : Type*} (C : Set (Model X))
+    (predictor : Model X) (err : Model X → Model X → ℝ)
+    (fair : Model X → Model X → Prop) (c : Model X) : Prop :=
+  c ∈ C ∧ fair predictor c ∧
+    ∀ c' ∈ C, fair predictor c' → err predictor c ≤ err predictor c'
+
+/--
+Approximate postprocessing guarantee: the output is in `C`, feasible up to a
+fairness tolerance, and error-optimal up to `errTol` among exact `gamma`-fair
+classifiers.
+-/
+def ApproxPostprocessingGuarantee {X : Type*} (C : Set (Model X))
+    (err fairness : Model X → ℝ) (c : Model X)
+    (gamma errTol fairTol : ℝ) : Prop :=
+  c ∈ C ∧ fairness c ≤ gamma + fairTol ∧
+    ∀ c' ∈ C, fairness c' ≤ gamma → err c ≤ err c' + errTol
+
+/-- Approximate postprocessing guarantees imply approximate Pareto membership. -/
+theorem approxParetoFrontMember_of_postprocessingGuarantee {X : Type*}
+    {C : Set (Model X)} {err fairness : Model X → ℝ}
+    {c : Model X} {gamma errTol fairTol : ℝ}
+    (hpost : ApproxPostprocessingGuarantee C err fairness c gamma errTol fairTol) :
+    ApproxParetoFrontMember C err fairness errTol fairTol c := by
+  rcases hpost with ⟨hcC, hcFair, hopt⟩
+  refine ⟨hcC, ?_⟩
+  rintro ⟨c', hc'C, herr, hfair⟩
+  have hc'_fair : fairness c' ≤ gamma := by
+    linarith
+  have hopt' := hopt c' hc'C hc'_fair
+  linarith
+
+end AlgorithmicFairness
+end EconCSLib

--- a/EconCSLib/Basic.lean
+++ b/EconCSLib/Basic.lean
@@ -4,10 +4,12 @@ import EconCSLib.Algorithms.Online
 import EconCSLib.Algorithms.Complexity.Yao
 import EconCSLib.Algorithms.Online.AdWords
 import EconCSLib.Algorithms.Online.Regret
+import EconCSLib.Learning.Statistics
 import EconCSLib.Learning.Bandits.ThompsonSampling
 import EconCSLib.MechanismDesign.Auctions
 import EconCSLib.SocialChoice
 import EconCSLib.Markets.Matching
+import EconCSLib.Applications.AlgorithmicFairness
 import EconCSLib.Applications.Admissions
 import EconCSLib.Applications.RecommenderSystems
 

--- a/EconCSLib/Learning/Statistics.lean
+++ b/EconCSLib/Learning/Statistics.lean
@@ -1,0 +1,7 @@
+import EconCSLib.Learning.Statistics.Prediction
+
+/-!
+# Learning and Statistics
+
+Reusable prediction, loss, rate, calibration, and finite-statistics interfaces.
+-/

--- a/EconCSLib/Learning/Statistics/Prediction.lean
+++ b/EconCSLib/Learning/Statistics/Prediction.lean
@@ -1,0 +1,273 @@
+import Mathlib.Algebra.BigOperators.Group.Finset.Basic
+import Mathlib.Algebra.Order.BigOperators.Ring.Finset
+import Mathlib.Data.Real.Basic
+import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.Ring
+
+/-!
+# Finite Prediction and Statistics Primitives
+
+Reusable finite weighted prediction-model, loss, rate, and calibration
+interfaces.  These definitions are intentionally not fairness-specific: they
+also support statistics, calibration, discretization-bias, and prediction
+papers.
+-/
+
+namespace EconCSLib
+namespace Statistics
+
+open scoped BigOperators
+
+/-- A real-valued predictor on feature space `X`. -/
+abbrev Model (X : Type*) := X → ℝ
+
+/-- A finite weighted distribution over feature observations. -/
+abbrev FiniteWeight (X : Type*) := X → ℝ
+
+/-- A group, event, or soft weighting function on feature space `X`. -/
+abbrev Group (X : Type*) := X → ℝ
+
+/-- Constant real-valued predictor. -/
+def constantModel {X : Type*} (a : ℝ) : Model X :=
+  fun _ => a
+
+/-- Squared-error loss at one observation. -/
+def squaredError {X : Type*} (f y : Model X) (x : X) : ℝ :=
+  (f x - y x) ^ 2
+
+/-- Finite weighted model loss. -/
+def modelLoss {X : Type*} [Fintype X] (w : FiniteWeight X)
+    (loss : X → ℝ) : ℝ :=
+  ∑ x, w x * loss x
+
+/-- Finite weighted squared-error loss. -/
+def squaredLoss {X : Type*} [Fintype X] (w : FiniteWeight X)
+    (f y : Model X) : ℝ :=
+  modelLoss w (fun x => squaredError f y x)
+
+/-- Weighted mass of a group/event. -/
+def groupMass {X : Type*} [Fintype X] (w : FiniteWeight X)
+    (g : Group X) : ℝ :=
+  ∑ x, w x * g x
+
+/-- Weighted numerator of a group/event-conditional loss. -/
+def groupLossNumerator {X : Type*} [Fintype X] (w : FiniteWeight X)
+    (g : Group X) (loss : X → ℝ) : ℝ :=
+  ∑ x, w x * g x * loss x
+
+/-- Conditional group/event loss, using totalized real division. -/
+noncomputable def groupLoss {X : Type*} [Fintype X] (w : FiniteWeight X)
+    (g : Group X) (loss : X → ℝ) : ℝ :=
+  groupLossNumerator w g loss / groupMass w g
+
+/-- Conditional group squared-error loss. -/
+noncomputable def groupSquaredLoss {X : Type*} [Fintype X] (w : FiniteWeight X)
+    (g : Group X) (f y : Model X) : ℝ :=
+  groupLoss w g (fun x => squaredError f y x)
+
+/-- Conditional group squared disagreement between two predictors. -/
+noncomputable def groupSquaredDisagreement {X : Type*} [Fintype X] (w : FiniteWeight X)
+    (g : Group X) (f h : Model X) : ℝ :=
+  groupLoss w g (fun x => (f x - h x) ^ 2)
+
+/-- Pointwise zero-one loss for classification labels encoded as real models. -/
+noncomputable def zeroOneLoss {X : Type*} (c y : Model X) (x : X) : ℝ :=
+  if c x = y x then 0 else 1
+
+/-- Expected zero-one classification error. -/
+noncomputable def classificationError {X : Type*} [Fintype X]
+    (w : FiniteWeight X) (c y : Model X) : ℝ :=
+  modelLoss w (fun x => zeroOneLoss c y x)
+
+/--
+Expected zero-one classification loss when `yProb` is the conditional
+probability of label one.
+-/
+noncomputable def probabilisticClassificationLoss {X : Type*}
+    (yProb c : Model X) (x : X) : ℝ :=
+  yProb x * zeroOneLoss c (constantModel 1) x +
+    (1 - yProb x) * zeroOneLoss c (constantModel 0) x
+
+/-- Numerator for a finite weighted conditional rate. -/
+def weightedRateNumerator {X : Type*} [Fintype X]
+    (w : FiniteWeight X) (weight loss : X → ℝ) : ℝ :=
+  ∑ x, w x * weight x * loss x
+
+/-- Mass/denominator for a finite weighted conditional rate. -/
+def weightedRateMass {X : Type*} [Fintype X]
+    (w : FiniteWeight X) (weight : X → ℝ) : ℝ :=
+  ∑ x, w x * weight x
+
+/-- Conditional rate for a finite weighted numerator and mass. -/
+noncomputable def weightedRate {X : Type*} [Fintype X]
+    (w : FiniteWeight X) (weight loss : X → ℝ) : ℝ :=
+  weightedRateNumerator w weight loss / weightedRateMass w weight
+
+/-- Selected-mass divided by population-mass coefficient. -/
+noncomputable def weightedRateBeta {X : Type*} [Fintype X]
+    (w : FiniteWeight X) (selected population : X → ℝ) : ℝ :=
+  weightedRateMass w selected / weightedRateMass w population
+
+/--
+Multiplying a conditional-rate gap by the selected mass is equivalent to the
+corresponding finite expectation-gap form.
+-/
+theorem weightedRate_gap_eq_expectation_gap {X : Type*} [Fintype X]
+    (w : FiniteWeight X) (selected population loss : X → ℝ)
+    (hselected_nonneg : 0 ≤ weightedRateMass w selected)
+    (hselected_ne : weightedRateMass w selected ≠ 0)
+    (hpopulation_ne : weightedRateMass w population ≠ 0) :
+    weightedRateMass w selected *
+        |weightedRate w selected loss - weightedRate w population loss| =
+      |weightedRateNumerator w selected loss -
+        weightedRateBeta w selected population *
+          weightedRateNumerator w population loss| := by
+  unfold weightedRate weightedRateBeta
+  set ms := weightedRateMass w selected
+  set mp := weightedRateMass w population
+  set ns := weightedRateNumerator w selected loss
+  set np := weightedRateNumerator w population loss
+  have hms : ms ≠ 0 := by simpa [ms] using hselected_ne
+  have hmp : mp ≠ 0 := by simpa [mp] using hpopulation_ne
+  have hscale :
+      ms * |ns / ms - np / mp| =
+        |ms * (ns / ms - np / mp)| := by
+    rw [abs_mul]
+    rw [abs_of_nonneg hselected_nonneg]
+  rw [hscale]
+  congr 1
+  field_simp [hms, hmp]
+
+/-- Indicator for a finite prediction level set `f(x) = v`. -/
+noncomputable def levelSetIndicator {X : Type*} (f : Model X) (v : ℝ) : X → ℝ :=
+  fun x => if f x = v then 1 else 0
+
+/-- Absolute product-class multiaccuracy in finite weighted notation. -/
+def ApproxMultiaccurateOnProducts {X : Type*} [Fintype X]
+    (w : FiniteWeight X) (f y : Model X)
+    (G : Set (Group X)) (H : Set (Model X)) (eta : ℝ) : Prop :=
+  ∀ g ∈ G, ∀ h ∈ H,
+    |groupLossNumerator w g (fun x => h x * (f x - y x))| ≤ eta
+
+/-- Source-style one-sided product-class multiaccuracy. -/
+def OneSidedMultiaccurateOnProducts {X : Type*} [Fintype X]
+    (w : FiniteWeight X) (f y : Model X)
+    (G : Set (Group X)) (H : Set (Model X)) (eta : ℝ) : Prop :=
+  ∀ g ∈ G, ∀ h ∈ H,
+    groupLossNumerator w g (fun x => h x * (y x - f x)) ≤ eta
+
+/-- A model class is closed under pointwise negation. -/
+def ModelClassClosedUnderNegation {X : Type*} (H : Set (Model X)) : Prop :=
+  ∀ h ∈ H, (fun x => -h x) ∈ H
+
+/-- Flipping the residual sign negates the weighted residual correlation. -/
+theorem groupLossNumerator_residual_flip {X : Type*} [Fintype X]
+    (w : FiniteWeight X) (g : Group X) (h f y : Model X) :
+    groupLossNumerator w g (fun x => h x * (f x - y x)) =
+      -groupLossNumerator w g (fun x => h x * (y x - f x)) := by
+  classical
+  unfold groupLossNumerator
+  rw [← Finset.sum_neg_distrib]
+  refine Finset.sum_congr rfl ?_
+  intro x _hx
+  ring
+
+/-- Negating the feature converts source-style residuals to the opposite sign. -/
+theorem groupLossNumerator_neg_sourceResidual_eq {X : Type*} [Fintype X]
+    (w : FiniteWeight X) (g : Group X) (h f y : Model X) :
+    groupLossNumerator w g (fun x => (-h x) * (y x - f x)) =
+      groupLossNumerator w g (fun x => h x * (f x - y x)) := by
+  classical
+  unfold groupLossNumerator
+  refine Finset.sum_congr rfl ?_
+  intro x _hx
+  ring
+
+/--
+One-sided multiaccuracy gives absolute multiaccuracy when the feature/model
+class is closed under negation.
+-/
+theorem approxMultiaccurateOnProducts_of_oneSided_negationClosed
+    {X : Type*} [Fintype X]
+    {w : FiniteWeight X} {f y : Model X}
+    {G : Set (Group X)} {H : Set (Model X)} {eta : ℝ}
+    (hma : OneSidedMultiaccurateOnProducts w f y G H eta)
+    (hneg : ModelClassClosedUnderNegation H) :
+    ApproxMultiaccurateOnProducts w f y G H eta := by
+  intro g hg h hh
+  have hsource :
+      groupLossNumerator w g (fun x => h x * (y x - f x)) ≤ eta :=
+    hma g hg h hh
+  have hnegsource :
+      groupLossNumerator w g (fun x => (-h x) * (y x - f x)) ≤ eta :=
+    hma g hg (fun x => -h x) (hneg h hh)
+  have hupper :
+      groupLossNumerator w g (fun x => h x * (f x - y x)) ≤ eta := by
+    rw [groupLossNumerator_neg_sourceResidual_eq w g h f y] at hnegsource
+    exact hnegsource
+  have hlower :
+      -eta ≤ groupLossNumerator w g (fun x => h x * (f x - y x)) := by
+    have hneg_le : -eta ≤
+        -groupLossNumerator w g (fun x => h x * (y x - f x)) :=
+      neg_le_neg hsource
+    simpa [groupLossNumerator_residual_flip w g h f y] using hneg_le
+  exact abs_le.mpr ⟨hlower, hupper⟩
+
+/--
+Absolute product-class multiaccuracy implies the printed one-sided source
+convention, after flipping the residual sign from `f - y` to `y - f`.
+-/
+theorem oneSidedMultiaccurateOnProducts_of_approxMultiaccurateOnProducts
+    {X : Type*} [Fintype X]
+    {w : FiniteWeight X} {f y : Model X}
+    {G : Set (Group X)} {H : Set (Model X)} {eta : ℝ}
+    (hma : ApproxMultiaccurateOnProducts w f y G H eta) :
+    OneSidedMultiaccurateOnProducts w f y G H eta := by
+  intro g hg h hh
+  have hcorr := hma g hg h hh
+  have hlower :
+      -eta ≤ groupLossNumerator w g (fun x => h x * (f x - y x)) :=
+    (abs_le.mp hcorr).1
+  have hneg_le :
+      -groupLossNumerator w g (fun x => h x * (f x - y x)) ≤ eta :=
+    by simpa using neg_le_neg hlower
+  simpa [groupLossNumerator_residual_flip w g h f y] using hneg_le
+
+/-- Approximate multicalibration in expectation over finite prediction values. -/
+def ApproxMulticalibratedInExpectation {X : Type*} [Fintype X]
+    (w : FiniteWeight X) (R : Finset ℝ) (f y : Model X)
+    (C : Set (Model X)) (alpha : ℝ) : Prop :=
+  ∀ c ∈ C,
+    R.sum (fun v =>
+      |weightedRateNumerator w (levelSetIndicator f v)
+        (fun x => c x * (f x - y x))|) ≤ alpha
+
+/-- Approximate joint multicalibration over a class of threshold functions. -/
+def ApproxJointMulticalibratedInExpectation {X : Type*} [Fintype X]
+    (w : FiniteWeight X) (R : Finset ℝ) (f y : Model X)
+    (B : Set (X → ℝ → ℝ)) (alpha : ℝ) : Prop :=
+  ∀ b ∈ B,
+    R.sum (fun v =>
+      |weightedRateNumerator w
+        (fun x => levelSetIndicator f v x * b x v)
+        (fun x => f x - y x)|) ≤ alpha
+
+/-- Absolute self-orthogonality of a predictor on a group collection. -/
+def SelfOrthogonalOnGroups {X : Type*} [Fintype X]
+    (w : FiniteWeight X) (f y : Model X)
+    (G : Set (Group X)) (eta : ℝ) : Prop :=
+  ∀ g ∈ G,
+    |groupLossNumerator w g (fun x => f x * (f x - y x))| ≤ eta
+
+/-- Conditional posterior mean absolute error contribution at one feature. -/
+noncomputable def posteriorConditionalMAE {X Y : Type*} [Fintype Y]
+    (q : X → Y → ℝ) (x : X) : ℝ :=
+  ∑ y : Y, q x y * (1 - q x y)
+
+/-- Finite weighted predictive MAE for posterior scores. -/
+noncomputable def posteriorMAE {X Y : Type*} [Fintype X] [Fintype Y]
+    (w : FiniteWeight X) (q : X → Y → ℝ) : ℝ :=
+  modelLoss w (posteriorConditionalMAE q)
+
+end Statistics
+end EconCSLib

--- a/examples/SmokeChecks.lean
+++ b/examples/SmokeChecks.lean
@@ -6,6 +6,7 @@ import EconCSLib.Foundations.Probability.Gaussian
 import EconCSLib.Foundations.Probability.MDP
 import EconCSLib.MechanismDesign.Auctions
 import GHW01DigitalGoods.MainTheorems
+import EOS07GSP.MainTheorems
 import EconCSLib.Applications.RecommenderSystems.PolicyAveraging
 import EconCSLib.Markets.Matching
 import EconCSLib.Algorithms.Online

--- a/scripts/audit_repository.py
+++ b/scripts/audit_repository.py
@@ -1881,6 +1881,19 @@ def paper_lean_declaration_index(folder: Path) -> dict[str, list[LeanDeclaration
     return declarations
 
 
+def resolve_declaration_name(
+    declaration_index: dict[str, list[LeanDeclaration]], name: object
+) -> list[LeanDeclaration]:
+    """Resolve an unqualified or module-qualified declaration name."""
+
+    target = str(name or "").strip()
+    if not target:
+        return []
+    if target in declaration_index:
+        return declaration_index[target]
+    return declaration_index.get(target.rsplit(".", 1)[-1], [])
+
+
 def library_lean_files() -> list[Path]:
     """Return tracked reusable-library Lean files."""
 
@@ -1998,6 +2011,7 @@ def paper_statement_sidecar_findings(
     """
 
     severity = completed_status_finding_severity(status)
+    findings = paper_statement_map_declaration_findings(paper_id, folder, status)
     try:
         from review_dashboard import (
             assumption_provenance_audit_summary,
@@ -2013,7 +2027,7 @@ def paper_statement_sidecar_findings(
         paper_coverage = paper_coverage_audit_summary(folder, items)
         assumptions = assumption_provenance_audit_summary(folder, items)
     except Exception as exc:  # noqa: BLE001 - audit should report parser failures.
-        return [
+        return findings + [
             Finding(
                 severity,
                 folder,
@@ -2021,7 +2035,6 @@ def paper_statement_sidecar_findings(
             )
         ]
 
-    findings: list[Finding] = []
     strict_evidence_required = status in {
         "formalized",
         "formalized with caveat",
@@ -2211,6 +2224,80 @@ def source_equation_wrapper_candidates(name: str, decl_names: set[str]) -> list[
         if any(marker in candidate for marker in SOURCE_EQUATION_WRAPPER_MARKERS):
             candidates.append(candidate)
     return sorted(candidates)
+
+
+def paper_statement_map_declaration_findings(
+    paper_id: str,
+    folder: Path,
+    status: object,
+) -> list[Finding]:
+    """Check that source-inventory Lean declaration names resolve."""
+
+    statement_map = folder / PAPER_AUDIT_DIR / "paper_statement_map.json"
+    if not statement_map.exists():
+        return []
+    try:
+        payload = json.loads(statement_map.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        return [
+            Finding(
+                completed_status_finding_severity(status),
+                statement_map,
+                f"`{paper_id}` source inventory is not readable JSON: {exc}",
+            )
+        ]
+    items = payload.get("items") if isinstance(payload, dict) else None
+    if not isinstance(items, dict):
+        return []
+
+    paper_declarations = paper_lean_declaration_index(folder)
+    library_declarations = library_lean_declaration_index()
+    missing: list[str] = []
+    malformed: list[str] = []
+    for source_key, item in items.items():
+        if not isinstance(item, dict):
+            continue
+        raw_declarations = item.get("lean_declarations")
+        if raw_declarations is None:
+            continue
+        if not isinstance(raw_declarations, list):
+            malformed.append(str(source_key))
+            continue
+        for raw_name in raw_declarations:
+            name = str(raw_name or "").strip()
+            if not name:
+                malformed.append(str(source_key))
+                continue
+            if resolve_declaration_name(paper_declarations, name):
+                continue
+            if resolve_declaration_name(library_declarations, name):
+                continue
+            missing.append(f"{source_key}:{name}")
+
+    findings: list[Finding] = []
+    severity = completed_status_finding_severity(status)
+    if malformed:
+        findings.append(
+            Finding(
+                severity,
+                statement_map,
+                f"`{paper_id}` source inventory has malformed lean_declarations for "
+                + ", ".join(malformed[:8])
+                + ("; ..." if len(malformed) > 8 else ""),
+            )
+        )
+    if missing:
+        findings.append(
+            Finding(
+                severity,
+                statement_map,
+                f"`{paper_id}` source inventory names {len(missing)} Lean declaration(s) "
+                "that do not resolve in paper-local or reusable-library Lean files: "
+                + ", ".join(missing[:8])
+                + ("; ..." if len(missing) > 8 else ""),
+            )
+        )
+    return findings
 
 
 def is_signature_only_review_alias(kind: str, source: str) -> bool:
@@ -4237,7 +4324,19 @@ def check_paper_facing_ledgers(include_active: bool) -> list[Finding]:
         if folder.name in ACTIVE_PAPERS and not include_active:
             continue
 
+        review_surface: dict[str, object] = {}
+        status_file = folder / "status.json"
+        if status_file.exists():
+            try:
+                status_payload = json.loads(status_file.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                status_payload = {}
+            if isinstance(status_payload, dict) and isinstance(status_payload.get("review_surface"), dict):
+                review_surface = status_payload["review_surface"]  # type: ignore[assignment]
+        review_source = review_surface_source_file_path(folder, review_surface)
         ledger_candidates = [folder / "MainTheorems.lean", folder / "PaperInterface.lean"]
+        if review_source.exists() and review_source not in ledger_candidates:
+            ledger_candidates.append(review_source)
         existing = [path for path in ledger_candidates if path.exists()]
         if not existing:
             continue
@@ -4248,7 +4347,12 @@ def check_paper_facing_ledgers(include_active: bool) -> list[Finding]:
                 findings.append(
                     Finding("ERROR", ledger, "paper-facing ledger still contains template placeholders")
                 )
-            if not LEAN_DECL_RE.search(text):
+            compact_import_shim = (
+                ledger.name == "PaperInterface.lean"
+                and review_source.exists()
+                and review_source.resolve() != ledger.resolve()
+            )
+            if not compact_import_shim and not LEAN_DECL_RE.search(text):
                 findings.append(
                     Finding("WARN", ledger, "paper-facing ledger has no theorem/lemma/def/abbrev declarations")
                 )
@@ -4277,6 +4381,17 @@ def check_post_paper_audit_interfaces(include_active: bool) -> list[Finding]:
             folder, FINAL_VALIDATION_REPORT_FILE, "FINAL_VALIDATION_REPORT.md"
         )
         aggregator = PAPERS / f"{folder.name}.lean"
+        review_surface: dict[str, object] = {}
+        status_file = folder / "status.json"
+        if status_file.exists():
+            try:
+                status_payload = json.loads(status_file.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                status_payload = {}
+            if isinstance(status_payload, dict) and isinstance(status_payload.get("review_surface"), dict):
+                review_surface = status_payload["review_surface"]  # type: ignore[assignment]
+        review_source = review_surface_source_file_path(folder, review_surface)
+        human_interface = review_source if review_source.exists() else interface
 
         if folder.name in interface_required and not interface.exists():
             findings.append(
@@ -4303,11 +4418,17 @@ def check_post_paper_audit_interfaces(include_active: bool) -> list[Finding]:
                 findings.append(
                     Finding("ERROR", interface, "human-facing interface should not use tuple witnesses")
                 )
+        if human_interface.exists():
+            text = human_interface.read_text(encoding="utf-8")
+            if "PProd" in text:
+                findings.append(
+                    Finding("ERROR", human_interface, "human-facing interface should not use tuple witnesses")
+                )
             if INTERFACE_WITNESS_RE.search(text):
                 findings.append(
                     Finding(
                         "ERROR",
-                        interface,
+                        human_interface,
                         "human-facing interface should not expose tuple/prod witness declarations",
                     )
                 )
@@ -4315,7 +4436,7 @@ def check_post_paper_audit_interfaces(include_active: bool) -> list[Finding]:
                 findings.append(
                     Finding(
                         "WARN",
-                        interface,
+                        human_interface,
                         "human-facing interface has no visible definition/abbrev declarations",
                     )
                 )
@@ -4327,7 +4448,7 @@ def check_post_paper_audit_interfaces(include_active: bool) -> list[Finding]:
             )
             if not has_theorem_or_theorem_alias:
                 findings.append(
-                    Finding("WARN", interface, "human-facing interface has no visible theorem statements")
+                    Finding("WARN", human_interface, "human-facing interface has no visible theorem statements")
                 )
 
         if audit.exists():
@@ -5441,11 +5562,18 @@ def check_readme_status_tables(
                 loc = fields.get("Lines of Code", "")
                 if loc and not re.fullmatch(r"\d{1,3}(?:,\d{3})*|\d+", loc):
                     findings.append(Finding("ERROR", readme, f"generated README has invalid Lines of Code `{loc}`"))
-                required_links = [
-                    (
+                if status == "paper draft":
+                    review_link = (
+                        "Agent source audit",
+                        r"Agent source audit:\s+\[[^\]]+\]\(docs/AGENT_SOURCE_AUDIT\.md\)",
+                    )
+                else:
+                    review_link = (
                         "Final validation report",
                         r"Final validation report:\s+\[[^\]]+\]\(FINAL_VALIDATION_REPORT\.md\)",
-                    ),
+                    )
+                required_links = [
+                    review_link,
                     (
                         "Dependency DAG",
                         r"Dependency DAG:\s+\[[^\]]+\]\(docs/DependencyDAG\.pdf\)",

--- a/scripts/review_dashboard.py
+++ b/scripts/review_dashboard.py
@@ -1045,6 +1045,12 @@ def parse_paper_statement_map(folder: Path) -> dict[str, str]:
             for alias in raw_item.get("aliases", []) or []:
                 if isinstance(alias, str) and alias.strip():
                     _add_statement_variant(statements, alias.strip(), text)
+            for alias in raw_item.get("lean_declarations", []) or []:
+                if isinstance(alias, str) and alias.strip():
+                    _add_statement_variant(statements, alias.strip(), text)
+            for alias in raw_item.get("support_lean_declarations", []) or []:
+                if isinstance(alias, str) and alias.strip():
+                    _add_statement_variant(statements, alias.strip(), text)
             continue
         source_text_file = str(raw_item.get("source_text_file") or "source.txt").strip()
         if not source_text_file or "/" in source_text_file or "\\" in source_text_file:
@@ -1075,6 +1081,12 @@ def parse_paper_statement_map(folder: Path) -> dict[str, str]:
             continue
         _add_statement_variant(statements, key.strip(), text)
         for alias in raw_item.get("aliases", []) or []:
+            if isinstance(alias, str) and alias.strip():
+                _add_statement_variant(statements, alias.strip(), text)
+        for alias in raw_item.get("lean_declarations", []) or []:
+            if isinstance(alias, str) and alias.strip():
+                _add_statement_variant(statements, alias.strip(), text)
+        for alias in raw_item.get("support_lean_declarations", []) or []:
             if isinstance(alias, str) and alias.strip():
                 _add_statement_variant(statements, alias.strip(), text)
     return statements
@@ -3547,9 +3559,25 @@ def paper_coverage_audit_required(folder: Path, inventory: dict[str, dict[str, A
 
     payload = load_review_slice_payload(folder)
     explicit = payload.get("paper_coverage_required")
+    explicit_configured = False
     if isinstance(explicit, str):
-        explicit_enabled = explicit.strip().lower() in {"1", "true", "yes", "required", "on"}
+        normalized_explicit = explicit.strip().lower()
+        explicit_configured = normalized_explicit in {
+            "0",
+            "1",
+            "false",
+            "true",
+            "no",
+            "yes",
+            "not required",
+            "optional",
+            "required",
+            "off",
+            "on",
+        }
+        explicit_enabled = normalized_explicit in {"1", "true", "yes", "required", "on"}
     elif isinstance(explicit, bool):
+        explicit_configured = True
         explicit_enabled = explicit
     else:
         explicit_enabled = False
@@ -3568,10 +3596,12 @@ def paper_coverage_audit_required(folder: Path, inventory: dict[str, dict[str, A
         or status_value.startswith("partially formalized")
         or status_value.startswith("conditional")
     )
+    if status_value == "paper draft":
+        return explicit_enabled if explicit_configured else False
     if public_facing_status:
         return True
-    if explicit_enabled:
-        return True
+    if explicit_configured:
+        return explicit_enabled
     return bool(
         inventory
         and (folder / PAPER_STATEMENT_MAP_FILE).exists()
@@ -3970,35 +4000,38 @@ def paper_coverage_audit_summary(folder: Path, items: list[ReviewItem]) -> dict[
             unknown.append(key)
 
     coverage_needs_attention = bool(
-        missing_inventory
-        or unresolved_statement_map
-        or (audit_required and inventory_is_scaffold)
-        or missing_required
-        or missing_source_grounded_audit
-        or coverage_metadata_missing
-        or inventory_missing_source_url
-        or inventory_missing_source_provenance
-        or missing_coverage
-        or missing_statement_digest
-        or stale_statement
-        or stale_inventory
-        or stale_surface
-        or invalid_row_links
-        or partial
-        or missing
-        or uncertain
-        or unknown
-        or covered_without_rows
-        or covered_without_reason
-        or covered_with_seed_reason
-        or covered_without_source_evidence
-        or support_without_declarations
-        or support_without_reason
-        or support_without_source_evidence
-        or required_out_of_scope
-        or out_of_scope_without_reason
-        or out_of_scope_without_source_evidence
-        or extra_coverage
+        audit_required
+        and (
+            missing_inventory
+            or unresolved_statement_map
+            or inventory_is_scaffold
+            or missing_required
+            or missing_source_grounded_audit
+            or coverage_metadata_missing
+            or inventory_missing_source_url
+            or inventory_missing_source_provenance
+            or missing_coverage
+            or missing_statement_digest
+            or stale_statement
+            or stale_inventory
+            or stale_surface
+            or invalid_row_links
+            or partial
+            or missing
+            or uncertain
+            or unknown
+            or covered_without_rows
+            or covered_without_reason
+            or covered_with_seed_reason
+            or covered_without_source_evidence
+            or support_without_declarations
+            or support_without_reason
+            or support_without_source_evidence
+            or required_out_of_scope
+            or out_of_scope_without_reason
+            or out_of_scope_without_source_evidence
+            or extra_coverage
+        )
     )
     source_to_lean_needs_attention = bool(
         coverage_needs_attention

--- a/scripts/sync_paper_status.py
+++ b/scripts/sync_paper_status.py
@@ -916,11 +916,21 @@ def generated_paper_readme_block(folder: Path, payload: dict[str, Any]) -> str:
 
     link_lines = []
     if review_path:
+        review_label = (
+            "Agent source audit"
+            if str(payload.get("status", "")).strip().lower() == "paper draft"
+            else "Final validation report"
+        )
         link_lines.append(
-            f"- Final validation report: {markdown_file_link(folder, review_path, Path(review_path).name)}"
+            f"- {review_label}: {markdown_file_link(folder, review_path, Path(review_path).name)}"
         )
     else:
-        link_lines.append("- Final validation report: not tracked in this folder.")
+        review_label = (
+            "Agent source audit"
+            if str(payload.get("status", "")).strip().lower() == "paper draft"
+            else "Final validation report"
+        )
+        link_lines.append(f"- {review_label}: not tracked in this folder.")
     if dag_path:
         link_lines.append(f"- Dependency DAG: {markdown_file_link(folder, dag_path, Path(dag_path).name)}")
     else:

--- a/site/index.html
+++ b/site/index.html
@@ -105,7 +105,7 @@
               <tr>
                 <td><a href="https://github.com/nikhgarg/EconCSLib/blob/main/EconCSLib/Foundations/Math.lean">Foundations: finite math and graph tools</a></td>
                 <td>Core finite mathematics used across the formalizations: finite-choice distances, ranking and order conversions, finite-sum algebra, threshold and interval certificates, asymptotic estimates, and graph-cycle extraction for local-improvement arguments.</td>
-                <td>15,968</td>
+                <td>15,970</td>
               </tr>
               <tr>
                 <td><a href="https://github.com/nikhgarg/EconCSLib/blob/main/EconCSLib/Foundations/Probability.lean">Foundations: probability and stochastic processes</a></td>

--- a/skills/econcs-session-insights/SKILL.md
+++ b/skills/econcs-session-insights/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: econcs-session-insights
+description: Mine Codex session traces for recurring EconCSLib workflow lessons, preserve provenance for user feedback, and promote durable rules into the operational skills without creating a parallel formalization rulebook. Use when asked to review past sessions, distill process insights, update skills from repeated mistakes, or apply a Skill-DISCO-style trace-to-skill workflow to EconCSLib work.
+---
+
+# EconCS Session Insights
+
+Credit: this skill adapts the trace-distillation idea from Guo, Qi, Gu,
+Cheng, and Xiong, *SKILL-DISCO: Distilling and Compiling Agent Traces into
+Reusable Procedural Skills*, arXiv:2606.26669v1. Their framework normalizes
+successful agent traces, clusters repeated procedural structure, and compiles
+the stable patterns into reusable skills; this file applies that idea to
+EconCSLib formalization sessions.
+
+Use this skill to turn prior Codex sessions into concise, reusable procedural
+guidance for EconCSLib formalization work. The goal is not to preserve history.
+The goal is to find repeated execution patterns, repeated user corrections, and
+stable cross-paper rules that should affect future agents.
+
+## Trace Distillation Workflow
+
+1. Start from `~/.codex/history.jsonl`.
+   - First read the `Last reviewed through` timestamp in
+     `references/user-feedback-course-corrections.md`.
+   - For routine updates, inspect only history rows and raw session turns after
+     that timestamp. Do a full backfill only when the user asks for one or the
+     ledger is missing/corrupt.
+   - Treat it as the high-level successful-trace index: user goals,
+     corrections, status checks, and boundary decisions.
+   - Group messages by session id and topic before opening raw session files.
+   - Do not begin by scanning every raw `~/.codex/sessions/**/*.jsonl` file.
+     Session continuations and subagents duplicate long instruction contexts and
+     can dominate runtime without adding new procedural signal.
+
+2. Open raw session JSONL files only when needed.
+   - Sample sessions that contain repeated correction phrases, failed tools,
+     unusual commits, CI fixes, or paper-boundary decisions.
+   - Ignore system/developer boilerplate, encrypted reasoning, copied context,
+     and repeated continuation payloads.
+   - Extract only normalized operations: user directive, repo/paper context,
+     action class, files or tools touched, result, and user correction.
+
+3. Segment normalized operations into subgoals.
+   Use these default clusters for EconCSLib:
+   - proof planning and theorem closure;
+   - source-version and TeX/PDF convention checks;
+   - assumption/certificate provenance;
+   - reusable library elevation;
+   - documentation, DAG, status, and audit timing;
+   - public/private repository release hygiene;
+   - CI/build/runtime environment handling;
+   - subagent coordination and handoff boundaries.
+
+   For the current distilled course-correction ledger, see
+   `references/user-feedback-course-corrections.md`. Load it when the task asks
+   specifically about prior user feedback, repeated corrections, or process
+   hardening from session history.
+
+4. Consolidate only repeated lessons.
+   A candidate insight is skill-worthy when it appears in at least two sessions,
+   affects at least two papers, or corrects a serious workflow failure. Do not
+   add one-off paper notation, temporary proof names, or paper-local strategy
+   details to a general skill.
+
+5. Compile insights into the narrowest appropriate skill file.
+   - Main workflow rules go in `skills/econcs-formalizer/SKILL.md`.
+   - Math-domain proof tactics go in the relevant reference file under
+     `skills/econcs-formalizer/references/`.
+   - Public-release rules go in the public/release workflow guidance.
+   - If the insight is still experimental, put it in a separate draft skill like
+     this one for review before merging.
+
+6. Validate the skill update.
+   - Keep the patch concise and grep for accidental paper-specific names.
+   - Check that the new instruction is actionable, not just retrospective.
+   - Update the `Last reviewed through` timestamp to the newest processed
+     session/history timestamp only after the promoted rules and ledger edits are
+     written.
+   - Do not commit generated transcript summaries or text caches unless the
+     user explicitly asked for them.
+
+## Promotion Destinations
+
+This skill is a provenance and maintenance layer, not a day-to-day paper
+formalization rulebook. Durable lessons should be promoted into the narrowest
+operational destination:
+
+- `skills/econcs-formalizer/SKILL.md` for active paper formalization workflow,
+  source provenance, audits, documentation timing, public/private repo hygiene,
+  and subagent use.
+- `skills/econcs-formalizer/references/proof-*.md` for math-domain tactics,
+  theorem patterns, and reusable proof routes.
+- `skills/lean-community-conventions/SKILL.md` for Lean naming, style,
+  documentation, and proof-claim gate conventions.
+- Paper-local planning or audit files for paper-specific notation, source
+  deviations, and temporary proof strategy.
+
+The current feedback ledger lives in
+`references/user-feedback-course-corrections.md`. Load it only when a task asks
+to mine prior sessions, explain the origin of a process rule, or update skills
+from repeated feedback.
+
+## Applying Insights Back to Skills
+
+When merging a draft insight into an operational skill:
+
+1. Rewrite it as a short command or checklist item.
+2. Remove references to the session that taught the lesson.
+3. Remove paper-specific notation unless the destination is a paper-specific
+   reference.
+4. Put math-specific proof content in the relevant proof reference, not the main
+   workflow skill.
+5. Delete or demote any duplicate rule from this session-insights skill once it
+   has been promoted.

--- a/skills/econcs-session-insights/references/user-feedback-course-corrections.md
+++ b/skills/econcs-session-insights/references/user-feedback-course-corrections.md
@@ -1,0 +1,282 @@
+# User Feedback Course Corrections
+
+Last reviewed through: 2026-06-28T18:56:52-04:00
+
+This reference distills recurring user feedback from local Codex history into
+candidate workflow rules. It is intentionally separate from the main skill body:
+the main skill should stay compact, while this ledger preserves the normalized
+corrections that justify future skill updates.
+
+Do not copy these as session history into public docs. When a rule matures,
+rewrite it as a direct instruction in the narrowest relevant skill or reference
+file. This ledger is provenance, not an operational rulebook for active paper
+formalization.
+
+## Extraction Method
+
+Source: `~/.codex/history.jsonl`, filtered for user messages containing
+course-correction language such as "do not", "why", "should", "instead",
+"too much", "wrong", "mistaken", "remember", "make sure", and repo-specific
+terms such as "paper", "formalization", "Lean", "library", "DAG", "audit",
+"public/private", "source", "certificate", and "CI".
+
+The pass found 507 course-correction-like messages out of 1307 user history
+rows. The clusters below are normalized rules, not quotations.
+
+For future incremental passes, start from rows after the `Last reviewed through`
+timestamp above unless the user asks for a full backfill.
+
+## Goal Discipline
+
+Trigger: the user says to keep going on a paper, finish to closure, or work up
+to an agreed boundary.
+
+Rule:
+- Keep the active paper fixed unless the user explicitly redirects.
+- Do not switch to another paper because it seems easier or because nearby
+  library work is tempting.
+- If another agent owns a paper or proof area, avoid interfering and work only
+  on shared library pieces that are clearly safe.
+- When the user repeats "keep going", treat it as permission to continue through
+  implementation, targeted validation, and the next real proof boundary.
+
+Common failure prevented: drifting into documentation, another paper, or a
+smaller local task while the user wanted sustained progress on the active proof.
+
+## Top-Down Proof Planning
+
+Trigger: proof search is becoming local, repetitive, or focused on the smallest
+next lemma.
+
+Rule:
+- Step back and write a top-down completion plan outside Lean.
+- Choose the next action by fastest path to overall paper closure, not easiest
+  local proof progress.
+- At paper start, identify good partial-formalization boundaries and why they
+  are meaningful; surface them to the user before deep proof work.
+- If a boundary is accepted, finish everything up to that boundary before doing
+  broad docs or unrelated library expansion.
+
+Common failure prevented: spending many turns on tiny lemmas without a credible
+route to the paper-facing theorem.
+
+## Source Truth and Source Deviations
+
+Trigger: theorem statements depend on paper conventions, constants, numbering,
+or corrected versions.
+
+Rule:
+- Download and cache the PDF/TeX/source once; use that local copy for repeated
+  checks.
+- Prefer the published conference or journal version as source of truth when it
+  clarifies assumptions or corrects arXiv text. Link arXiv when useful, but cite
+  the published venue for paper metadata where appropriate.
+- If a paper has a wrong constant, missing factor, sign issue, or finite-bound
+  typo, prove the corrected statement when it is mathematically justified.
+- Do not block downstream theorem closure on exact printed algebra if the main
+  result only needs a weaker or corrected lemma.
+- Document source deviations in the validation/audit report and only surface
+  them in tables when they affect a paper-facing result or remaining boundary.
+
+Common failure prevented: repeated web searches, treating source typos as proof
+blockers, or burying source deviations in generic prose.
+
+## Caveat, Partial, and Boundary Language
+
+Trigger: a result uses extra assumptions, a source convention is implicit, or a
+statement differs from the printed paper.
+
+Rule:
+- Use "caveat" for a meaningful source deviation, source error, or missing
+  source assumption.
+- Use "partial formalization" or "boundary" for proof debt, external library
+  debt, or a theorem that still assumes an unproved certificate.
+- Do not mark a reasonable source interpretation as a caveat if the result is
+  fully proved under that interpretation; explain the interpretation in the
+  human-facing report.
+- Do not mark definitions as red/caveated merely because they are definitions.
+
+Common failure prevented: making completed results look conditional, or making
+conditional results look fully closed.
+
+2026-06-28 update:
+- A source-defined convention that intentionally selects, erases, or normalizes
+  terms is not a caveat merely because an alternate raw object would differ.
+  Keep the paper-facing status focused on whether the source-shaped theorem is
+  closed; put convention details in agent-facing audit notes unless they change
+  the theorem statement or expose a source-paper issue.
+- Human-facing final reports should not carry detailed source-record or
+  convention warnings that exist only to prevent future agent confusion.
+
+## Assumption and Certificate Provenance
+
+Trigger: a Lean theorem has model certificates, record fields, row packages, or
+opaque wrappers in its assumptions.
+
+Rule:
+- "Fully closed" means derived from primitive Lean/mathlib foundations and
+  primitive paper assumptions, not merely proved from a certificate.
+- Every non-derived certificate field must be recursively traced to either a
+  primitive paper assumption, an upstream theorem that derives it, or an
+  explicit visible proof boundary.
+- Hidden formulas inside records, certificates, library definitions, or source
+  rows require provenance checks. Lean can prove wrappers around an incorrect
+  formula if the formula is assumed as data.
+- Use Lean dependency/axiom-style checks where possible, but supplement them
+  with source-provenance audits and LLM review of the eventual assumptions.
+- Recursion failure is an audit error, not a silent pass.
+
+Common failure prevented: claiming full formalization when Lean only checked
+"hypotheses imply conclusion" and not "hypotheses are source-derived".
+
+## LLM-As-Judge and Audit Hardening
+
+Trigger: statement matching passes but the proof may rely on hidden assumptions
+or source-row formulas.
+
+Rule:
+- Statement-translation judging is not enough. Add provenance judging for
+  assumptions, certificates, and record fields.
+- Run a smaller no-context statement/judge pass near the beginning of a paper to
+  set correct `PaperInterface.lean` targets.
+- Run full post-formalization audit only at closeout or real proof boundaries;
+  use targeted checks during active proof work.
+- Keep audit code general. Do not add paper-specific function-name heuristics
+  where a structural rule can be checked instead.
+- Audits of DAGs, validation reports, assumptions, and source records should be
+  part of closeout, not optional afterthoughts.
+
+Common failure prevented: LLM judge approving displayed formulas while missing
+that they were assumed rather than derived.
+
+2026-06-28 update:
+- A compact review surface can be too small as well as too large. Hundreds of
+  rows expose implementation internals, but a handful of rows can fail to cover
+  the paper claim. For large completed papers, curate a source-level dashboard
+  that covers main theorem blocks, key formulas, examples, and appendix pieces.
+- `include_names` controls the visible human dashboard, but every other
+  `PaperInterface.lean` declaration still needs classification as auxiliary or
+  assumption for the closeout audit. Auxiliary slice buckets may satisfy
+  readiness checks without expanding the human dashboard.
+- After changing source-provenance docstrings, review-surface rows, or
+  statement comments, refresh the dashboard cache and regenerate tracked
+  sidecars from the current surface; stale sidecars are audit failures even when
+  Lean code did not change.
+
+## Library Elevation
+
+Trigger: a proof pattern, definition, or lemma appears useful for multiple
+papers or future EconCS papers.
+
+Rule:
+- Elevate when at least two papers can use the result, or when future EconCS
+  papers in the area are clearly likely to use it.
+- Build shared infrastructure for recurring continuous probability, large
+  deviations, ranking models, stochastic processes, auctions, matching, social
+  choice, algorithms, or optimization patterns.
+- Keep paper-facing theorem wrappers, paper-specific certificates, and source
+  interpretation text in paper folders.
+- After extraction, verify that user-facing theorem statements did not change
+  unless a source-deviation update was explicitly approved.
+
+Common failure prevented: either duplicating reusable proofs across papers or
+moving paper-specific progress into the public library.
+
+## Documentation Timing
+
+Trigger: proof work is ongoing and docs/status files are being updated often.
+
+Rule:
+- Avoid documentation churn while proving. Update README/status/DAG/audit files
+  at real session boundaries, proof-boundary changes, public PR preparation, or
+  final closeout.
+- Do not update `status.json` after every proof loop.
+- Do not run full closeout audit when the paper is not done; run targeted checks
+  that directly support the active proof.
+- Human-facing docs should state current status, not history markers like
+  "previously" or "no longer".
+
+Common failure prevented: spending more time synchronizing status artifacts than
+closing the proof.
+
+## Human-Facing Documentation Standards
+
+Trigger: updating README, DAG, validation reports, public tables, website, or
+paper dashboards.
+
+Rule:
+- Human summaries should be concise, current, and paper-facing.
+- Avoid dumping long Lean declaration lists. Usually record one main Lean
+  declaration per paper-facing result.
+- Paper-specific status tables may include rare source-deviation notes, but
+  public summary tables should stay sparse.
+- DAG nodes for completed results should summarize mathematical content, not
+  say only "closed" or "formalized".
+- Review dashboards should expose paper-named results and displayed formulas,
+  not every helper lemma.
+- Keep DAG arrowheads, caveat coloring, and dependency density aligned with the
+  workflow template.
+
+Common failure prevented: public/human docs becoming internal debugging logs.
+
+## Public and Private Repository Hygiene
+
+Trigger: committing, pushing, merging, opening public PRs, or syncing private
+and public repositories.
+
+Rule:
+- Private main is acceptable for routine private work unless the user asks for a
+  branch.
+- Do not rebase private repos frequently; do it only for substantial changes or
+  when needed for sync.
+- Public PRs must be filtered: do not expose unpublished partial papers,
+  private source caches, text caches, or private-only artifacts.
+- Before merging public work, confirm CI/audit expectations, website/table
+  regeneration, line counts, and status files are correct.
+- If private and public diverge, preserve private proof progress and publish
+  only the intended public subset.
+
+Common failure prevented: accidentally publishing partial private formalizations
+or losing private proof work during library extraction.
+
+## Runtime and Tooling
+
+Trigger: shell commands fail with stream-fd errors, repeated source lookups, or
+slow status synchronization.
+
+Rule:
+- On this Ubuntu setup, use `login=false` for shell commands to avoid repeated
+  `Failed to create stream fd: Operation not permitted` failures.
+- Cache downloaded paper sources and use local copies.
+- Do not keep searching the web after source is available locally.
+- Do not wait on private CI unless the task requires merging, diagnosing CI, or
+  the user explicitly asks.
+
+Common failure prevented: losing proof time to repeated environment and source
+lookup overhead.
+
+## Subagents and Concurrent Work
+
+Trigger: using subagents or working while another agent is active.
+
+Rule:
+- Use subagents for independent source checks, proof-route comparison, library
+  search, and audit validation.
+- Give subagents narrow tasks and ask for artifacts or conclusions, not broad
+  open-ended proof ownership.
+- Do not work on a paper another agent is actively formalizing unless the user
+  tells you to. Shared library changes are acceptable when coordinated and
+  minimally disruptive.
+
+Common failure prevented: duplicated or conflicting work across active agents.
+
+## Promotion Checklist
+
+Before moving any rule from this ledger into `skills/econcs-formalizer`:
+
+1. Remove references to the session that taught the lesson.
+2. Remove paper-specific notation unless the destination is a paper-specific
+   reference.
+3. Phrase the lesson as an action or check, not a retrospective explanation.
+4. Put math-specific content in a math/proof reference file, not the main skill.
+5. Keep public-release rules separate from proof-search rules when possible.


### PR DESCRIPTION
## Summary

- adds reusable finite statistics/prediction and algorithmic-fairness interfaces
- publishes shared audit/status script improvements from private into public
- adds the session-insights workflow skill referenced by the formalizer skill
- regenerates the public site from public metadata, producing only a public LOC update

## Intentional omissions

- does not copy private `site/index.html`; the included site diff is generated in the public checkout
- does not change `lakefile.toml`, because the private delta only adds private paper targets
- does not add or keep `HumanStartHere.lean`; `examples/SmokeChecks.lean` remains the compile-smoke surface
- does not publish private paper folders, source caches, or old planning docs

## Validation

- `python3 -m py_compile scripts/audit_repository.py scripts/review_dashboard.py scripts/sync_paper_status.py`
- `python3 scripts/sync_paper_status.py --check`
- `python3 scripts/audit_repository.py --library-only --library-premise-audit --info-limit 0`
- `lake env lean EconCSLib/Learning/Statistics/Prediction.lean`
- `lake build EconCSLib.Learning.Statistics.Prediction`
- `lake build EconCSLib.Applications.AlgorithmicFairness.Basic`
- `lake env lean examples/SmokeChecks.lean`
- `lake build EconCSLib`
- private-paper leakage grep over the changed public paths
