### PR TITLE
Preserve unchecked changes in incremental CI

### DIFF
--- a/.github/workflows/lean_action_ci.yml
+++ b/.github/workflows/lean_action_ci.yml
@@ -9,10 +9,11 @@ on:
 
 permissions:
   contents: read
+  actions: read
 
 concurrency:
   group: lean-action-ci-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build:
@@ -140,11 +141,23 @@ jobs:
         env:
           EVENT_NAME: ${{ github.event_name }}
           EVENT_BASE: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           if [[ "$EVENT_NAME" == "pull_request" ]]; then
             SCOPE_TOOL="$TRUSTED_CI_ROOT/scripts/ci_change_scope.py"
           else
             SCOPE_TOOL="$GITHUB_WORKSPACE/scripts/ci_change_scope.py"
+          fi
+          if [[ "$EVENT_NAME" == "push" ]]; then
+            # Include earlier failed, canceled, or superseded pending changes.
+            # An unavailable baseline safely selects the full integration lane.
+            EVENT_BASE=""
+            RUNS_FILE="$RUNNER_TEMP/successful-main-runs.json"
+            if gh api "repos/$GITHUB_REPOSITORY/actions/workflows/lean_action_ci.yml/runs?branch=main&event=push&status=success&per_page=100" > "$RUNS_FILE"; then
+              EVENT_BASE=$(python3 "$SCOPE_TOOL" successful-main-base \
+                --repo "$GITHUB_WORKSPACE" --head HEAD --runs-json "$RUNS_FILE" \
+                --repository "$GITHUB_REPOSITORY")
+            fi
           fi
           echo "CI_SCOPE_TOOL=$SCOPE_TOOL" >> "$GITHUB_ENV"
           echo "CI_BASE_SHA=$EVENT_BASE" >> "$GITHUB_ENV"

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ human-facing reporting, a review dashboard, and auditing procedures to support
 this workflow.
 
 Links:
-- [Project website](https://gargnikhil.com/EconCSLib/)
+- [Project website](https://gargnikhil.com/AppliedModelingLib/)
 - [Paper describing project](https://arxiv.org/abs/2606.13306)
 - [Slack workspace for applied math modeling in Lean](https://join.slack.com/t/appliedmodelinglib/shared_invite/zt-42slirzxx-rEO8eEns7~4~i3Lbu7N~lA)
 

--- a/config/formalization_engine_revisions.json
+++ b/config/formalization_engine_revisions.json
@@ -982,6 +982,15 @@
       "verification": [
         "132 closure and terminal Lean identity tests pass; strict private checks are unchanged."
       ]
+    },
+    {
+      "engine_tree_sha256": "5e3a2644f318dd813e112b7535e2e58587f7e5f60beac32e530281d9f4916660",
+      "formalization_review_protocol_sha256": "ca5ffddd01335d26b9b44d361eeaea34261ea281d4fed0eb4f8d38d85a6c4e70",
+      "rationale": "Carry unvalidated main changes into subsequent CI runs and preserve running main builds.",
+      "sequence": 82,
+      "verification": [
+        "27 focused CI scope and workflow tests pass, including canceled proof changes followed by documentation."
+      ]
     }
   ],
   "schema": 2

--- a/scripts/ci_change_scope.py
+++ b/scripts/ci_change_scope.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 from pathlib import Path, PurePosixPath
 import subprocess
 import sys
@@ -19,6 +20,26 @@ from scripts.tomllib_compat import tomllib
 
 def git(repo, *args):
     return subprocess.check_output(["git", "-C", str(repo), *args])
+
+
+def successful_main_base(repo: Path, head: str, runs: dict, repository: str) -> str:
+    """Select an already successful ancestor, never an unverified push parent."""
+    head = git(repo, "rev-parse", "--verify", head + "^{commit}").decode().strip()
+    best = ""
+    for run in runs.get("workflow_runs", []):
+        sha = run.get("head_sha", "")
+        if (run.get("status") != "completed" or run.get("conclusion") != "success"
+                or run.get("event") != "push" or run.get("head_branch") != "main"
+                or run.get("path", "").split("@")[0] != ".github/workflows/lean_action_ci.yml"
+                or (run.get("head_repository") or {}).get("full_name") != repository
+                or not isinstance(sha, str) or not re.fullmatch(r"[0-9a-f]{40}", sha)):
+            continue
+        def ancestor(a, b):
+            return subprocess.run(["git", "-C", str(repo), "merge-base", "--is-ancestor", a, b],
+                                  stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL).returncode == 0
+        if ancestor(sha, head) and (not best or ancestor(best, sha)):
+            best = sha
+    return best
 
 
 def plan(repo: Path, base: str, head: str = "HEAD") -> dict:
@@ -170,13 +191,23 @@ def prune_build_cache(repo: Path, head: str):
 
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("action", choices=("plan", "build", "check", "prune-cache"))
+    parser.add_argument("action", choices=("plan", "build", "check", "prune-cache", "successful-main-base"))
     parser.add_argument("--repo", type=Path, default=Path.cwd())
-    parser.add_argument("--base", required=True)
+    parser.add_argument("--base")
     parser.add_argument("--head", default="HEAD")
     parser.add_argument("--github-output", type=Path)
     parser.add_argument("--public", action="store_true")
+    parser.add_argument("--runs-json", type=Path)
+    parser.add_argument("--repository")
     args = parser.parse_args()
+    if args.action == "successful-main-base":
+        if not args.runs_json or not args.repository:
+            parser.error("successful-main-base requires --runs-json and --repository")
+        print(successful_main_base(args.repo, args.head,
+                                   json.loads(args.runs_json.read_text()), args.repository))
+        return
+    if not args.base:
+        parser.error("this action requires --base")
     selection = plan(args.repo, args.base, args.head)
     if args.github_output:
         with args.github_output.open("a") as out:

--- a/scripts/tests/test_ci_change_scope.py
+++ b/scripts/tests/test_ci_change_scope.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import subprocess
 import tempfile
 import unittest
-from scripts.ci_change_scope import plan, prune_build_cache, require_clean_head
+from scripts.ci_change_scope import plan, prune_build_cache, require_clean_head, successful_main_base
 
 
 class ScopeTests(unittest.TestCase):
@@ -38,6 +38,51 @@ class ScopeTests(unittest.TestCase):
     def commit(self):
         self.git('add', '--all')
         self.git('commit', '-qm', 'fixture')
+
+    def successful_run(self, sha):
+        return dict(status='completed', conclusion='success', event='push',
+                    head_branch='main', head_sha=sha,
+                    path='.github/workflows/lean_action_ci.yml',
+                    head_repository={'full_name': 'Owner/Repo'})
+
+    def test_docs_followup_still_checks_prior_unvalidated_proof_change(self):
+        base = self.git('rev-parse', 'base').decode().strip()
+        self.write('papers/AAA24Paper/Main.lean', '-- Changed proof\n')
+        self.commit()
+        unfinished = self.git('rev-parse', 'HEAD').decode().strip()
+        self.write('docs/readme.md', '# Documentation follow-up\n')
+        self.commit()
+        failed = self.successful_run(unfinished)
+        failed['conclusion'] = 'cancelled'
+        selected = successful_main_base(self.root, 'HEAD',
+            {'workflow_runs': [failed, self.successful_run(base)]}, 'Owner/Repo')
+        self.assertEqual(selected, base)
+        # A mixed proof/documentation diff conservatively takes the full lane.
+        self.assertEqual(plan(self.root, selected)['mode'], 'integration')
+        self.assertEqual(plan(self.root, unfinished)['mode'], 'docs')
+
+    def test_successful_baseline_is_the_newest_validated_ancestor(self):
+        old = self.git('rev-parse', 'HEAD').decode().strip()
+        self.write('docs/a.md', 'First documentation change\n')
+        self.commit()
+        newer = self.git('rev-parse', 'HEAD').decode().strip()
+        self.write('docs/b.md', 'Second documentation change\n')
+        self.commit()
+        runs = {'workflow_runs': [self.successful_run(newer), self.successful_run(old)]}
+        self.assertEqual(successful_main_base(self.root, 'HEAD', runs, 'Owner/Repo'), newer)
+        self.assertEqual(plan(self.root, newer)['mode'], 'docs')
+
+    def test_no_untrusted_run_can_supply_a_main_baseline(self):
+        sha = self.git('rev-parse', 'HEAD').decode().strip()
+        for key, value in [('event', 'pull_request'), ('status', 'in_progress'),
+                           ('head_branch', 'other'), ('conclusion', 'failure'),
+                           ('path', '.github/workflows/pages.yml'),
+                           ('head_sha', '0' * 40),
+                           ('head_repository', {'full_name': 'Other/Repo'})]:
+            row = self.successful_run(sha); row[key] = value
+            with self.subTest(key=key):
+                self.assertEqual(successful_main_base(self.root, 'HEAD',
+                    {'workflow_runs': [row]}, 'Owner/Repo'), '')
 
     def test_restored_cache_keeps_live_modules_and_removes_deleted_interfaces(self):
         self.write('.lake/build/lib/lean/AAA24Paper/Main.olean', 'live compiled module')

--- a/scripts/tests/test_private_ci_workflow.py
+++ b/scripts/tests/test_private_ci_workflow.py
@@ -173,13 +173,17 @@ class PrivateCIWorkflowTests(unittest.TestCase):
         self.assertNotIn("outputs.mode == 'aggregate'", body)
         self.assertNotIn("github.event_name != 'pull_request'", body)
 
-    def test_change_selection_uses_trusted_base_for_prs_and_exact_push_base(self) -> None:
+    def test_change_selection_uses_trusted_pr_base_and_successful_main_ancestor(self) -> None:
         body = self.step("Select changed-work validation")
         self.assertIn('$TRUSTED_CI_ROOT/scripts/ci_change_scope.py', body)
         self.assertIn('github.event.before', body)
         self.assertIn('--base "$EVENT_BASE" --head HEAD', body)
         self.assertIn('echo "mode=integration"', body)
         self.assertNotIn('echo "mode=papers"', body)
+        self.assertIn('successful-main-base', body)
+        self.assertIn('EVENT_BASE=""', body)
+        self.assertIn('status=success', body)
+        self.assertIn("cancel-in-progress: ${{ github.event_name == 'pull_request' }}", self.text)
 
     def test_batch_paper_validation_keeps_build_and_evidence_checks(self) -> None:
         build = self.step("Build changed papers and their dependents")


### PR DESCRIPTION
A documentation follow-up could cancel an unfinished main build and then compare only with the previous push, skipping checks for the earlier proof changes. Main pushes now compare with the newest successful main ancestor and preserve a running main build. If no trusted successful ancestor is available, CI runs full validation. Pull requests retain trusted-base selection and cancel superseded PR runs.

The README project link also points directly to AppliedModelingLib.

Validation: 27 focused scope and workflow tests pass in the public candidate, including a canceled proof update followed by documentation. The release guard checks the six exact public-safe files; no paper statements, proofs, or review evidence change.
