### PR TITLE
Fix public evidence recovery after shared Lean changes

### DIFF
--- a/config/formalization_engine_revisions.json
+++ b/config/formalization_engine_revisions.json
@@ -973,6 +973,15 @@
       "verification": [
         "131 closure, receipt, and terminal Lean semantic revalidation tests passed; PRPKG public evidence validates without issuing acceptance."
       ]
+    },
+    {
+      "engine_tree_sha256": "d83dbc65ae1f7362441404b87b610a1116b85f614503d03f032794052eb57c30",
+      "formalization_review_protocol_sha256": "ca5ffddd01335d26b9b44d361eeaea34261ea281d4fed0eb4f8d38d85a6c4e70",
+      "rationale": "Public Lean recovery checks recorded source clauses without replaying withheld approval material.",
+      "sequence": 81,
+      "verification": [
+        "132 closure and terminal Lean identity tests pass; strict private checks are unchanged."
+      ]
     }
   ],
   "schema": 2

--- a/docs/RELEASE_LOG.md
+++ b/docs/RELEASE_LOG.md
@@ -13,7 +13,7 @@ the precise result-by-result statements and qualifications.
 - **Documentation — PRPKG24:** updated the validation report, clarification
   memo, and review packet to distinguish shared regularity conventions from
   result-specific corrections.
