### PR TITLE
Fix trusted CI startup and scope checks to changed work

### DIFF
--- a/.github/workflows/lean_action_ci.yml
+++ b/.github/workflows/lean_action_ci.yml
@@ -20,6 +20,7 @@ jobs:
     env:
       # Bounds Lake's runtime pool and every Lean subprocess it launches.
       LEAN_NUM_THREADS: "1"
+      PUBLIC_SOURCE_MODE: ${{ github.event.repository.private != true }}
 
     steps:
       - name: Check out repository
@@ -46,7 +47,7 @@ jobs:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
           mkdir -p "$TRUSTED_CI_ROOT"
-          git archive "$BASE_SHA" scripts | tar -x -C "$TRUSTED_CI_ROOT"
+          git archive "$BASE_SHA" scripts config | tar -x -C "$TRUSTED_CI_ROOT"
       - name: Classify pull request scope
         id: contribution-scope
         if: github.event_name == 'pull_request'
@@ -134,11 +135,28 @@ jobs:
         run: >-
           python3 scripts/check_formalization_engine_revision.py
           --tree HEAD --base-tree HEAD^
+      - name: Select changed-work validation
+        id: change-scope
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_BASE: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+        run: |
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            SCOPE_TOOL="$TRUSTED_CI_ROOT/scripts/ci_change_scope.py"
+          else
+            SCOPE_TOOL="$GITHUB_WORKSPACE/scripts/ci_change_scope.py"
+          fi
+          echo "CI_SCOPE_TOOL=$SCOPE_TOOL" >> "$GITHUB_ENV"
+          echo "CI_BASE_SHA=$EVENT_BASE" >> "$GITHUB_ENV"
+          if [[ "$EVENT_NAME" == "workflow_dispatch" || -z "$EVENT_BASE" || "$EVENT_BASE" =~ ^0+$ || ! -f "$SCOPE_TOOL" ]]; then
+            echo "mode=integration" >> "$GITHUB_OUTPUT"
+            echo "build_lean=true" >> "$GITHUB_OUTPUT"
+          else
+            python3 "$SCOPE_TOOL" plan --repo "$GITHUB_WORKSPACE" \
+              --base "$EVENT_BASE" --head HEAD --github-output "$GITHUB_OUTPUT"
+          fi
       - name: Set up Lean dependencies
-        if: >-
-          github.event_name != 'pull_request' ||
-          (steps.contribution-scope.outputs.mode != 'docs' &&
-          steps.contribution-scope.outputs.mode != 'aggregate')
+        if: steps.change-scope.outputs.mode != 'docs'
         uses: leanprover/lean-action@38fbc41a8c28c4cbaec22d7f7de508ec2e7c0dd9 # v1
         with:
           # The private workspace expands beyond the hosted runner's free disk
@@ -150,6 +168,20 @@ jobs:
           lint: "false"
           use-github-cache: "false"
           use-mathlib-cache: "true"
+      - name: Restore project build cache
+        if: steps.change-scope.outputs.mode != 'docs'
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: .lake/build
+          key: ${{ runner.os }}-aml-project-v1-${{ hashFiles('lean-toolchain', 'lake-manifest.json') }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-aml-project-v1-${{ hashFiles('lean-toolchain', 'lake-manifest.json') }}-
+      - name: Remove obsolete cached module interfaces
+        if: steps.change-scope.outputs.mode != 'docs'
+        run: |
+          if [[ -f "$CI_SCOPE_TOOL" ]]; then
+            python3 "$CI_SCOPE_TOOL" prune-cache --repo "$GITHUB_WORKSPACE" --base HEAD --head HEAD
+          fi
       - name: Check isolated paper contribution
         if: >-
           github.event_name == 'pull_request' &&
@@ -162,52 +194,66 @@ jobs:
           --repo "$GITHUB_WORKSPACE"
           --base "$BASE_SHA"
           --allow-missing-source-bytes
-      - name: Build Lean targets
+      - name: Build changed papers and their dependents
         if: >-
-          github.event_name != 'pull_request' ||
-          steps.contribution-scope.outputs.mode == 'integration'
+          steps.change-scope.outputs.mode == 'papers' &&
+          (github.event_name != 'pull_request' || steps.contribution-scope.outputs.mode != 'paper')
+        run: >-
+          python3 "$CI_SCOPE_TOOL" build --repo "$GITHUB_WORKSPACE"
+          --base "$CI_BASE_SHA" --head HEAD
+      - name: Validate selected paper evidence
+        if: >-
+          steps.change-scope.outputs.mode == 'papers' &&
+          (github.event_name != 'pull_request' || steps.contribution-scope.outputs.mode != 'paper')
+        run: |
+          SOURCE_FLAG=()
+          if [[ "$PUBLIC_SOURCE_MODE" == "true" ]]; then SOURCE_FLAG+=(--public); fi
+          python3 "$CI_SCOPE_TOOL" check --repo "$GITHUB_WORKSPACE" \
+            --base "$CI_BASE_SHA" --head HEAD "${SOURCE_FLAG[@]}"
+      - name: Build Lean targets
+        if: steps.change-scope.outputs.mode == 'integration'
         # defaultTargets intentionally excludes some private/new paper targets.
         # Integration must still compile every registered lean_lib.
         run: python3 scripts/paper_target_registration.py build-all
       - name: Test semantic provenance audits
-        if: >-
-          github.event_name != 'pull_request' ||
-          steps.contribution-scope.outputs.mode == 'integration'
+        if: steps.change-scope.outputs.mode == 'integration'
         run: python3 scripts/run_isolated_audit_tests.py
       - name: Audit conclusion-bearing theorem inputs
-        if: >-
-          github.event_name != 'pull_request' ||
-          steps.contribution-scope.outputs.mode == 'integration'
+        if: steps.change-scope.outputs.mode == 'integration'
         run: python3 scripts/audit_conclusion_provenance.py
       - name: Check paper status aggregate
         if: >-
           github.event_name == 'workflow_dispatch' ||
           (github.event_name == 'pull_request' &&
-          steps.contribution-scope.outputs.mode == 'integration')
+          steps.change-scope.outputs.mode == 'integration')
         run: python3 scripts/sync_paper_status.py --check
       - name: Audit source-evidence integrity
