### PR TITLE
Fix CI disk space and stale paper registrations

### DIFF
--- a/.github/workflows/lean_action_ci.yml
+++ b/.github/workflows/lean_action_ci.yml
@@ -168,6 +168,18 @@ jobs:
             python3 "$SCOPE_TOOL" plan --repo "$GITHUB_WORKSPACE" \
               --base "$EVENT_BASE" --head HEAD --github-output "$GITHUB_OUTPUT"
           fi
+      - name: Make room for Lean build artifacts
+        if: steps.change-scope.outputs.mode != 'docs' && runner.environment == 'github-hosted'
+        # Lean and its caches need more disk than the default image leaves free.
+        # These fixed SDK directories are unused by this Linux Lean workflow.
+        run: |
+          if [[ "${RUNNER_ENVIRONMENT:-}" != "github-hosted" ]]; then
+            echo "Refusing SDK cleanup outside a GitHub-hosted runner." >&2
+            exit 1
+          fi
+          df -h .
+          sudo rm -rf -- /usr/local/lib/android /usr/share/dotnet /usr/local/.ghcup /opt/ghc
+          df -h .
       - name: Set up Lean dependencies
         if: steps.change-scope.outputs.mode != 'docs'
         uses: leanprover/lean-action@38fbc41a8c28c4cbaec22d7f7de508ec2e7c0dd9 # v1

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -224,12 +224,3 @@ srcDir = "papers"
 [[lean_lib]]
 name = "SeshadriUgander2020IIATesting"
 srcDir = "papers"
-
-
-[[lean_lib]]
-name = "AL16SupplyDemandMatching"
-srcDir = "papers"
-
-[[lean_lib]]
-name = "ZhouChenLi2014OptimalPACMultipleArm"
-srcDir = "papers"

--- a/scripts/public_release_candidate_guard.py
+++ b/scripts/public_release_candidate_guard.py
@@ -3328,6 +3328,35 @@ def _candidate_explicit_lake_srcdir_modules(
     }
 
 