-  [Read the report](https://gargnikhil.com/AppliedModelingLib/artifacts/papers/PRPKG24AccuracyDiversity/FINAL_VALIDATION_REPORT.html).
+  [Read the report](https://gargnikhil.com/AppliedModelingLib/artifacts/papers/PRPKG24AccuracyDiversity/FINAL_VALIDATION_REPORT.html) · [Release PR](https://github.com/nikhgarg/AppliedModelingLib/pull/45).
 - **Website:** AI and applications appears immediately after Foundations in
   the library table. Deployment checks verify the published documents, their
   links, and the old project URLs.

--- a/scripts/obligation_closure_credential.py
+++ b/scripts/obligation_closure_credential.py
@@ -2139,7 +2139,8 @@ def validate_public_recorded_graph_inputs(
             )
             guard, _semantic_paths = revalidate_terminal_lean_semantics(
                 root, paper, current, preflight=_preflight,
-                accepted_import_closure=closure,
+                accepted_import_closure=dict(closure),
+                allow_withheld_source_material=True,
                 authenticated_prerequisite_source_items_by_declaration=prerequisite_sources,
             )
         if not guard.finalize_unchanged():

--- a/scripts/terminal_lean_semantic_revalidation.py
+++ b/scripts/terminal_lean_semantic_revalidation.py
@@ -158,6 +158,7 @@ def _validate_current_source_routes(
     preflight: ObligationStructuralPreflight,
     *,
     paper_dir: Path,
+    allow_withheld_source_material: bool = False,
     authenticated_prerequisite_source_items_by_declaration: (
         Mapping[str, str] | None
     ) = None,
@@ -186,17 +187,44 @@ def _validate_current_source_routes(
     assert isinstance(prerequisites, Mapping)
     assert isinstance(leaves, Mapping)
     try:
+        projected_source_map = source_map
+        withheld_roles = set()
+        if allow_withheld_source_material:
+            if "source_text_file" in source_map:
+                raise ValueError("public source recovery requires a withheld source locator")
+            items = source_map.get("items", {})
+            withheld_roles = {
+                key for key, item in items.items()
+                if isinstance(item, Mapping) and item.get("corrected_target") is not None
+            }
+            if withheld_roles:
+                if source_map.get("publication_corrected_target_projection") != {
+                    "schema": 1, "approval_material_included": False
+                }:
+                    raise ValueError("public corrected targets lack their withholding declaration")
+                # Approval provenance participates in the private role digest.
+                # Public transport checks the retained clauses and current Lean
+                # meanings; it cannot attest to withheld approval provenance.
+                projected_source_map = dict(source_map, items={
+                    key: {k: v for k, v in item.items() if k != "corrected_target"}
+                    for key, item in items.items()
+                })
         current_leaves, navigation = (
             project_source_route_leaf_material_from_validated_inputs(
-                source_map=source_map,
+                source_map=projected_source_map,
                 preflight=preflight,
             )
         )
-        source_material = current_source_semantic_material(
-            paper_dir=paper_dir,
-            source_map=source_map,
-            source_route_navigation=navigation,
-        )
+        if allow_withheld_source_material:
+            if "source_text_file" in source_map:
+                raise ValueError("public source recovery requires a withheld source locator")
+            source_material = None
+        else:
+            source_material = current_source_semantic_material(
+                paper_dir=paper_dir,
+                source_map=source_map,
+                source_route_navigation=navigation,
+            )
     except (
         ObligationEvidenceError,
         ObligationEvidenceProjectionError,
@@ -236,6 +264,23 @@ def _validate_current_source_routes(
             "source_atoms": semantic_atoms(atom_ids, leaves),
         }
         accepted_bundles[str(source_item_id)] = set()
+
+    if allow_withheld_source_material:
+        # Public exports cannot replay private verbatim/approval bundles. Keep
+        # their exact route names and semantic source atoms fixed instead;
+        # subsequent Lean checks still validate every target and dependency.
+        # This route reads recorded evidence and cannot issue acceptance.
+        if set(navigation) != set(accepted_entries) or any(
+            tuple(a[:2] if source_item_id in withheld_roles else a
+                  for a in semantic_atoms(tuple(atom_ids), current_leaves))
+            != tuple(a[:2] if source_item_id in withheld_roles else a
+                     for a in accepted_entries[source_item_id]["source_atoms"])
+            for source_item_id, atom_ids in navigation.items()
+        ):
+            raise TerminalLeanSemanticRevalidationError(
+                "public source routes or semantic atoms changed"
+            )
+        return {source_item_id: source_item_id for source_item_id in navigation}
 
     def judgment_bundle(digest: str, atom_ids: tuple[str, ...]) -> str:
         leaf = leaves.get(digest)
@@ -930,6 +975,7 @@ def revalidate_terminal_lean_semantics(
     preflight: ObligationStructuralPreflight,
     accepted_import_closure: Mapping[str, Any],
     current_import_closure: Mapping[str, Any] | None = None,
+    allow_withheld_source_material: bool = False,
     authenticated_prerequisite_source_items_by_declaration: (
         Mapping[str, str] | None
     ) = None,
@@ -968,6 +1014,7 @@ def revalidate_terminal_lean_semantics(
         source_map,
         preflight,
         paper_dir=paper_dir,
+        allow_withheld_source_material=allow_withheld_source_material,
         authenticated_prerequisite_source_items_by_declaration=(
             authenticated_prerequisite_source_items_by_declaration
         ),

--- a/scripts/tests/test_terminal_lean_semantic_revalidation.py
+++ b/scripts/tests/test_terminal_lean_semantic_revalidation.py
@@ -21,6 +21,39 @@ from scripts.obligation_evidence_graph import (
 
 
 class TerminalLeanSemanticRevalidationTests(unittest.TestCase):
+    def test_public_source_recovery_requires_exact_routes_and_atoms(self) -> None:
+        def atom(quote):
+            return source_atom_leaf(
+                contract_sha256="1" * 64, source_artifact_sha256="2" * 64,
+                source_quote_sha256=quote * 64, source_component_sha256="4" * 64,
+                source_role_contract_sha256="5" * 64,
+            )
+        original, changed = atom("3"), atom("6")
+        loaded = SimpleNamespace(
+            paper_index=SimpleNamespace(
+                route_leaf_sha256s_by_source_item={
+                    "claim": {"source_atom": (original.leaf_sha256,)}},
+                prerequisite_leaf_sha256s_by_declaration={}),
+            graph=SimpleNamespace(leaves={original.leaf_sha256: original}))
+        with mock.patch.object(terminal, "current_source_semantic_material",
+                               side_effect=ValueError("private material withheld")), \
+             mock.patch.object(terminal, "project_source_route_leaf_material_from_validated_inputs") as project:
+            project.return_value = ({original.leaf_sha256: original}, {"claim": (original.leaf_sha256,)})
+            call = lambda source, public: terminal._validate_current_source_routes(
+                loaded, source, SimpleNamespace(), paper_dir=Path("/fixture"),
+                allow_withheld_source_material=public)
+            self.assertEqual(call({}, True), {"claim": "claim"})
+            with self.assertRaisesRegex(terminal.TerminalLeanSemanticRevalidationError, "private material withheld"):
+                call({}, False)
+            with self.assertRaisesRegex(terminal.TerminalLeanSemanticRevalidationError, "withheld source locator"):
+                call({"source_text_file": "source.tex"}, True)
+            project.return_value = ({changed.leaf_sha256: changed}, {"claim": (changed.leaf_sha256,)})
+            with self.assertRaisesRegex(terminal.TerminalLeanSemanticRevalidationError, "semantic atoms changed"):
+                call({}, True)
+            project.return_value = ({original.leaf_sha256: original}, {"renamed": (original.leaf_sha256,)})
+            with self.assertRaisesRegex(terminal.TerminalLeanSemanticRevalidationError, "source routes"):
+                call({}, True)
+
     def test_module_discovery_failure_preserves_bounded_causal_diagnostic(self) -> None:
         root = Path("/tmp/diagnostic-fixture")
         provider = terminal.RepositoryBuildInputSnapshotProvider(root)


### PR DESCRIPTION
Public evidence validation can reach a shared Lean file whose bytes have changed since a paper's recorded audit. The compiler identity recovery path now works with intentionally withheld approval bundles and the immutable stored closure object. It checks the retained source clauses and current Lean meanings without claiming a new private-source review or issuing paper acceptance.

Private source-present validation keeps its full verbatim-bundle checks. The release log also links the PRPKG update to PR #45.

Validation: 132 regression tests passed; the live GJ18 public recovery check passed with only its existing human-review warning; canonical release candidate guard passed. The broader public evidence pass and full CI are still running. No paper statement or proof is changed by this PR.