-        if: >-
-          github.event_name != 'pull_request' ||
-          steps.contribution-scope.outputs.mode == 'integration'
-        run: python3 scripts/audit_evidence_integrity.py
+        if: steps.change-scope.outputs.mode == 'integration'
+        run: |
+          SOURCE_FLAG=()
+          if [[ "$PUBLIC_SOURCE_MODE" == "true" ]]; then SOURCE_FLAG+=(--allow-missing-source-bytes); fi
+          python3 scripts/audit_evidence_integrity.py "${SOURCE_FLAG[@]}"
       - name: Audit reusable library provenance
-        if: >-
-          github.event_name != 'pull_request' ||
-          steps.contribution-scope.outputs.mode == 'integration'
+        if: steps.change-scope.outputs.mode == 'integration'
         run: python3 scripts/audit_repository.py --library-only --library-premise-audit --info-limit 0
       - name: Audit statement translations
-        if: >-
-          github.event_name != 'pull_request' ||
-          steps.contribution-scope.outputs.mode == 'integration'
+        if: steps.change-scope.outputs.mode == 'integration'
         run: python3 scripts/review_dashboard.py --statement-check
       - name: Audit paper coverage
-        if: >-
-          github.event_name != 'pull_request' ||
-          steps.contribution-scope.outputs.mode == 'integration'
+        if: steps.change-scope.outputs.mode == 'integration'
         run: python3 scripts/review_dashboard.py --paper-coverage-check
       - name: Full repository closeout audit
         if: >-
           github.event_name == 'workflow_dispatch' ||
           (github.event_name == 'pull_request' &&
-          steps.contribution-scope.outputs.mode == 'integration')
-        run: python3 scripts/audit_repository.py --include-active --library-premise-audit --info-limit 0
+          steps.change-scope.outputs.mode == 'integration')
+        run: |
+          SOURCE_FLAG=()
+          if [[ "$PUBLIC_SOURCE_MODE" == "true" ]]; then SOURCE_FLAG+=(--allow-missing-source-bytes); fi
+          python3 scripts/audit_repository.py --include-active --library-premise-audit --info-limit 0 "${SOURCE_FLAG[@]}"
+      - name: Save trusted main project build cache
+        if: success() && github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.change-scope.outputs.mode != 'docs'
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: .lake/build
+          key: ${{ runner.os }}-aml-project-v1-${{ hashFiles('lean-toolchain', 'lake-manifest.json') }}-${{ github.sha }}

--- a/config/formalization_engine_revisions.json
+++ b/config/formalization_engine_revisions.json
@@ -212,7 +212,6 @@
       "previous_engine_tree_sha256": "cfa504fd80a4535e12b09f7ffdaba4fd8b7f4d9bf5c6f3189673c587cf80a2da",
       "previous_formalization_review_protocol_sha256": "e94b775a4b0bfdebe915ac7d0c13c414fad98036906876fb9239a7086c3cd805",
       "rationale": "Repair source-vocabulary direct-route provenance with separately authenticated broad-binding and one-route selectors, preserve historic non-feature raw reuse, report semantic rebind debt accurately, and remove duplicate closeout cache and failure-path work without changing review obligations.",
-      "relation_to_previous": "review_compatible",
       "raw_producer_compatibility": {
         "invariant": "same-nonproducer-source-record-fingerprint-v1",
         "predecessor_raw_producer_code_identity_sets": [
@@ -255,6 +254,7 @@
           }
         ]
       },
