### PR TITLE
Publish readable validation reports and memos on the website

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -6,6 +6,7 @@ on:
     branches: [main]
     paths:
       - "site/**"
+      - "papers/**"
       - ".github/workflows/pages.yml"
 
 permissions:
@@ -33,10 +34,19 @@ jobs:
         with:
           enablement: true
 
+      - name: Install document renderer
+        run: sudo apt-get update && sudo apt-get install -y pandoc
+
+      - name: Test published document rendering
+        run: python3 -m unittest discover -s site -p 'test_*.py'
+
+      - name: Build website and paper documents
+        run: python3 site/build_public_site.py --output "$RUNNER_TEMP/published-site"
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v5
         with:
-          path: site
+          path: ${{ runner.temp }}/published-site
 
       - name: Deploy to GitHub Pages
         id: deployment

--- a/docs/WEBSITE_MAINTENANCE.md
+++ b/docs/WEBSITE_MAINTENANCE.md
@@ -1,9 +1,9 @@
 # Website Maintenance
 
-The `site/` directory contains the GitHub Pages source for the public Applied Modeling Lib
-project, currently hosted in the `EconCSLib`
-repository. The deployment workflow publishes `site/` from `main` and
-enables Pages through GitHub Actions on the first successful deployment.
+The `site/` directory contains the GitHub Pages source for
+[AppliedModelingLib](https://gargnikhil.com/AppliedModelingLib/).
+The deployment workflow builds the landing page, rendered Markdown documents,
+and paper PDFs from `main`. Changes to `site/` or `papers/` trigger deployment.
 
 ## Preview Locally
 
@@ -62,13 +62,28 @@ python3 site/private_preview_server.py --port 8080
 ```
 
 The browser switches artifact links to this checkout only when the localhost
-server advertises that capability. A normal static server or the public site
-keeps the GitHub links.
+server advertises that capability. A plain server of the unbuilt `site/`
+directory keeps the GitHub fallback links.
 Markdown reports and linked memos render as HTML, with tables and mathematics;
 generator boundary comments remain in their source files and are hidden from
 readers. Heading identifiers match GitHub Markdown, so the same section links
 work locally and in the public repository. The preview does not rewrite the
 reports or their audit evidence.
+
+To preview the deployed form from a public checkout, build into a fresh directory:
+
+```bash
+python3 site/build_public_site.py --output ../appliedmodelinglib-site --base-path ''
+python3 -m http.server 8081 --directory ../appliedmodelinglib-site
+```
+
+The public build uses the same Markdown renderer. Reports and memos have `.html`
+URLs under `/AppliedModelingLib/artifacts/papers/`; their relative links and
+heading fragments remain usable. PDFs open on the site, while Lean, JSON, and
+TeX links open their GitHub sources. Each rendered document also offers its
+Markdown source. Only tracked files in folders explicitly marked public are
+eligible; a table link to an unpublished artifact stops the build. The builder
+does not modify report text or audit records.
 
 The hero vision sentence, the maintainer footer, the former-name note,
 and the note about the separate `gametheoryinlean/EconCSLib` project are

--- a/site/README.md
+++ b/site/README.md
@@ -1,6 +1,6 @@
 # AppliedModelingLib Website
 
-[Visit the project website](https://gargnikhil.com/EconCSLib/) to explore the
+[Visit the project website](https://gargnikhil.com/AppliedModelingLib/) to explore the
 reusable Lean library and paper formalizations.
 
 The paper table links to validation reports, source-clarification memos,

--- a/site/build_public_site.py
+++ b/site/build_public_site.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""Build the published website and HTML versions of released paper documents.
+
+Only tracked files in explicitly public paper folders are eligible. The build
+never changes Markdown, status, proof, or audit inputs. Pandoc is required.
+"""
+from __future__ import annotations
+
+import argparse
+import html
+from html.parser import HTMLParser
+import json
+from pathlib import Path, PurePosixPath
+import posixpath
+import re
+import shutil
+import subprocess
+from urllib.parse import quote, unquote, urlsplit, urlunsplit
+
+from private_preview_server import render_markdown_artifact
+
+REPOSITORY = "https://github.com/nikhgarg/AppliedModelingLib"
+OLD_REPOSITORY = "https://github.com/nikhgarg/EconCSLib"
+ASSET_SUFFIXES = {".pdf", ".svg", ".png", ".jpg", ".jpeg", ".gif", ".webp"}
+
+
+class LinkRewriter(HTMLParser):
+    """Change URL attributes without reformatting document text or mathematics."""
+
+    def __init__(self, rewrite, *, landing=False):
+        super().__init__(convert_charrefs=False)
+        self.rewrite = rewrite
+        self.landing = landing
+        self.parts = []
+
+    def handle_starttag(self, tag, attrs):
+        raw = self.get_starttag_text()
+        local = dict(attrs).get("data-local-artifact-href") if self.landing else None
+
+        def replace(match):
+            name, delimiter, value = match.groups()
+            target = local if name == "href" and local else html.unescape(value)
+            return f'{name}={delimiter}{html.escape(self.rewrite(target), quote=True)}{delimiter}'
+
+        raw = re.sub(r'''(?<![\w-])(href|src)=(['"])(.*?)\2''', replace, raw)
+        if self.landing:
+            raw = re.sub(r'''\sdata-local-artifact-href=(['"]).*?\1''', "", raw)
+        self.parts.append(raw)
+
+    handle_startendtag = handle_starttag
+
+    def handle_endtag(self, tag):
+        self.parts.append(f"</{tag}>")
+
+    def handle_data(self, data):
+        self.parts.append(data)
+
+    def handle_entityref(self, name):
+        self.parts.append(f"&{name};")
+
+    def handle_charref(self, name):
+        self.parts.append(f"&#{name};")
+
+    def handle_comment(self, data):
+        self.parts.append(f"<!--{data}-->")
+
+    def handle_decl(self, decl):
+        self.parts.append(f"<!{decl}>")
+
+
+def rewrite_html(content, rewrite, *, landing=False):
+    parser = LinkRewriter(rewrite, landing=landing)
+    parser.feed(content)
+    parser.close()
+    return "".join(parser.parts)
+
+
+def build(repo: Path, output: Path, base_path: str = "/AppliedModelingLib") -> dict:
+    repo, output = repo.resolve(), output.resolve()
+    if output.exists() and any(output.iterdir()):
+        raise ValueError("Output directory must be empty; use a fresh build directory")
+    if output == repo or repo.is_relative_to(output):
+        raise ValueError("Output must not contain the repository")
+    base_path = "/" + base_path.strip("/") if base_path.strip("/") else ""
+    tracked = set(subprocess.check_output(
+        ["git", "-C", str(repo), "ls-files", "-z"], text=True
+    ).split("\0")) - {""}
+    public = set()
+    for name in sorted(tracked):
+        path = PurePosixPath(name)
+        if len(path.parts) == 3 and path.parts[0] == "papers" and path.name == "status.json":
+            if json.loads((repo / name).read_text()).get("repository_visibility") == "public":
+                public.add(path.parts[1])
+
+    artifacts = {}
+    for name in sorted(tracked):
+        path = PurePosixPath(name)
+        if len(path.parts) < 3 or path.parts[0] != "papers" or path.parts[1] not in public:
+            continue
+        if path.suffix.lower() not in ASSET_SUFFIXES | {".md"}:
+            continue
+        source = repo / name
+        if source.is_symlink() or not source.is_file() or not source.resolve().is_relative_to(repo):
+            raise ValueError(f"Artifact must be a regular repository file: {name}")
+        destination = path.with_suffix(".html") if path.suffix.lower() == ".md" else path
+        artifacts[name] = "artifacts/" + str(destination)
+
+    def url_for(name):
+        return base_path + "/" + quote(artifacts[name], safe="/")
+
+    def source_url(name):
+        kind = "tree" if (repo / name).is_dir() else "blob"
+        return f"{REPOSITORY}/{kind}/main/{quote(name, safe='/')}"
+
+    def rewrite(url, current=None):
+        url = url.replace(OLD_REPOSITORY, REPOSITORY)
+        parsed = urlsplit(url)
+        path = unquote(parsed.path)
+        if url.startswith(REPOSITORY + "/blob/main/"):
+            name = path.split("/blob/main/", 1)[1]
+        elif not parsed.netloc and not parsed.scheme and path.startswith("/artifacts/"):
+            name = path[len("/artifacts/"):]
+            if name not in artifacts:
+                if name not in tracked or PurePosixPath(name).parts[1] not in public:
+                    raise ValueError(f"Landing page links to an unpublished artifact: {name}")
+        elif parsed.scheme or parsed.netloc or not path or path.startswith("/") or current is None:
+            return url
+        else:
+            name = posixpath.normpath(str(PurePosixPath(current).parent / path))
+        destination = url_for(name) if name in artifacts else source_url(name)
+        result = urlsplit(destination)
+        return urlunsplit((result.scheme, result.netloc, result.path, parsed.query, parsed.fragment))
+
+    output.mkdir(parents=True, exist_ok=True)
+    for name in sorted(tracked):
+        path = PurePosixPath(name)
+        if path.parts[:2] in {("site", "styles"), ("site", "assets")}:
+            source = repo / name
+            if source.is_symlink():
+                raise ValueError(f"Site assets cannot be symlinks: {name}")
+            target = output / path.relative_to("site")
+            target.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copyfile(source, target)
+    landing = rewrite_html((repo / "site/index.html").read_text(), rewrite, landing=True)
+    (output / "index.html").write_text(landing)
+    (output / ".nojekyll").touch()
+
+    for name, destination in artifacts.items():
+        target = output / destination
+        target.parent.mkdir(parents=True, exist_ok=True)
+        if not name.lower().endswith(".md"):
+            shutil.copyfile(repo / name, target)
+            continue
+        folder = "/".join(PurePosixPath(name).parts[:2])
+        links = [("Papers", base_path + "/")]
+        for label, filename in (
+            ("Report", "FINAL_VALIDATION_REPORT.md"),
+            ("Lean statements", "PaperInterface.lean"),
+            ("Dependency DAG", "docs/DependencyDAG.pdf"),
+            ("Review packet", "docs/HUMAN_REVIEW_PACKET.pdf"),
+        ):
+            relative = folder + "/" + filename
+            if relative in tracked:
+                links.append((label, url_for(relative) if relative in artifacts else source_url(relative)))
+        links.append(("Markdown source", source_url(name)))
+        navigation = '<nav class="artifact-links" aria-label="Paper artifacts">' + " ".join(
+            f'<a href="{html.escape(url, quote=True)}">{label}</a>' for label, url in links
+        ) + "</nav>"
+        rendered = render_markdown_artifact(
+            repo / name, css_url=base_path + "/styles/site.css", navigation=""
+        ).decode()
+        rendered = rewrite_html(rendered, lambda url: rewrite(url, name))
+        rendered = rendered.replace('<body class="artifact-document">',
+                                    '<body class="artifact-document">' + navigation, 1)
+        target.write_text(rendered)
+    result = {"public_papers": len(public), "documents": sum(n.endswith(".md") for n in artifacts),
+              "assets": sum(not n.endswith(".md") for n in artifacts)}
+    (output / "build-manifest.json").write_text(json.dumps(result, indent=2) + "\n")
+    return result
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", type=Path, default=Path(__file__).resolve().parents[1])
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--base-path", default="/AppliedModelingLib")
+    args = parser.parse_args()
+    print(json.dumps(build(args.repo, args.output, args.base_path), indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/site/private_preview_server.py
+++ b/site/private_preview_server.py
@@ -1,10 +1,8 @@
 #!/usr/bin/env python3
 """Serve the current status site and current paper artifacts on localhost.
 
-The generated site continues to contain only public GitHub artifact URLs.
-When it is viewed through this server, a small browser-side rewrite selects the
-``/artifacts/`` route below, which is deliberately available only from the
-local checkout.
+The local server renders current checkout documents on demand. The public
+Pages builder uses the same renderer to publish static HTML documents.
 """
 
 from __future__ import annotations
@@ -55,7 +53,9 @@ def paper_artifact_navigation(path: Path) -> str:
     return '<nav class="artifact-links" aria-label="Paper artifacts">' + " ".join(links) + "</nav>"
 
 
-def render_markdown_artifact(path: Path) -> bytes:
+def render_markdown_artifact(
+    path: Path, *, css_url: str = "/styles/site.css", navigation: str | None = None
+) -> bytes:
     """Render report prose while keeping source-only generator comments hidden."""
 
     result = subprocess.run(
@@ -63,13 +63,15 @@ def render_markdown_artifact(path: Path) -> bytes:
             "pandoc", "--from=markdown+gfm_auto_identifiers", "--to=html5",
             "--standalone", "--strip-comments", "--mathml",
             "--metadata", f"pagetitle={path.stem.replace('_', ' ').title()}",
-            "--css=/styles/site.css",
+            f"--css={css_url}",
         ],
         input=path.read_text(encoding="utf-8"),
         text=True, capture_output=True, check=True, timeout=15,
     )
     return result.stdout.replace(
-        "<body>", '<body class="artifact-document">' + paper_artifact_navigation(path), 1
+        "<body>", '<body class="artifact-document">' + (
+            paper_artifact_navigation(path) if navigation is None else navigation
+        ), 1
     ).encode("utf-8")
 
 

--- a/site/test_build_public_site.py
+++ b/site/test_build_public_site.py
@@ -1,0 +1,86 @@
+"""Published reports must remain readable and navigable under a project URL."""
+import json
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+from build_public_site import build
+
+
+@unittest.skipUnless(shutil.which("pandoc"), "Pandoc is required")
+class PublishedReportTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        self.repo = self.root / "repo"
+        self.repo.mkdir()
+        subprocess.run(["git", "init", "-q", str(self.repo)], check=True)
+        self.write("site/styles/site.css", "body { color: black; }")
+        self.write("site/index.html", '<html><body><a href="https://github.com/nikhgarg/EconCSLib/blob/main/papers/Example/FINAL_VALIDATION_REPORT.md" data-local-artifact-href="/artifacts/papers/Example/FINAL_VALIDATION_REPORT.md">Report</a></body></html>')
+        self.write("papers/Example/status.json", json.dumps({"repository_visibility": "public"}))
+        self.write("papers/Example/FINAL_VALIDATION_REPORT.md", """# Report
+
+<!-- BEGIN GENERATED -->
+| Result | Status |
+|---|---|
+| Theorem 1 | Exact |
+
+[Memo](docs/CLARIFICATIONS.md#6-extra-assumptions)
+[PDF](docs/DependencyDAG.pdf)
+[Lean](PaperInterface.lean#L2)
+[Remote memo](https://github.com/nikhgarg/EconCSLib/blob/main/papers/Example/docs/CLARIFICATIONS.md#6-extra-assumptions)
+
+The result is $x^2 > 0$.
+<!-- END GENERATED -->
+""")
+        self.write("papers/Example/docs/CLARIFICATIONS.md", "# Memo\n\n## 6. Extra Assumptions\n\n[Report](../FINAL_VALIDATION_REPORT.md)\n")
+        self.write("papers/Example/docs/DependencyDAG.pdf", "%PDF-1.7\n")
+        self.write("papers/Example/PaperInterface.lean", "-- Public Lean statements\n")
+        self.write("papers/Private/status.json", json.dumps({"repository_visibility": "private_only"}))
+        self.write("papers/Private/FINAL_VALIDATION_REPORT.md", "# Private report\n")
+        subprocess.run(["git", "-C", str(self.repo), "add", "site", "papers"], check=True)
+        self.write("papers/Example/local-notes.md", "# Untracked notes\n")
+
+    def write(self, name, value):
+        path = self.repo / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(value)
+
+    def test_published_report_math_tables_and_nested_navigation(self):
+        output = self.root / "output"
+        result = build(self.repo, output)
+        self.assertEqual(result, {"public_papers": 1, "documents": 2, "assets": 1})
+        index = (output / "index.html").read_text()
+        self.assertIn('href="/AppliedModelingLib/artifacts/papers/Example/FINAL_VALIDATION_REPORT.html"', index)
+        self.assertNotIn("data-local-artifact-href", index)
+        report = (output / "artifacts/papers/Example/FINAL_VALIDATION_REPORT.html").read_text()
+        self.assertIn("<table>", report)
+        self.assertIn("<math", report)
+        self.assertNotIn("BEGIN GENERATED", report)
+        self.assertIn('href="/AppliedModelingLib/styles/site.css"', report)
+        self.assertEqual(report.count('href="/AppliedModelingLib/artifacts/papers/Example/docs/CLARIFICATIONS.html#6-extra-assumptions"'), 2)
+        self.assertIn('href="https://github.com/nikhgarg/AppliedModelingLib/blob/main/papers/Example/PaperInterface.lean#L2"', report)
+        self.assertIn('href="https://github.com/nikhgarg/AppliedModelingLib/blob/main/papers/Example/FINAL_VALIDATION_REPORT.md">Markdown source', report)
+        memo = (output / "artifacts/papers/Example/docs/CLARIFICATIONS.html").read_text()
+        self.assertIn('id="6-extra-assumptions"', memo)
+        self.assertIn('href="/AppliedModelingLib/artifacts/papers/Example/FINAL_VALIDATION_REPORT.html"', memo)
+        self.assertEqual((output / "artifacts/papers/Example/docs/DependencyDAG.pdf").read_bytes(), b"%PDF-1.7\n")
+        self.assertFalse((output / "artifacts/papers/Private").exists())
+        self.assertFalse((output / "artifacts/papers/Example/local-notes.html").exists())
+
+    def test_unpublished_landing_link_stops_deployment(self):
+        self.write("site/index.html", '<a href="#" data-local-artifact-href="/artifacts/papers/Private/FINAL_VALIDATION_REPORT.md">Report</a>')
+        with self.assertRaisesRegex(ValueError, "unpublished artifact"):
+            build(self.repo, self.root / "output")
+
+    def test_project_root_can_be_previewed_without_a_prefix(self):
+        output = self.root / "output"
+        build(self.repo, output, "")
+        self.assertIn('href="/artifacts/papers/Example/FINAL_VALIDATION_REPORT.html"', (output / "index.html").read_text())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Reports and linked memos now open as styled HTML on the project website, with rendered mathematics, working section links, and direct PDF access. The Pages build uses the local preview renderer and retains GitHub source links; paper updates trigger deployment.

Validation: seven focused rendering tests passed; the full public build produced 154 documents and 73 PDFs for 36 papers; all 1,637 local links and anchors resolved; LG24 was visually checked in Chrome. The authoritative public-release guard passed. No proof or audit evidence changed.