+def public_paper_target_issues(repo: Path, candidate_commit: str) -> list[str]:
+    """Require every registered paper root in the exact exported Git tree."""
+
+    try:
+        lake = tomllib.loads(_git(repo, ["show", f"{candidate_commit}:lakefile.toml"]))
+    except (RuntimeError, UnicodeError, tomllib.TOMLDecodeError) as exc:
+        return [f"public Lake configuration is unavailable or malformed: {exc}"]
+    paths = set(_git(repo, ["ls-tree", "-r", "--name-only", candidate_commit]).splitlines())
+    issues: list[str] = []
+    for library in lake.get("lean_lib", []):
+        if not isinstance(library, dict) or library.get("srcDir") != "papers":
+            continue
+        name = library.get("name")
+        roots = library.get("roots", [name])
+        if not isinstance(roots, list):
+            issues.append(f"public paper target {name}: roots must be a list")
+            continue
+        for root in roots:
+            if not isinstance(root, str) or not re.fullmatch(
+                r"[A-Za-z_][A-Za-z0-9_']*(?:\.[A-Za-z_][A-Za-z0-9_']*)*", root
+            ):
+                issues.append(f"public paper target {name}: malformed root {root!r}")
+                continue
+            path = "papers/" + root.replace(".", "/") + ".lean"
+            if path not in paths:
+                issues.append(f"public paper target {name}: registered root is not exported: {path}")
+    return issues
+
+
 def _public_candidate_dependency_closure_issues(
     repo: Path,
     candidate_commit: str,
@@ -3568,6 +3597,7 @@ def run_guard(
         selected_graph_authority_registration_issues(repo, candidate_commit)
     )
     issues.extend(generated_status_freshness_issues(repo, candidate_commit))
+    issues.extend(public_paper_target_issues(repo, candidate_commit))
     for issue in _public_candidate_dependency_closure_issues(
         repo,
         candidate_commit,

--- a/scripts/tests/test_ci_disk_budget.py
+++ b/scripts/tests/test_ci_disk_budget.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import re
+import subprocess
+import tempfile
+import textwrap
+import unittest
+
+
+WORKFLOW = Path(__file__).resolve().parents[2] / ".github/workflows/lean_action_ci.yml"
+
+
+class HostedRunnerDiskBudgetTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.workflow = WORKFLOW.read_text()
+        match = re.search(
+            r"(?ms)^      - name: Make room for Lean build artifacts\n"
+            r"(?P<body>.*?)(?=^      - name:)", self.workflow,
+        )
+        self.assertIsNotNone(match)
+        self.step = match.group("body")
+        self.script = textwrap.dedent(self.step.split("        run: |\n", 1)[1])
+
+    def execute(self, environment: str | None) -> tuple[subprocess.CompletedProcess, str]:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            calls = root / "calls"
+            # Intercept the destructive command; execute the actual workflow shell.
+            sudo = root / "sudo"
+            sudo.write_text('#!/bin/sh\nprintf "%s\\n" "$@" >> "$DISK_TEST_CALLS"\n')
+            sudo.chmod(0o755)
+            env = dict(os.environ, PATH=f"{root}:{os.environ['PATH']}",
+                       DISK_TEST_CALLS=str(calls))
+            env.pop("RUNNER_ENVIRONMENT", None)
+            if environment is not None:
+                env["RUNNER_ENVIRONMENT"] = environment
+            result = subprocess.run(["bash", "-euo", "pipefail", "-c", self.script],
+                                    cwd=root, env=env, text=True, capture_output=True)
+            return result, calls.read_text() if calls.exists() else ""
+
+    def test_cleanup_is_before_dependencies_and_excludes_documentation_jobs(self) -> None:
+        self.assertIn("steps.change-scope.outputs.mode != 'docs'", self.step)
+        self.assertIn("runner.environment == 'github-hosted'", self.step)
+        self.assertLess(self.workflow.index("- name: Make room for Lean build artifacts"),
+                        self.workflow.index("- name: Set up Lean dependencies"))
+
+    def test_hosted_cleanup_targets_only_the_fixed_unused_sdks(self) -> None:
+        result, calls = self.execute("github-hosted")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(calls.splitlines(), ["rm", "-rf", "--",
+                         "/usr/local/lib/android", "/usr/share/dotnet",
+                         "/usr/local/.ghcup", "/opt/ghc"])
+
+    def test_nonhosted_or_missing_environment_never_attempts_cleanup(self) -> None:
+        for value in (None, "", "self-hosted", "github-hosted; echo unsafe"):
+            with self.subTest(environment=value):
+                result, calls = self.execute(value)
+                self.assertNotEqual(result.returncode, 0)
+                self.assertEqual(calls, "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_public_release_candidate_guard.py
+++ b/scripts/tests/test_public_release_candidate_guard.py
@@ -83,6 +83,39 @@ def _projected_corrected_target_map() -> dict[str, object]:
 
 
 class PublicReleaseCandidateGuardTests(unittest.TestCase):
+    def test_paper_target_guard_checks_registered_roots_beyond_default_targets(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo = Path(temp_dir)
+            self.init_repo(repo)
+            (repo / "lakefile.toml").write_text(
+                'name = "Fixture"\ndefaultTargets = []\n'
+                '[[lean_lib]]\nname = "HiddenPaper"\nsrcDir = "papers"\n'
+            )
+            commit = self.commit(repo, "unexported registered paper")
+            self.assertEqual(guard.public_paper_target_issues(repo, commit), [
+                "public paper target HiddenPaper: registered root is not exported: "
+                "papers/HiddenPaper.lean"
+            ])
+            (repo / "papers").mkdir()
+            (repo / "papers/HiddenPaper.lean").write_text("import Lean\n")
+            # A local file must not hide a missing file in the release commit.
+            self.assertTrue(guard.public_paper_target_issues(repo, commit))
+            complete = self.commit(repo, "export the registered root")
+            self.assertEqual(guard.public_paper_target_issues(repo, complete), [])
+
+    def test_paper_target_guard_uses_explicit_roots(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo = Path(temp_dir)
+            self.init_repo(repo)
+            (repo / "lakefile.toml").write_text(
+                'name = "Fixture"\n[[lean_lib]]\nname = "Paper"\n'
+                'srcDir = "papers"\nroots = ["Paper.ProofInterface"]\n'
+            )
+            (repo / "papers/Paper").mkdir(parents=True)
+            (repo / "papers/Paper/ProofInterface.lean").write_text("import Lean\n")
+            complete = self.commit(repo, "export explicit paper root")
+            self.assertEqual(guard.public_paper_target_issues(repo, complete), [])
+
     def test_dependency_closure_resolves_explicit_lake_script_root(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             repo = Path(temp_dir)
@@ -2351,6 +2384,7 @@ class PublicReleaseCandidateGuardTests(unittest.TestCase):
             candidate = root / "candidate"
             self.init_repo(private)
             self.init_repo(candidate)
+            (candidate / "lakefile.toml").write_text('name = "Fixture"\n', encoding="utf-8")
 
             (private / "reviewed.txt").write_text("reviewed\n", encoding="utf-8")
             source_commit = self.commit(private, "private source")


### PR DESCRIPTION
Full CI could not finish: hosted runners exhausted disk, and the public Lake configuration still registered two paper roots that were not exported. This update frees four unused SDK directories on GitHub-hosted runners before Lean setup and removes those two stale public registrations. It does not add any papers or change proof or review evidence.

The release guard now rejects registered public paper roots absent from the committed tree, including targets outside `defaultTargets`. All existing build, source, evidence, and publication checks remain enabled.

Validation: 120 focused workflow, scope, cleanup-execution, and release-guard tests pass in the clean public candidate. The canonical private release guard passes its exact five-file allowlist. Full main CI will verify the build after merge; the separately diagnosed source-role projection compatibility issue remains under repair.