+      "relation_to_previous": "review_compatible",
       "sequence": 17,
       "verification": [
         "Focused source-record association, vocabulary-selection, target-disposition, semantic-rebind, planner-cache, and closeout-worker regressions pass.",
@@ -923,37 +923,46 @@
     {
       "engine_tree_sha256": "a9ced0288ffc640f0fe3a4c7fbc5c1e16fd8cede1e6ff02f6b166d633eae3ca7",
       "formalization_review_protocol_sha256": "ca5ffddd01335d26b9b44d361eeaea34261ea281d4fed0eb4f8d38d85a6c4e70",
-      "sequence": 75,
       "rationale": "Register the reviewed public source-free evidence readers and current audit tooling.",
+      "sequence": 75,
       "verification": [
         "302 focused regression tests passed for credential reading, review packets, status synchronization, and release packaging."
       ]
     },
     {
-      "sequence": 76,
       "engine_tree_sha256": "c1b1c310e0876fd442ed2be661c49f67a658082686886e9aafcf8af727d341a5",
       "formalization_review_protocol_sha256": "ca5ffddd01335d26b9b44d361eeaea34261ea281d4fed0eb4f8d38d85a6c4e70",
       "rationale": "Register an audited engine authority referenced by the selected public paper closeouts.",
+      "sequence": 76,
       "verification": [
         "Engine and review-protocol identities match the recorded authority for the selected accepted graphs."
       ]
     },
     {
-      "sequence": 77,
       "engine_tree_sha256": "76e19a5efb6c5fbd2e8042dcde5a4be43439617cb3d9d96e1723a587bf14f7a8",
       "formalization_review_protocol_sha256": "ca5ffddd01335d26b9b44d361eeaea34261ea281d4fed0eb4f8d38d85a6c4e70",
       "rationale": "Register an audited engine authority referenced by the selected public paper closeouts.",
+      "sequence": 77,
       "verification": [
         "Engine and review-protocol identities match the recorded authority for the selected accepted graphs."
       ]
     },
     {
-      "sequence": 78,
       "engine_tree_sha256": "63d91eacceb07fdc2eb705ff3ae41cdfaf4e0758a15ef08e8773caac96c819d3",
       "formalization_review_protocol_sha256": "ca5ffddd01335d26b9b44d361eeaea34261ea281d4fed0eb4f8d38d85a6c4e70",
       "rationale": "Register an audited engine authority referenced by the selected public paper closeouts.",
+      "sequence": 78,
       "verification": [
         "Engine and review-protocol identities match the recorded authority for the selected accepted graphs."
+      ]
+    },
+    {
+      "engine_tree_sha256": "78a96aedb4a58905b261ae3df87893f6586fc8eb4484304ac60f36f027e94019",
+      "formalization_review_protocol_sha256": "ca5ffddd01335d26b9b44d361eeaea34261ea281d4fed0eb4f8d38d85a6c4e70",
+      "rationale": "Repair trusted CI configuration loading and artifact-history classification; select changed papers and reverse import dependents while retaining source and evidence checks; recognize the renamed repository.",
+      "sequence": 79,
+      "verification": [
+        "77 contribution, changed-scope, and trusted-archive tests passed; 97 scope and public-release-guard tests passed; the original large release is no longer blocked by the artifact-history classifier."
       ]
     }
   ],

--- a/docs/NEW_CONTRIBUTOR_WORKFLOW.md
+++ b/docs/NEW_CONTRIBUTOR_WORKFLOW.md
@@ -23,9 +23,17 @@ It does not own or update:
 - any other paper folder or audit evidence
 
 The paper-scoped check and pull-request CI build and audit only `<PaperName>`.
-Existing paper state cannot make that lane fail. A change to shared library,
-tooling, audit protocol, workflow, or multiple papers instead uses the
-integration lane.
+A multi-paper update builds and audits the changed papers and their reverse
+import dependents. Documentation and website updates skip Lean compilation.
+Changes to shared library code, tooling, audit protocol, or build controls use
+the full integration lane; manual workflow runs also retain that backstop.
+
+Main pushes use the same committed-change selection, so merging a paper update
+does not automatically rebuild every unrelated paper. CI restores only the
+project's `.lake/build` cache, separately from Mathlib, removes obsolete module
+interfaces, and saves caches only after successful trusted main pushes.
+Source-export checks, engine registration, and paper evidence checks remain
+required. CI reads existing evidence; it does not issue fresh semantic reviews.
 
 ## 1. Create A Public-Based Working Branch
 
@@ -33,9 +41,9 @@ Fork the public repository on GitHub, then clone the fork and retain the project
 repository as `upstream`:
 
 ```bash
-git clone https://github.com/example-contributor/EconCSLib.git
-cd EconCSLib
-git remote add upstream https://github.com/nikhgarg/EconCSLib.git
+git clone https://github.com/example-contributor/AppliedModelingLib.git
+cd AppliedModelingLib
+git remote add upstream https://github.com/nikhgarg/AppliedModelingLib.git
 git fetch upstream
 git switch -c paper/abc24-short-title upstream/main
 ```

--- a/scripts/ci_change_scope.py
+++ b/scripts/ci_change_scope.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""Select exact-commit CI work without changing paper evidence or proof scope."""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path, PurePosixPath
+import subprocess
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+from scripts.lean_import_closure import (
+    _candidate_blob_ids, _batch_blob_texts, imported_modules,
+)
+from scripts.tomllib_compat import tomllib
+
+
+def git(repo, *args):
+    return subprocess.check_output(["git", "-C", str(repo), *args])
+
+
+def plan(repo: Path, base: str, head: str = "HEAD") -> dict:
+    base = git(repo, "rev-parse", "--verify", base + "^{commit}").decode().strip()
+    head = git(repo, "rev-parse", "--verify", head + "^{commit}").decode().strip()
+    paths = sorted(filter(None, git(repo, "diff", "--no-renames", "--name-only", "-z", base, head).decode().split("\0")))
+    result = {"mode": "integration", "base": base, "head": head, "papers": [], "targets": [], "changed_paths": paths}
+    if subprocess.run(["git", "-C", str(repo), "merge-base", "--is-ancestor", base, head]).returncode:
+        return result
+    libraries = tomllib.loads(git(repo, "show", head + ":lakefile.toml").decode()).get("lean_lib", [])
+    paper_targets = {p["name"] for p in libraries if p.get("srcDir") == "papers"}
+    all_targets = {p["name"] for p in libraries}
+
+    def owner(path):
+        parts = PurePosixPath(path).parts
+        if len(parts) >= 2 and parts[0] == "papers":
+            name = PurePosixPath(parts[1]).stem if len(parts) == 2 else parts[1]
+            return name if name in paper_targets else None
+        return None
+
+    def doc(path):
+        return (path in {"README.md", "CONTRIBUTING.md", "CITATION.cff", ".github/workflows/pages.yml"}
+                or path.startswith(("docs/", "site/", ".github/ISSUE_TEMPLATE/"))
+                or path == ".github/pull_request_template.md")
+
+    aggregates = {"papers/status.json", "papers/human_status.json", "docs/PAPER_STATUS.md", "site/index.html"}
+    # Documentation scopes cannot hide build controls or Lean sources in a
+    # documentation directory. Unknown paths and routing changes stay broad.
+    if any(path.endswith(".lean") and not owner(path) for path in paths):
+        return result
+    if all(doc(path) or path in aggregates for path in paths):
+        return {**result, "mode": "docs"}
+    if not all(owner(path) or path in aggregates for path in paths):
+        return result
+    if any(set(library) - {"name", "srcDir", "roots"} for library in libraries):
+        return result
+    routes = []
+    for library in libraries:
+        roots = library.get("roots", [library["name"]])
+        if not isinstance(roots, list) or not all(isinstance(root, str) for root in roots):
+            return result
+        routes.extend((root, library["name"], library.get("srcDir", ".")) for root in roots)
+
+    def import_owner(module):
+        matches = {target for root, target, _ in routes if module == root or module.startswith(root + ".")}
+        return next(iter(matches)) if len(matches) == 1 else None
+
+    def source_owner(path):
+        matches = set()
+        for root, target, source_dir in routes:
+            try:
+                relative = PurePosixPath(path).relative_to(source_dir)
+            except ValueError:
+                continue
+            module = str(relative.with_suffix("")).replace("/", ".")
+            if module == root or module.startswith(root + "."):
+                matches.add(target)
+        return next(iter(matches)) if len(matches) == 1 else None
+
+    papers = {owner(path) for path in paths if owner(path)}
+    tracked = set(filter(None, git(repo, "ls-tree", "-r", "--name-only", "-z", head).decode().split("\0")))
+    if any(f"papers/{paper}/status.json" not in tracked for paper in papers):
+        return result
+    changed_lean = {owner(path) for path in paths if path.endswith(".lean")}
+    targets = set(changed_lean)
+    if changed_lean:
+        # Union both committed dependency graphs: deletions and removed imports
+        # still invalidate former consumers. Collapsing modules to their Lake
+        # target is conservative and includes non-root modules within a paper.
+        views = [_candidate_blob_ids(repo, candidate="tree", treeish=ref) for ref in (base, head)]
+        blobs = {sha for view in views for path, sha in view.items()
+                 if source_owner(path) in all_targets}
+        texts = _batch_blob_texts(repo, blobs)
+        imports = {sha: {import_owner(name) for name in imported_modules(text)} for sha, text in texts.items()}
+        dependents = {}
+        for view in views:
+            for path, sha in view.items():
+                target = source_owner(path)
+                if target not in all_targets:
+                    continue
+                for dependency in imports[sha] & all_targets:
+                    if dependency != target:
+                        dependents.setdefault(dependency, set()).add(target)
+        pending = list(targets)
+        while pending:
+            for dependent in dependents.get(pending.pop(), set()) - targets:
+                targets.add(dependent)
+                pending.append(dependent)
+        if targets - paper_targets:
+            return result
+        papers |= targets
+    return {**result, "mode": "papers", "papers": sorted(papers), "targets": sorted(targets)}
+
+
+def run_checks(repo, selection, *, public=False):
+    if selection["mode"] != "papers":
+        raise ValueError("Scoped paper checks require a papers plan")
+    source_flag = ["--allow-missing-source-bytes"] if public else []
+    for paper in selection["papers"]:
+        commands = [
+            ["scripts/audit_conclusion_provenance.py", "--paper", paper],
+            ["scripts/audit_evidence_integrity.py", "--paper", paper, *source_flag],
+            ["scripts/review_dashboard.py", "--paper", paper, "--statement-check"],
+            ["scripts/review_dashboard.py", "--paper", paper, "--paper-coverage-check"],
+            ["scripts/audit_repository.py", "--paper", paper, "--include-active", "--library-premise-audit", "--info-limit", "0", *source_flag],
+        ]
+        for command in commands:
+            require_clean_head(repo, selection["head"])
+            print("Checking:", " ".join(command), flush=True)
+            subprocess.run([sys.executable, *command], cwd=repo, check=True)
+            require_clean_head(repo, selection["head"])
+
+
+def require_clean_head(repo, head):
+    if git(repo, "rev-parse", "HEAD").decode().strip() != head:
+        raise ValueError("CI head changed during validation")
+    subprocess.run(["git", "-C", str(repo), "diff", "--quiet", "HEAD", "--"], check=True)
+    untracked = git(repo, "ls-files", "--others", "--exclude-standard", "-z").decode().split("\0")
+    if any(path.endswith(".lean") for path in untracked):
+        raise ValueError("Untracked Lean sources cannot participate in CI validation")
+
+
+def prune_build_cache(repo: Path, head: str):
+    """Remove orphaned module interfaces after restoring an older build cache."""
+    root = repo / ".lake/build/lib/lean"
+    if not root.exists():
+        return
+    if not root.resolve().is_relative_to(repo.resolve()):
+        raise ValueError("Project build cache must stay inside the checkout")
+    paths = _candidate_blob_ids(repo, candidate="tree", treeish=head)
+    libraries = tomllib.loads(git(repo, "show", head + ":lakefile.toml").decode()).get("lean_lib", [])
+    modules = set()
+    for source_dir in {library.get("srcDir", ".") for library in libraries}:
+        for path in paths:
+            try:
+                relative = PurePosixPath(path).relative_to(source_dir)
+            except ValueError:
+                continue
+            modules.add(str(relative.with_suffix("")).replace("/", "."))
+    for path in root.rglob("*"):
+        relative = str(path.relative_to(root))
+        for suffix in (".olean", ".ilean", ".trace"):
+            if suffix in relative:
+                module = relative.split(suffix, 1)[0].replace("/", ".")
+                if module not in modules and (path.is_file() or path.is_symlink()):
+                    path.unlink()
+                break
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("action", choices=("plan", "build", "check", "prune-cache"))
+    parser.add_argument("--repo", type=Path, default=Path.cwd())
+    parser.add_argument("--base", required=True)
+    parser.add_argument("--head", default="HEAD")
+    parser.add_argument("--github-output", type=Path)
+    parser.add_argument("--public", action="store_true")
+    args = parser.parse_args()
+    selection = plan(args.repo, args.base, args.head)
+    if args.github_output:
+        with args.github_output.open("a") as out:
+            out.write("mode=" + selection["mode"] + "\n")
+            out.write("build_lean=" + str(selection["mode"] == "integration" or bool(selection["targets"])).lower() + "\n")
+    if args.action == "build":
+        if selection["mode"] != "papers":
+            raise ValueError("Scoped build requires a papers plan")
+        if selection["targets"]:
+            require_clean_head(args.repo, selection["head"])
+            subprocess.run(["lake", "build", *selection["targets"]], cwd=args.repo, check=True)
+            require_clean_head(args.repo, selection["head"])
+    elif args.action == "check":
+        run_checks(args.repo, selection, public=args.public)
+    elif args.action == "prune-cache":
+        prune_build_cache(args.repo, selection["head"])
+    print(json.dumps(selection, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/paper_contribution.py
+++ b/scripts/paper_contribution.py
@@ -260,7 +260,9 @@ def _changed_paths(merge_base: str, head: str) -> tuple[ChangedPath, ...]:
     return tuple(changes)
 
 
-def _commit_history_paths(merge_base: str, head: str) -> tuple[str, ...]:
+def _commit_history_paths(
+    merge_base: str, head: str, *, include_deletions: bool = True
+) -> tuple[str, ...]:
     """Return every path mentioned by a non-merge candidate commit."""
 
     merge_commits = _git_text(
@@ -278,6 +280,7 @@ def _commit_history_paths(merge_base: str, head: str) -> tuple[str, ...]:
             "--name-only",
             "-z",
             "--no-renames",
+            *([] if include_deletions else ["--diff-filter=ACMRT"]),
             f"{merge_base}..{head}",
         ],
         cwd=ROOT,
@@ -304,7 +307,7 @@ def _unsafe_public_artifact(path: str) -> bool:
         return False
     if parts[0] == ".scratch":
         return True
-    if len(parts) < 3 or parts[0] != "papers" or not PAPER_ID_RE.fullmatch(parts[1]):
+    if len(parts) < 3 or parts[0] != "papers":
         return False
     relative = parts[2:]
     if not relative:
@@ -313,7 +316,7 @@ def _unsafe_public_artifact(path: str) -> bool:
     source_candidate = PurePosixPath(name)
     source_directory = re.sub(r"[-_.]", "", relative[0].lower())
     return bool(
-        source_directory.startswith("source")
+        (len(relative) > 1 and source_directory.startswith("source"))
         or source_directory in {"auditsource", "papersource"}
         or name.startswith("source-audited")
         or name in {"source.pdf", "source.txt", "source.tex"}
@@ -324,7 +327,10 @@ def _unsafe_public_artifact(path: str) -> bool:
         or name.endswith((".doc", ".docx", ".rtf", ".epub"))
         or (
             name.endswith(".pdf")
-            and tuple(relative) != ("docs", "DependencyDAG.pdf")
+            and tuple(relative) not in {
+                ("docs", "DependencyDAG.pdf"),
+                ("docs", "HUMAN_REVIEW_PACKET.pdf"),
+            }
         )
         or name.endswith(
             (
@@ -763,10 +769,14 @@ def contribution_plan(base_ref: str, head_ref: str = "HEAD") -> ContributionPlan
         )
     try:
         history_paths = _commit_history_paths(merge_base, head)
+        introduced_paths = _commit_history_paths(merge_base, head, include_deletions=False)
     except ContributionError as exc:
         history_paths = ()
+        introduced_paths = ()
         reasons.append(str(exc))
-    for path in history_paths:
+    # A deletion removes content already reachable from the public base. Added
+    # and later deleted source bytes still occur in introduced_paths and block.
+    for path in introduced_paths:
         if _unsafe_public_artifact(path):
             blocked = True
             reasons.append(

--- a/scripts/public_release_candidate_guard.py
+++ b/scripts/public_release_candidate_guard.py
@@ -116,7 +116,7 @@ REVIEWER_APPROVAL_PATH = (
 )
 PUBLIC_REMOTE_RE = re.compile(
     r"^(?:https://github\.com/|ssh://git@github\.com/|git@github\.com:)"
-    r"nikhgarg/EconCSLib(?:\.git)?$",
+    r"nikhgarg/(?:AppliedModelingLib|EconCSLib)(?:\.git)?$",
     re.IGNORECASE,
 )
 PRIVATE_REMOTE_RE = re.compile(

--- a/scripts/tests/test_ci_change_scope.py
+++ b/scripts/tests/test_ci_change_scope.py
@@ -1,0 +1,113 @@
+"""CI selection includes changed papers and former or transitive consumers."""
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+from scripts.ci_change_scope import plan, prune_build_cache, require_clean_head
+
+
+class ScopeTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        self.git("init", "-q")
+        self.git("config", "user.name", "Fixture")
+        self.git("config", "user.email", "fixture@example.org")
+        self.write("lakefile.toml", 'name="Fixture"\n' + '\n'.join(
+            f'[[lean_lib]]\nname="{name}"\n' + ('srcDir="papers"\n' if name != 'AppliedModelingLib' else '')
+            for name in ('AppliedModelingLib', 'AAA24Paper', 'BBB24Paper', 'CCC24Paper', 'DDD24Paper')))
+        self.write('AppliedModelingLib.lean', '-- Library\n')
+        for paper in ('AAA24Paper', 'BBB24Paper', 'CCC24Paper', 'DDD24Paper'):
+            self.write(f'papers/{paper}/status.json', '{}\n')
+            self.write(f'papers/{paper}.lean', f'import {paper}.Main\n')
+            self.write(f'papers/{paper}/Main.lean', '-- Proofs\n')
+        self.write('papers/BBB24Paper/Main.lean', 'import AAA24Paper.Main\n')
+        self.write('papers/CCC24Paper/Main.lean', 'import BBB24Paper.Main\n')
+        self.commit()
+        self.git('tag', 'base')
+
+    def git(self, *args):
+        return subprocess.check_output(['git', '-C', str(self.root), *args], stderr=subprocess.DEVNULL)
+
+    def write(self, name, text):
+        path = self.root / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text)
+
+    def commit(self):
+        self.git('add', '--all')
+        self.git('commit', '-qm', 'fixture')
+
+    def test_restored_cache_keeps_live_modules_and_removes_deleted_interfaces(self):
+        self.write('.lake/build/lib/lean/AAA24Paper/Main.olean', 'live compiled module')
+        self.write('.lake/build/lib/lean/Removed/Main.olean', 'obsolete compiled module')
+        self.write('.lake/build/lib/lean/Removed/Main.olean.private', 'obsolete private data')
+        prune_build_cache(self.root, 'HEAD')
+        self.assertTrue((self.root / '.lake/build/lib/lean/AAA24Paper/Main.olean').exists())
+        self.assertFalse((self.root / '.lake/build/lib/lean/Removed/Main.olean').exists())
+        self.assertFalse((self.root / '.lake/build/lib/lean/Removed/Main.olean.private').exists())
+
+    def test_build_refuses_uncommitted_lean_inputs(self):
+        head = self.git('rev-parse', 'HEAD').decode().strip()
+        self.write('papers/AAA24Paper/Untracked.lean', '-- Hidden input')
+        with self.assertRaisesRegex(ValueError, 'Untracked Lean'):
+            require_clean_head(self.root, head)
+
+    def test_website_only_skips_lean(self):
+        self.write('site/index.html', '<h1>Project</h1>')
+        self.commit()
+        self.assertEqual(plan(self.root, 'base')['mode'], 'docs')
+
+    def test_aggregate_projection_also_skips_lean(self):
+        self.write('papers/status.json', '{}\n')
+        self.commit()
+        self.assertEqual(plan(self.root, 'base')['mode'], 'docs')
+
+    def test_multiple_papers_and_transitive_dependents(self):
+        self.write('papers/AAA24Paper/Main.lean', '-- Updated theorem\n')
+        self.write('papers/DDD24Paper/Main.lean', '-- Another theorem\n')
+        self.commit()
+        result = plan(self.root, 'base')
+        self.assertEqual(result['mode'], 'papers')
+        self.assertEqual(result['targets'], ['AAA24Paper', 'BBB24Paper', 'CCC24Paper', 'DDD24Paper'])
+
+    def test_deleted_module_and_former_dependency_are_checked(self):
+        (self.root / 'papers/AAA24Paper/Main.lean').unlink()
+        self.write('papers/BBB24Paper/Main.lean', '-- Former dependency removed\n')
+        self.commit()
+        self.assertEqual(plan(self.root, 'base')['targets'], ['AAA24Paper', 'BBB24Paper', 'CCC24Paper'])
+
+    def test_report_only_checks_its_paper_without_compilation(self):
+        self.write('papers/AAA24Paper/FINAL_VALIDATION_REPORT.md', '# Report\n')
+        self.commit()
+        result = plan(self.root, 'base')
+        self.assertEqual(result['papers'], ['AAA24Paper'])
+        self.assertEqual(result['targets'], [])
+
+    def test_shared_build_and_tooling_changes_stay_broad(self):
+        for path in ('AppliedModelingLib.lean', 'lean-toolchain', 'scripts/audit.py', 'docs/Unexpected.lean'):
+            with self.subTest(path=path):
+                self.write(path, '-- Changed\n')
+                self.commit()
+                self.assertEqual(plan(self.root, 'base')['mode'], 'integration')
+
+    def test_custom_registered_consumer_forces_broader_validation(self):
+        with (self.root / 'lakefile.toml').open('a') as stream:
+            stream.write('\n[[lean_lib]]\nname="FixtureAudit"\nsrcDir="scripts"\nroots=["fixture_helper"]\n')
+        self.write('scripts/fixture_helper.lean', 'import AAA24Paper.Main\n')
+        self.commit()
+        self.git('tag', '-f', 'base')
+        self.write('papers/AAA24Paper/Main.lean', '-- Changed premise\n')
+        self.commit()
+        self.assertEqual(plan(self.root, 'base')['mode'], 'integration')
+
+    def test_worktree_edits_cannot_change_committed_selection(self):
+        self.write('site/index.html', '<h1>Project</h1>')
+        self.commit()
+        self.write('AppliedModelingLib.lean', '-- Uncommitted source edit\n')
+        self.assertEqual(plan(self.root, 'base')['mode'], 'docs')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/scripts/tests/test_paper_contribution.py
+++ b/scripts/tests/test_paper_contribution.py
@@ -170,6 +170,24 @@ class PaperContributionScopeTests(unittest.TestCase):
             )
         )
 
+    def test_review_packets_and_source_model_lean_are_project_artifacts(self) -> None:
+        for paper in (PAPER, "LongAuthorEtAl2017Example"):
+            for relative in ("SourceModel.lean", "docs/HUMAN_REVIEW_PACKET.pdf"):
+                self.assertFalse(contribution._unsafe_public_artifact(f"papers/{paper}/{relative}"))
+            self.assertTrue(contribution._unsafe_public_artifact(f"papers/{paper}/source/main.tex"))
+
+    def test_removing_source_already_in_base_does_not_export_new_content(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            fixture = GitFixture(Path(temp_dir))
+            source = fixture.root / "papers" / EXISTING / "source.pdf"
+            source.write_bytes(b"previously published source")
+            fixture.commit("old public source")
+            fixture.git("tag", "-f", "base")
+            source.unlink()
+            fixture.commit("remove source from current public tree")
+            plan = self.plan(fixture)
+        self.assertFalse(plan.blocked)
+
     def test_exact_new_paper_and_registration_select_only_that_paper(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             fixture = GitFixture(Path(temp_dir))

--- a/scripts/tests/test_private_ci_workflow.py
+++ b/scripts/tests/test_private_ci_workflow.py
@@ -25,7 +25,7 @@ class PrivateCIWorkflowTests(unittest.TestCase):
 
     def test_lean_setup_is_bounded_and_skipped_for_docs_only_prs(self) -> None:
         body = self.step("Set up Lean dependencies")
-        self.assertRegex(body, r"steps\.contribution-scope\.outputs\.mode != 'docs'")
+        self.assertRegex(body, r"steps\.change-scope\.outputs\.mode != 'docs'")
         self.assertRegex(body, r"uses: leanprover/lean-action@[0-9a-f]{40}")
         for field in ("auto-config", "build", "test", "lint", "use-github-cache"):
             self.assertRegex(body, rf'{field}:\s*["\']?false["\']?')
@@ -44,7 +44,7 @@ class PrivateCIWorkflowTests(unittest.TestCase):
         self.assertNotIn("${{ runner.temp }}", self.text)
 
         trusted = self.step("Materialize trusted CI implementation")
-        self.assertIn('git archive "$BASE_SHA" scripts', trusted)
+        self.assertIn('git archive "$BASE_SHA" scripts config', trusted)
         self.assertIn('tar -x -C "$TRUSTED_CI_ROOT"', trusted)
         self.assertIn('BASE_SHA: ${{ github.event.pull_request.base.sha }}', trusted)
         self.assertLess(
@@ -115,7 +115,7 @@ class PrivateCIWorkflowTests(unittest.TestCase):
         ):
             self.assertNotIn(forbidden, body)
 
-    def test_every_broad_step_is_integration_only_on_pull_requests(self) -> None:
+    def test_every_broad_step_requires_integration_even_on_main_pushes(self) -> None:
         broad_steps = (
             "Build Lean targets",
             "Test semantic provenance audits",
@@ -128,12 +128,12 @@ class PrivateCIWorkflowTests(unittest.TestCase):
         for name in broad_steps:
             with self.subTest(name=name):
                 body = self.step(name)
-                self.assertIn("github.event_name != 'pull_request'", body)
-                self.assertIn("outputs.mode == 'integration'", body)
+                self.assertNotIn("github.event_name != 'pull_request'", body)
+                self.assertIn("steps.change-scope.outputs.mode == 'integration'", body)
 
     def test_aggregate_only_pr_skips_lean_and_runs_only_projection_check(self) -> None:
         setup = self.step("Set up Lean dependencies")
-        self.assertIn("outputs.mode != 'aggregate'", setup)
+        self.assertIn("steps.change-scope.outputs.mode != 'docs'", setup)
 
         aggregate = self.step("Check aggregate-only contribution")
         self.assertIn("outputs.mode == 'aggregate'", aggregate)
@@ -172,6 +172,36 @@ class PrivateCIWorkflowTests(unittest.TestCase):
         self.assertIn("outputs.mode == 'integration'", body)
         self.assertNotIn("outputs.mode == 'aggregate'", body)
         self.assertNotIn("github.event_name != 'pull_request'", body)
+
+    def test_change_selection_uses_trusted_base_for_prs_and_exact_push_base(self) -> None:
+        body = self.step("Select changed-work validation")
+        self.assertIn('$TRUSTED_CI_ROOT/scripts/ci_change_scope.py', body)
+        self.assertIn('github.event.before', body)
+        self.assertIn('--base "$EVENT_BASE" --head HEAD', body)
+        self.assertIn('echo "mode=integration"', body)
+        self.assertNotIn('echo "mode=papers"', body)
+
+    def test_batch_paper_validation_keeps_build_and_evidence_checks(self) -> None:
+        build = self.step("Build changed papers and their dependents")
+        checks = self.step("Validate selected paper evidence")
+        for body in (build, checks):
+            self.assertIn("steps.change-scope.outputs.mode == 'papers'", body)
+            self.assertIn('"$CI_SCOPE_TOOL"', body)
+            self.assertIn('--base "$CI_BASE_SHA" --head HEAD', body)
+        self.assertIn(' build ', build)
+        self.assertIn(' check ', checks)
+
+    def test_only_successful_trusted_main_runs_save_project_cache(self) -> None:
+        restore = self.step("Restore project build cache")
+        save = self.step("Save trusted main project build cache")
+        prune = self.step("Remove obsolete cached module interfaces")
+        self.assertIn('path: .lake/build', restore)
+        self.assertIn('path: .lake/build', save)
+        self.assertIn("success() && github.event_name == 'push'", save)
+        self.assertIn("github.ref == 'refs/heads/main'", save)
+        self.assertIn('prune-cache', prune)
+        self.assertLess(self.text.index('- name: Remove obsolete cached module interfaces'),
+                        self.text.index('- name: Build changed papers and their dependents'))
 
     def test_integration_build_enumerates_registered_not_only_default_targets(self) -> None:
         body = self.step("Build Lean targets")

--- a/scripts/tests/test_public_release_candidate_guard.py
+++ b/scripts/tests/test_public_release_candidate_guard.py
@@ -2208,6 +2208,10 @@ class PublicReleaseCandidateGuardTests(unittest.TestCase):
             )
         )
 
+    def test_renamed_public_repository_is_still_canonical(self) -> None:
+        self.assertIsNotNone(guard.PUBLIC_REMOTE_RE.fullmatch("https://github.com/nikhgarg/AppliedModelingLib.git"))
+        self.assertIsNone(guard.PUBLIC_REMOTE_RE.fullmatch("https://github.com/attacker/AppliedModelingLib.git"))
+
     def test_canonical_remote_checks_fetch_and_every_push_url(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             repo = Path(temp_dir) / "candidate"

--- a/scripts/tests/test_trusted_ci_archive.py
+++ b/scripts/tests/test_trusted_ci_archive.py
@@ -1,0 +1,24 @@
+"""The exact trusted archive must load without borrowing candidate config."""
+from pathlib import Path
+import os
+import subprocess
+import tempfile
+import unittest
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+class TrustedArchiveTests(unittest.TestCase):
+    def test_workflow_archive_can_start_scope_classifier(self):
+        workflow = (ROOT / '.github/workflows/lean_action_ci.yml').read_text()
+        command = next(line.strip() for line in workflow.splitlines() if line.strip().startswith('git archive "$BASE_SHA"'))
+        with tempfile.TemporaryDirectory() as temp:
+            environment = {**os.environ, 'BASE_SHA': 'HEAD', 'TRUSTED_CI_ROOT': temp}
+            subprocess.run(['bash', '-o', 'pipefail', '-c', command], cwd=ROOT, env=environment, check=True)
+            result = subprocess.run(['python3', str(Path(temp) / 'scripts/paper_contribution.py'), 'scope', '--help'], cwd=temp, text=True, capture_output=True)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn('--base', result.stdout)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Routine documentation pushes currently trigger the full Lean build, and trusted PR startup omits configuration required by its scripts. This change fixes startup and selects validation from the exact base/head diff: documentation skips Lean; paper changes check the changed papers and reverse import dependents; shared code, toolchain, and audit tooling retain integration checks.

Project build artifacts are cached separately from Mathlib. The source-history classifier accepts review-packet PDFs and source-removal changes while still rejecting introduced source artifacts, including add-then-delete history. Both old and renamed repository URLs are recognized.

Validation: 92 targeted CI tests pass; 97 scope/release-guard tests pass; the canonical candidate guard passes. No paper proof, statement, or semantic-review evidence was changed.
