### PR TITLE
Authenticate public source-role projections for released papers

### DIFF
--- a/config/formalization_engine_revisions.json
+++ b/config/formalization_engine_revisions.json
@@ -991,6 +991,15 @@
       "verification": [
         "27 focused CI scope and workflow tests pass, including canceled proof changes followed by documentation."
       ]
+    },
+    {
+      "engine_tree_sha256": "31d87678dd350d0b474d04ebc137df73f7e87975a960e46e31cdda7baa451c53",
+      "formalization_review_protocol_sha256": "ca5ffddd01335d26b9b44d361eeaea34261ea281d4fed0eb4f8d38d85a6c4e70",
+      "rationale": "Authenticate exact public source-role projections using accepted private role bindings and canonical public main release metadata.",
+      "sequence": 83,
+      "verification": [
+        "59 focused terminal and source-role projection tests pass; deterministic metadata generated for the same 36 public papers without modifying accepted graphs or claims."
+      ]
     }
   ],
   "schema": 2

--- a/papers/DGD26AdmissionsPredictability/audit/paper_statement_map.json
+++ b/papers/DGD26AdmissionsPredictability/audit/paper_statement_map.json
@@ -3682,6 +3682,11 @@
     "approval_material_included": false,
     "schema": 1
   },
+  "publication_source_display_projection": {
+    "manifest": "audit/public_source_display_projection.json",
+    "raw_source_bytes_included": false,
+    "schema": 1
+  },
   "schema": 1,
   "semantic_contract_schema": 1,
   "semantic_route_schema": 2,

--- a/papers/DGD26AdmissionsPredictability/audit/public_source_role_projection.json
+++ b/papers/DGD26AdmissionsPredictability/audit/public_source_role_projection.json
@@ -1,0 +1,443 @@
+{
+  "acceptance_credential": false,
+  "accepted_graph_sha256": "5ef3a4b2e88009d2e3039d2bb6b33c236e21e18f82ce3349e822d8af49913c69",
+  "bindings_by_source_item": {
+    "definition_binary_classifier_model": {
+      "accepted_source_role_contract_sha256": "e8bd731c387f27f23e485836c19e8cd56ab3be13060fd6b4343e29952fe8b856",
+      "public_source_role_projection_sha256": "e8bd731c387f27f23e485836c19e8cd56ab3be13060fd6b4343e29952fe8b856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition_borderline_set": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition_choice_distance": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition_choice_function_model": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition_choice_label_formula": {
+      "accepted_source_role_contract_sha256": "7943bb0a1038c9b9ca1ec777a62b2cf0d2afdf222d3ccb832d0d97bcd18dfc6a",
+      "public_source_role_projection_sha256": "7943bb0a1038c9b9ca1ec777a62b2cf0d2afdf222d3ccb832d0d97bcd18dfc6a",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition_consistency": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition_d_instability": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition_fixed_threshold_score_formula": {
+      "accepted_source_role_contract_sha256": "7943bb0a1038c9b9ca1ec777a62b2cf0d2afdf222d3ccb832d0d97bcd18dfc6a",
+      "public_source_role_projection_sha256": "7943bb0a1038c9b9ca1ec777a62b2cf0d2afdf222d3ccb832d0d97bcd18dfc6a",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition_general_variability": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition_independence": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition_lap_assignment_choice": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition_lap_model_objective": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition_lap_slot_order": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition_lap_slot_order_equivalence": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition_main_variability": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition_ml_representation": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition_monotonicity": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition_q_acceptance": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition_q_representativeness": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition_rank_threshold_formula": {
+      "accepted_source_role_contract_sha256": "7943bb0a1038c9b9ca1ec777a62b2cf0d2afdf222d3ccb832d0d97bcd18dfc6a",
+      "public_source_role_projection_sha256": "7943bb0a1038c9b9ca1ec777a62b2cf0d2afdf222d3ccb832d0d97bcd18dfc6a",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition_sequential_composition": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition_substitutability": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition_tight_d_instability": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition_total_order": {
+      "accepted_source_role_contract_sha256": "90a478a6d2c3969acc92690f5a05b03ca3f0c74fb5434b722c1ce7aa305ed5f1",
+      "public_source_role_projection_sha256": "c90e65c514c077c1604fc5b07a8bd25a884fa68d4aa29dcedadcf91d81ab9e00",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "definition_waitlisted_set": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition_zero_instability": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "result_additive_variability_bound": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "result_append_remove_max_equality": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "result_calculating_instability": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "result_choice_distance_triangle": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "result_corrected_removable_sets": {
+      "accepted_source_role_contract_sha256": "5ffe31dab895959e5279fb101fcd3eb71d2c9b24af8d813fba8b160204a21a94",
+      "public_source_role_projection_sha256": "1d77ee0db46877461dfd02def1baba28f3faf41ad276ad0ffe4dcd3dff1f8661",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "result_edopt_dia_variability_six": {
+      "accepted_source_role_contract_sha256": "3d91ef87e191b09891d61b739edc97f0a9f4059a7414d038c2a9927df2a2df54",
+      "public_source_role_projection_sha256": "90180dfb9ae9575baad483b8f5fa74dbf9d8d15822fd113518e82ea2a38b8be1",
+      "schema": 1,
+      "withheld_field_paths": [
+        "user_approved_scope_exclusion.approval_reference",
+        "user_approved_scope_exclusion.source_locator"
+      ]
+    },
+    "result_edopt_variability_three": {
+      "accepted_source_role_contract_sha256": "b57c4f376ab1b6f8d7add73ecad5c31db7d35a9eff7f17d0f565a12c380087d7",
+      "public_source_role_projection_sha256": "90180dfb9ae9575baad483b8f5fa74dbf9d8d15822fd113518e82ea2a38b8be1",
+      "schema": 1,
+      "withheld_field_paths": [
+        "user_approved_scope_exclusion.approval_reference",
+        "user_approved_scope_exclusion.source_locator"
+      ]
+    },
+    "result_even_distance_iff_inconsistent": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "result_independence_iff_substitutable_monotonic": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "result_independence_iff_zero_instability": {
+      "accepted_source_role_contract_sha256": "f4254796949514af697b1a57a525740c36a37b17d9eafef0da4f0bb27d637328",
+      "public_source_role_projection_sha256": "f4254796949514af697b1a57a525740c36a37b17d9eafef0da4f0bb27d637328",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "result_lap_assigned_outranks_rejected": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "result_lap_distinct_order_variability": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "result_lap_higher_applicant_chosen": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "result_lap_one_instability": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "result_ml_independent_only_zero": {
+      "accepted_source_role_contract_sha256": "64a83a0ae6edbdb2d3cfb6cb84e3bf045734ef9303f62643ff780eff69b02885",
+      "public_source_role_projection_sha256": "64a83a0ae6edbdb2d3cfb6cb84e3bf045734ef9303f62643ff780eff69b02885",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "result_ml_rank_can_represent_one_one": {
+      "accepted_source_role_contract_sha256": "64a83a0ae6edbdb2d3cfb6cb84e3bf045734ef9303f62643ff780eff69b02885",
+      "public_source_role_projection_sha256": "64a83a0ae6edbdb2d3cfb6cb84e3bf045734ef9303f62643ff780eff69b02885",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "result_ml_rank_cannot_instability_gt_one": {
+      "accepted_source_role_contract_sha256": "64a83a0ae6edbdb2d3cfb6cb84e3bf045734ef9303f62643ff780eff69b02885",
+      "public_source_role_projection_sha256": "64a83a0ae6edbdb2d3cfb6cb84e3bf045734ef9303f62643ff780eff69b02885",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "result_ml_rank_cannot_variability_gt_one": {
+      "accepted_source_role_contract_sha256": "64a83a0ae6edbdb2d3cfb6cb84e3bf045734ef9303f62643ff780eff69b02885",
+      "public_source_role_projection_sha256": "64a83a0ae6edbdb2d3cfb6cb84e3bf045734ef9303f62643ff780eff69b02885",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "result_monotonicity_distance_term": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "result_monotonicity_qacceptance_incompatibility": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "result_no_consistent_tightly_even": {
+      "accepted_source_role_contract_sha256": "de1a8671e8f0a6c4345642151d9b74c749fcca89d302e7ed2568f263fc3a58b5",
+      "public_source_role_projection_sha256": "a99917c70eb6a7983b31b163560e79b9250005eef6af1a0aef68cebaf6fbd2a4",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "result_no_qacceptant_zero_instability_corollary": {
+      "accepted_source_role_contract_sha256": "eb31ae4721c41819cef52bb25f62e75345afc0115452106236c45104cc005a13",
+      "public_source_role_projection_sha256": "8ffde2eae178ec2e3f56460f38961cb15ed077e003ba592a043ed7dbcfe3cfea",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "result_non_substitutable_single_add": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "result_program_classes_one_instability": {
+      "accepted_source_role_contract_sha256": "3d91ef87e191b09891d61b739edc97f0a9f4059a7414d038c2a9927df2a2df54",
+      "public_source_role_projection_sha256": "90180dfb9ae9575baad483b8f5fa74dbf9d8d15822fd113518e82ea2a38b8be1",
+      "schema": 1,
+      "withheld_field_paths": [
+        "user_approved_scope_exclusion.approval_reference",
+        "user_approved_scope_exclusion.source_locator"
+      ]
+    },
+    "result_qacceptant_substitutable_consistent": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "result_qacceptant_substitutable_iff_one": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "result_qrepresentative_converse": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "result_qrepresentative_forward": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "result_ranking_m_borderline_waitlisted": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "result_screened_open_dia_variability_two": {
+      "accepted_source_role_contract_sha256": "3d91ef87e191b09891d61b739edc97f0a9f4059a7414d038c2a9927df2a2df54",
+      "public_source_role_projection_sha256": "90180dfb9ae9575baad483b8f5fa74dbf9d8d15822fd113518e82ea2a38b8be1",
+      "schema": 1,
+      "withheld_field_paths": [
+        "user_approved_scope_exclusion.approval_reference",
+        "user_approved_scope_exclusion.source_locator"
+      ]
+    },
+    "result_screened_open_variability_one": {
+      "accepted_source_role_contract_sha256": "3d91ef87e191b09891d61b739edc97f0a9f4059a7414d038c2a9927df2a2df54",
+      "public_source_role_projection_sha256": "90180dfb9ae9575baad483b8f5fa74dbf9d8d15822fd113518e82ea2a38b8be1",
+      "schema": 1,
+      "withheld_field_paths": [
+        "user_approved_scope_exclusion.approval_reference",
+        "user_approved_scope_exclusion.source_locator"
+      ]
+    },
+    "result_sequential_preserves_substitutability": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "result_substitutability_distance_term": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "result_theorem1_no_zero": {
+      "accepted_source_role_contract_sha256": "edb02a53538d86aad721e9f072e03f76cca6cff76469030c790e86e7eae976e9",
+      "public_source_role_projection_sha256": "3760aa14cf99e1130b8d3df21297c2a03b2fdc8033d64b6a85d19966c401f2fe",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "result_theorem1_substitutability_iff_one": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "result_theorem1_tight_all_d": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "result_theorem2_one_iff_single_order": {
+      "accepted_source_role_contract_sha256": "f4fbe2c6404f224f4374c5fcec99ee985f010db473f8b0db760ba64b19c2bca2",
+      "public_source_role_projection_sha256": "ecb8b393d84d3d2a4cc53b2a0b8f9e05cdd35f106f9b726c88bccec7b3b3ee16",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "result_theorem2_variability_range": {
+      "accepted_source_role_contract_sha256": "8991322ae4cc26c864ccd39406b3f505b3cf0df4585e1ddc5d352a9b34260663",
+      "public_source_role_projection_sha256": "85a60faee51261510a6ac01656ce5719d69b478770335586c88f9aeefa6ea5f3",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "result_zero_iff_substitutable_monotonic": {
+      "accepted_source_role_contract_sha256": "f4254796949514af697b1a57a525740c36a37b17d9eafef0da4f0bb27d637328",
+      "public_source_role_projection_sha256": "f4254796949514af697b1a57a525740c36a37b17d9eafef0da4f0bb27d637328",
+      "schema": 1,
+      "withheld_field_paths": []
+    }
+  },
+  "paper": "DGD26AdmissionsPredictability",
+  "private_role_material_included": false,
+  "private_source_map_material_sha256": "5f6781d1d774cd6c9946c434588bd2d7fcde964a1d53dc74430e65c40fa8b52c",
+  "private_source_map_sha256": "8b43abc54c008aa739aadfeaf5bbf8fa5a68592a576d75a0fc3f3773e969fe0f",
+  "projection_contract_sha256": "ed0964edc9c70f5ce087ce9bf134712ca40c7964ecaefd403309ac9a1b47d34d",
+  "public_display_manifest_material_sha256": "7f8d7259dc064c27387b23f1766d8fe43a401338b46a133f07268b8daabcfaf6",
+  "public_display_manifest_sha256": "0f0ac603b69b00eee7a5640e45aed82d1a06ad85c0a398fec345c247768f9a92",
+  "public_source_map_material_sha256": "142460e70db19a662917489d4ec347e37f42901a48d2022e0c476b787b072cde",
+  "public_source_map_sha256": "086ef880804db944dbe8c8543f06053a0c1e445aef5fb5fa463e31a68a74c8e6",
+  "raw_private_approval_material_included": false,
+  "schema": 1
+}

--- a/papers/DSWG24DiscretizationBias/audit/paper_statement_map.json
+++ b/papers/DSWG24DiscretizationBias/audit/paper_statement_map.json
@@ -2975,6 +2975,11 @@
     "DSWG24DiscretizationBias.ProofBridge.posteriorSimplex": "posteriorSimplex",
     "DSWG24DiscretizationBias.ProofBridge.referenceSimplexAt": "referenceDistribution"
   },
+  "publication_source_display_projection": {
+    "manifest": "audit/public_source_display_projection.json",
+    "raw_source_bytes_included": false,
+    "schema": 1
+  },
   "schema": 1,
   "seed_scaffold": false,
   "semantic_contract_schema": 1,

--- a/papers/DSWG24DiscretizationBias/audit/public_source_role_projection.json
+++ b/papers/DSWG24DiscretizationBias/audit/public_source_role_projection.json
@@ -1,0 +1,614 @@
+{
+  "acceptance_credential": false,
+  "accepted_graph_sha256": "9d337f2a83168b98fd47e3e173928e41c779da06cf1ef5415aef58fec4cffb6f",
+  "bindings_by_source_item": {
+    "accuracy": {
+      "accepted_source_role_contract_sha256": "4e2860f9afc7904499c08f8f362a510ce115c0b4125dcf957d4523636b259d76",
+      "public_source_role_projection_sha256": "4e2860f9afc7904499c08f8f362a510ce115c0b4125dcf957d4523636b259d76",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "aggregatePosterior": {
+      "accepted_source_role_contract_sha256": "4e2860f9afc7904499c08f8f362a510ce115c0b4125dcf957d4523636b259d76",
+      "public_source_role_projection_sha256": "4e2860f9afc7904499c08f8f362a510ce115c0b4125dcf957d4523636b259d76",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "assumption_theorem1_argmax_rule_measurable": {
+      "accepted_source_role_contract_sha256": "3655538858b859e235133d14c1d69377b737bef395a8c0e74f9dbba5670d65c2",
+      "public_source_role_projection_sha256": "3655538858b859e235133d14c1d69377b737bef395a8c0e74f9dbba5670d65c2",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "assumption_theorem1_calibrated_classifier": {
+      "accepted_source_role_contract_sha256": "3655538858b859e235133d14c1d69377b737bef395a8c0e74f9dbba5670d65c2",
+      "public_source_role_projection_sha256": "3655538858b859e235133d14c1d69377b737bef395a8c0e74f9dbba5670d65c2",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "assumption_theorem1_no_information_case": {
+      "accepted_source_role_contract_sha256": "3655538858b859e235133d14c1d69377b737bef395a8c0e74f9dbba5670d65c2",
+      "public_source_role_projection_sha256": "3655538858b859e235133d14c1d69377b737bef395a8c0e74f9dbba5670d65c2",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "assumption_theorem1_perfect_classifier": {
+      "accepted_source_role_contract_sha256": "3655538858b859e235133d14c1d69377b737bef395a8c0e74f9dbba5670d65c2",
+      "public_source_role_projection_sha256": "3655538858b859e235133d14c1d69377b737bef395a8c0e74f9dbba5670d65c2",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "assumption_theorem1_plurality_argmax_class": {
+      "accepted_source_role_contract_sha256": "3655538858b859e235133d14c1d69377b737bef395a8c0e74f9dbba5670d65c2",
+      "public_source_role_projection_sha256": "3655538858b859e235133d14c1d69377b737bef395a8c0e74f9dbba5670d65c2",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "assumption_theorem2_at_least_two_classes": {
+      "accepted_source_role_contract_sha256": "3655538858b859e235133d14c1d69377b737bef395a8c0e74f9dbba5670d65c2",
+      "public_source_role_projection_sha256": "3655538858b859e235133d14c1d69377b737bef395a8c0e74f9dbba5670d65c2",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "assumption_theorem2_more_rows_than_classes": {
+      "accepted_source_role_contract_sha256": "3655538858b859e235133d14c1d69377b737bef395a8c0e74f9dbba5670d65c2",
+      "public_source_role_projection_sha256": "3655538858b859e235133d14c1d69377b737bef395a8c0e74f9dbba5670d65c2",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "assumption_theorem2_positive_sample_count": {
+      "accepted_source_role_contract_sha256": "3655538858b859e235133d14c1d69377b737bef395a8c0e74f9dbba5670d65c2",
+      "public_source_role_projection_sha256": "3655538858b859e235133d14c1d69377b737bef395a8c0e74f9dbba5670d65c2",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "assumption_theorem2_reference_nonnegative": {
+      "accepted_source_role_contract_sha256": "3655538858b859e235133d14c1d69377b737bef395a8c0e74f9dbba5670d65c2",
+      "public_source_role_projection_sha256": "3655538858b859e235133d14c1d69377b737bef395a8c0e74f9dbba5670d65c2",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "bayesOptimal": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "bias": {
+      "accepted_source_role_contract_sha256": "4e2860f9afc7904499c08f8f362a510ce115c0b4125dcf957d4523636b259d76",
+      "public_source_role_projection_sha256": "4e2860f9afc7904499c08f8f362a510ce115c0b4125dcf957d4523636b259d76",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "calibrated": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "classifierMAE": {
+      "accepted_source_role_contract_sha256": "4e2860f9afc7904499c08f8f362a510ce115c0b4125dcf957d4523636b259d76",
+      "public_source_role_projection_sha256": "4e2860f9afc7904499c08f8f362a510ce115c0b4125dcf957d4523636b259d76",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "continuousAggregateBias": {
+      "accepted_source_role_contract_sha256": "b5f4804192214264d69cde3f0680e8ffdbbff8a552d1c1351ffe3d859c5b31d6",
+      "public_source_role_projection_sha256": "b5f4804192214264d69cde3f0680e8ffdbbff8a552d1c1351ffe3d859c5b31d6",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "continuousAggregatePosterior": {
+      "accepted_source_role_contract_sha256": "b5f4804192214264d69cde3f0680e8ffdbbff8a552d1c1351ffe3d859c5b31d6",
+      "public_source_role_projection_sha256": "b5f4804192214264d69cde3f0680e8ffdbbff8a552d1c1351ffe3d859c5b31d6",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "continuousBias": {
+      "accepted_source_role_contract_sha256": "b5f4804192214264d69cde3f0680e8ffdbbff8a552d1c1351ffe3d859c5b31d6",
+      "public_source_role_projection_sha256": "b5f4804192214264d69cde3f0680e8ffdbbff8a552d1c1351ffe3d859c5b31d6",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "continuousClassifierMAE": {
+      "accepted_source_role_contract_sha256": "b5f4804192214264d69cde3f0680e8ffdbbff8a552d1c1351ffe3d859c5b31d6",
+      "public_source_role_projection_sha256": "b5f4804192214264d69cde3f0680e8ffdbbff8a552d1c1351ffe3d859c5b31d6",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "continuousJointClassifierMAE": {
+      "accepted_source_role_contract_sha256": "b5f4804192214264d69cde3f0680e8ffdbbff8a552d1c1351ffe3d859c5b31d6",
+      "public_source_role_projection_sha256": "b5f4804192214264d69cde3f0680e8ffdbbff8a552d1c1351ffe3d859c5b31d6",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "continuousJointPriorBias": {
+      "accepted_source_role_contract_sha256": "b5f4804192214264d69cde3f0680e8ffdbbff8a552d1c1351ffe3d859c5b31d6",
+      "public_source_role_projection_sha256": "b5f4804192214264d69cde3f0680e8ffdbbff8a552d1c1351ffe3d859c5b31d6",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "continuousMarginalLabelShare": {
+      "accepted_source_role_contract_sha256": "b5f4804192214264d69cde3f0680e8ffdbbff8a552d1c1351ffe3d859c5b31d6",
+      "public_source_role_projection_sha256": "b5f4804192214264d69cde3f0680e8ffdbbff8a552d1c1351ffe3d859c5b31d6",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "datasetMostLikelyClass": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "equation1Objective": {
+      "accepted_source_role_contract_sha256": "4e2860f9afc7904499c08f8f362a510ce115c0b4125dcf957d4523636b259d76",
+      "public_source_role_projection_sha256": "4e2860f9afc7904499c08f8f362a510ce115c0b4125dcf957d4523636b259d76",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "equation2ExpectedAccuracy": {
+      "accepted_source_role_contract_sha256": "4e2860f9afc7904499c08f8f362a510ce115c0b4125dcf957d4523636b259d76",
+      "public_source_role_projection_sha256": "4e2860f9afc7904499c08f8f362a510ce115c0b4125dcf957d4523636b259d76",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "equation3ExpectedObjective": {
+      "accepted_source_role_contract_sha256": "4e2860f9afc7904499c08f8f362a510ce115c0b4125dcf957d4523636b259d76",
+      "public_source_role_projection_sha256": "4e2860f9afc7904499c08f8f362a510ce115c0b4125dcf957d4523636b259d76",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "expectedBiasAt": {
+      "accepted_source_role_contract_sha256": "4e2860f9afc7904499c08f8f362a510ce115c0b4125dcf957d4523636b259d76",
+      "public_source_role_projection_sha256": "4e2860f9afc7904499c08f8f362a510ce115c0b4125dcf957d4523636b259d76",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "expectedFidelityAt": {
+      "accepted_source_role_contract_sha256": "4e2860f9afc7904499c08f8f362a510ce115c0b4125dcf957d4523636b259d76",
+      "public_source_role_projection_sha256": "4e2860f9afc7904499c08f8f362a510ce115c0b4125dcf957d4523636b259d76",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "expectedObjective": {
+      "accepted_source_role_contract_sha256": "4e2860f9afc7904499c08f8f362a510ce115c0b4125dcf957d4523636b259d76",
+      "public_source_role_projection_sha256": "4e2860f9afc7904499c08f8f362a510ce115c0b4125dcf957d4523636b259d76",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "fidelity": {
+      "accepted_source_role_contract_sha256": "4e2860f9afc7904499c08f8f362a510ce115c0b4125dcf957d4523636b259d76",
+      "public_source_role_projection_sha256": "4e2860f9afc7904499c08f8f362a510ce115c0b4125dcf957d4523636b259d76",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "formalIndependentRule": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "isArgmaxRule": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "isIndependentRule": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "isThompsonSamplingRule": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "isTieBrokenArgmaxRule": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "marginalLabelShare": {
+      "accepted_source_role_contract_sha256": "4e2860f9afc7904499c08f8f362a510ce115c0b4125dcf957d4523636b259d76",
+      "public_source_role_projection_sha256": "4e2860f9afc7904499c08f8f362a510ce115c0b4125dcf957d4523636b259d76",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "maximizesEquation1": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "objective": {
+      "accepted_source_role_contract_sha256": "4e2860f9afc7904499c08f8f362a510ce115c0b4125dcf957d4523636b259d76",
+      "public_source_role_projection_sha256": "4e2860f9afc7904499c08f8f362a510ce115c0b4125dcf957d4523636b259d76",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "paretoOptimal": {
+      "accepted_source_role_contract_sha256": "11089874d4db43d996f2ec1b744f56d79aade0c93649acae9953b3ff8e997a83",
+      "public_source_role_projection_sha256": "78a5121ca8693096dc5c4307e830a6a82c760b493fbd789928e9c111e97572f1",
+      "schema": 1,
+      "withheld_field_paths": [
+        "user_approved_scope_exclusion.approval_reference",
+        "user_approved_scope_exclusion.source_locator"
+      ]
+    },
+    "perfectClassifierOnSupport": {
+      "accepted_source_role_contract_sha256": "43fe4e87069c94608dac16100690da025fa919cc69a4a402f366e301b0a75f40",
+      "public_source_role_projection_sha256": "43fe4e87069c94608dac16100690da025fa919cc69a4a402f366e301b0a75f40",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "posteriorSimplex": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "prior": {
+      "accepted_source_role_contract_sha256": "4e2860f9afc7904499c08f8f362a510ce115c0b4125dcf957d4523636b259d76",
+      "public_source_role_projection_sha256": "4e2860f9afc7904499c08f8f362a510ce115c0b4125dcf957d4523636b259d76",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "proof_equation_04": {
+      "accepted_source_role_contract_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "public_source_role_projection_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "proof_equation_05": {
+      "accepted_source_role_contract_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "public_source_role_projection_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "proof_equation_06": {
+      "accepted_source_role_contract_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "public_source_role_projection_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "proof_equation_07": {
+      "accepted_source_role_contract_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "public_source_role_projection_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "proof_equation_08": {
+      "accepted_source_role_contract_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "public_source_role_projection_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "proof_equation_09": {
+      "accepted_source_role_contract_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "public_source_role_projection_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "proof_equation_10": {
+      "accepted_source_role_contract_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "public_source_role_projection_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "proof_equation_11": {
+      "accepted_source_role_contract_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "public_source_role_projection_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "proof_equation_12": {
+      "accepted_source_role_contract_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "public_source_role_projection_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "proof_equation_13": {
+      "accepted_source_role_contract_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "public_source_role_projection_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "proof_equation_14": {
+      "accepted_source_role_contract_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "public_source_role_projection_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "proof_equation_15": {
+      "accepted_source_role_contract_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "public_source_role_projection_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "proof_equation_16": {
+      "accepted_source_role_contract_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "public_source_role_projection_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "proof_equation_17": {
+      "accepted_source_role_contract_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "public_source_role_projection_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "proof_equation_18": {
+      "accepted_source_role_contract_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "public_source_role_projection_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "proof_equation_19": {
+      "accepted_source_role_contract_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "public_source_role_projection_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "proof_equation_20": {
+      "accepted_source_role_contract_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "public_source_role_projection_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "proof_equation_21": {
+      "accepted_source_role_contract_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "public_source_role_projection_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "proof_equation_22": {
+      "accepted_source_role_contract_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "public_source_role_projection_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "proof_equation_23": {
+      "accepted_source_role_contract_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "public_source_role_projection_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "proof_equation_24": {
+      "accepted_source_role_contract_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "public_source_role_projection_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "proof_equation_25": {
+      "accepted_source_role_contract_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "public_source_role_projection_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "proof_equation_26": {
+      "accepted_source_role_contract_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "public_source_role_projection_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "proof_equation_27": {
+      "accepted_source_role_contract_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "public_source_role_projection_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "proof_equation_28": {
+      "accepted_source_role_contract_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "public_source_role_projection_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "proof_equation_29": {
+      "accepted_source_role_contract_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "public_source_role_projection_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "proof_equation_30": {
+      "accepted_source_role_contract_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "public_source_role_projection_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "proof_equation_31": {
+      "accepted_source_role_contract_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "public_source_role_projection_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "proof_equation_32": {
+      "accepted_source_role_contract_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "public_source_role_projection_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "proof_equation_33": {
+      "accepted_source_role_contract_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "public_source_role_projection_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "referenceDistribution": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "sourcePNq": {
+      "accepted_source_role_contract_sha256": "7943bb0a1038c9b9ca1ec777a62b2cf0d2afdf222d3ccb832d0d97bcd18dfc6a",
+      "public_source_role_projection_sha256": "7943bb0a1038c9b9ca1ec777a62b2cf0d2afdf222d3ccb832d0d97bcd18dfc6a",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "sourceSa": {
+      "accepted_source_role_contract_sha256": "b5f4804192214264d69cde3f0680e8ffdbbff8a552d1c1351ffe3d859c5b31d6",
+      "public_source_role_projection_sha256": "b5f4804192214264d69cde3f0680e8ffdbbff8a552d1c1351ffe3d859c5b31d6",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "sourceSb": {
+      "accepted_source_role_contract_sha256": "b5f4804192214264d69cde3f0680e8ffdbbff8a552d1c1351ffe3d859c5b31d6",
+      "public_source_role_projection_sha256": "b5f4804192214264d69cde3f0680e8ffdbbff8a552d1c1351ffe3d859c5b31d6",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "sourceSc": {
+      "accepted_source_role_contract_sha256": "b5f4804192214264d69cde3f0680e8ffdbbff8a552d1c1351ffe3d859c5b31d6",
+      "public_source_role_projection_sha256": "b5f4804192214264d69cde3f0680e8ffdbbff8a552d1c1351ffe3d859c5b31d6",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "sourceSd": {
+      "accepted_source_role_contract_sha256": "b5f4804192214264d69cde3f0680e8ffdbbff8a552d1c1351ffe3d859c5b31d6",
+      "public_source_role_projection_sha256": "b5f4804192214264d69cde3f0680e8ffdbbff8a552d1c1351ffe3d859c5b31d6",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "sourceSe": {
+      "accepted_source_role_contract_sha256": "b5f4804192214264d69cde3f0680e8ffdbbff8a552d1c1351ffe3d859c5b31d6",
+      "public_source_role_projection_sha256": "b5f4804192214264d69cde3f0680e8ffdbbff8a552d1c1351ffe3d859c5b31d6",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem1i_appendix_presentation": {
+      "accepted_source_role_contract_sha256": "1d239652a90cbe5e5a6acfbc5170f0d2356a133066e0067a00e2dbb97c464b60",
+      "public_source_role_projection_sha256": "1d239652a90cbe5e5a6acfbc5170f0d2356a133066e0067a00e2dbb97c464b60",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem1i_no_information_bias": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem1i_nonplurality_bias_formula": {
+      "accepted_source_role_contract_sha256": "b5f4804192214264d69cde3f0680e8ffdbbff8a552d1c1351ffe3d859c5b31d6",
+      "public_source_role_projection_sha256": "b5f4804192214264d69cde3f0680e8ffdbbff8a552d1c1351ffe3d859c5b31d6",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem1i_plurality_bias_formula": {
+      "accepted_source_role_contract_sha256": "b5f4804192214264d69cde3f0680e8ffdbbff8a552d1c1351ffe3d859c5b31d6",
+      "public_source_role_projection_sha256": "b5f4804192214264d69cde3f0680e8ffdbbff8a552d1c1351ffe3d859c5b31d6",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem1ii_appendix_presentation": {
+      "accepted_source_role_contract_sha256": "1d239652a90cbe5e5a6acfbc5170f0d2356a133066e0067a00e2dbb97c464b60",
+      "public_source_role_projection_sha256": "1d239652a90cbe5e5a6acfbc5170f0d2356a133066e0067a00e2dbb97c464b60",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem1ii_prior_reference_zero_bias": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem1iii_appendix_presentation": {
+      "accepted_source_role_contract_sha256": "1d239652a90cbe5e5a6acfbc5170f0d2356a133066e0067a00e2dbb97c464b60",
+      "public_source_role_projection_sha256": "1d239652a90cbe5e5a6acfbc5170f0d2356a133066e0067a00e2dbb97c464b60",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem1iii_argmax_bias_le_mae": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem1iii_tight_binary_example": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem2i_appendix_presentation": {
+      "accepted_source_role_contract_sha256": "1d239652a90cbe5e5a6acfbc5170f0d2356a133066e0067a00e2dbb97c464b60",
+      "public_source_role_projection_sha256": "1d239652a90cbe5e5a6acfbc5170f0d2356a133066e0067a00e2dbb97c464b60",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem2i_joint_rule_exists": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem2ii_appendix_presentation": {
+      "accepted_source_role_contract_sha256": "1d239652a90cbe5e5a6acfbc5170f0d2356a133066e0067a00e2dbb97c464b60",
+      "public_source_role_projection_sha256": "1d239652a90cbe5e5a6acfbc5170f0d2356a133066e0067a00e2dbb97c464b60",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem2ii_argmax_accuracy_maximizing": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem2iii_appendix_presentation": {
+      "accepted_source_role_contract_sha256": "1d239652a90cbe5e5a6acfbc5170f0d2356a133066e0067a00e2dbb97c464b60",
+      "public_source_role_projection_sha256": "1d239652a90cbe5e5a6acfbc5170f0d2356a133066e0067a00e2dbb97c464b60",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem2iii_non_argmax_not_pareto": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem2iii_source_dataset_reference_bridge": {
+      "accepted_source_role_contract_sha256": "581440dfd564e79e623e51ab1405cee6a60dc9d12e4e8765d870fb79460b2da5",
+      "public_source_role_projection_sha256": "581440dfd564e79e623e51ab1405cee6a60dc9d12e4e8765d870fb79460b2da5",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem2iii_source_dataset_weighted_bridge": {
+      "accepted_source_role_contract_sha256": "581440dfd564e79e623e51ab1405cee6a60dc9d12e4e8765d870fb79460b2da5",
+      "public_source_role_projection_sha256": "581440dfd564e79e623e51ab1405cee6a60dc9d12e4e8765d870fb79460b2da5",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem2iii_strict_disagreement_not_weighted_objective_maximizer": {
+      "accepted_source_role_contract_sha256": "581440dfd564e79e623e51ab1405cee6a60dc9d12e4e8765d870fb79460b2da5",
+      "public_source_role_projection_sha256": "581440dfd564e79e623e51ab1405cee6a60dc9d12e4e8765d870fb79460b2da5",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem2iii_weighted_objective_maximizer_agrees_argmax": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "thresholdRule": {
+      "accepted_source_role_contract_sha256": "0abb924c80a29b86bd1ef11b87a7e2969408537de22f337b8fcec75972f483b9",
+      "public_source_role_projection_sha256": "0abb924c80a29b86bd1ef11b87a7e2969408537de22f337b8fcec75972f483b9",
+      "schema": 1,
+      "withheld_field_paths": []
+    }
+  },
+  "paper": "DSWG24DiscretizationBias",
+  "private_role_material_included": false,
+  "private_source_map_material_sha256": "508c0a7ae1961a04e1bb2780d926f108c185e495e5dc39289700ebddf7906c48",
+  "private_source_map_sha256": "e8ae7dfb703a07f19e31d29d918caf79535ca37810e9b48709207968ea437962",
+  "projection_contract_sha256": "ed0964edc9c70f5ce087ce9bf134712ca40c7964ecaefd403309ac9a1b47d34d",
+  "public_display_manifest_material_sha256": "8605404dd480cd94453a855293c79c655ac7307edc7db0a72146d110c7d9a1bd",
+  "public_display_manifest_sha256": "ce8df5176864d14ae9854e640b45da8b0f0c97532cd93c1e131652ba648fcd79",
+  "public_source_map_material_sha256": "3ba65aa7fafc4befcbd300655bc53d54dab6a4bd0ddfddc45be4376dc2eb0b16",
+  "public_source_map_sha256": "c4b16584e9dddb354e8a0fe89ed69ed2f04b927fa07009118e0d512aefc9a9f3",
+  "raw_private_approval_material_included": false,
+  "schema": 1
+}

--- a/papers/EOS07GSP/audit/paper_statement_map.json
+++ b/papers/EOS07GSP/audit/paper_statement_map.json
@@ -1136,6 +1136,11 @@
     "approval_material_included": false,
     "schema": 1
   },
+  "publication_source_display_projection": {
+    "manifest": "audit/public_source_display_projection.json",
+    "raw_source_bytes_included": false,
+    "schema": 1
+  },
   "schema": 1,
   "semantic_contract_schema": 1,
   "semantic_route_schema": 2,

--- a/papers/EOS07GSP/audit/public_source_role_projection.json
+++ b/papers/EOS07GSP/audit/public_source_role_projection.json
@@ -1,0 +1,176 @@
+{
+  "acceptance_credential": false,
+  "accepted_graph_sha256": "c15348a7dc0d3ae607fa7f28f30dc97dfc207cd8ae9643f259d5adcb7b0ea888",
+  "bindings_by_source_item": {
+    "definition4_locally_envy_free": {
+      "accepted_source_role_contract_sha256": "3f75a8175e9b5193276187527d0bba442196c3b978734a5361f8c147fc4f027c",
+      "public_source_role_projection_sha256": "c974636347aed45abe3cbb18ac31257e86f0eba7e172364d12b231323b176e7a",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "first_price_running_example_profitable_revision_chain": {
+      "accepted_source_role_contract_sha256": "24af3b57d5538434b02162eaed2147ad48cd373b770e44446d79c3c9a8da45f3",
+      "public_source_role_projection_sha256": "24af3b57d5538434b02162eaed2147ad48cd373b770e44446d79c3c9a8da45f3",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lemma5_locally_envy_free_stable": {
+      "accepted_source_role_contract_sha256": "6c1a577edfd4a98ac0a62782220e9b914134bf3a98403ae849b9736ea39486b4",
+      "public_source_role_projection_sha256": "9404acee16c81e5686e29aca722b7c40d6d2e84ee26fc2b803b7ff633a37a518",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "lemma6_tiebreak_ranked_gsp_stable_assignment_locally_envy_free": {
+      "accepted_source_role_contract_sha256": "418779c6b8bd567d0b3decfef2a4b37683556f123e701224737a4864e71b3dc8",
+      "public_source_role_projection_sha256": "70adfdfcd7cbc8fca470de07f4c9e5a8b9d9c83a84bc3868db31c1c9e30e7f3a",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "remark1_gsp_payments_weakly_dominate_vcg": {
+      "accepted_source_role_contract_sha256": "ff5a0e099e16c780ec0c807bad8030a1474e5e84b20ee9670ac2ec27355bdb21",
+      "public_source_role_projection_sha256": "ff5a0e099e16c780ec0c807bad8030a1474e5e84b20ee9670ac2ec27355bdb21",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "remark2_vcg_truthful": {
+      "accepted_source_role_contract_sha256": "ff5a0e099e16c780ec0c807bad8030a1474e5e84b20ee9670ac2ec27355bdb21",
+      "public_source_role_projection_sha256": "ff5a0e099e16c780ec0c807bad8030a1474e5e84b20ee9670ac2ec27355bdb21",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "remark3_gsp_not_truthful": {
+      "accepted_source_role_contract_sha256": "ff5a0e099e16c780ec0c807bad8030a1474e5e84b20ee9670ac2ec27355bdb21",
+      "public_source_role_projection_sha256": "ff5a0e099e16c780ec0c807bad8030a1474e5e84b20ee9670ac2ec27355bdb21",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "running_example_truthful_gsp_nash": {
+      "accepted_source_role_contract_sha256": "24af3b57d5538434b02162eaed2147ad48cd373b770e44446d79c3c9a8da45f3",
+      "public_source_role_projection_sha256": "24af3b57d5538434b02162eaed2147ad48cd373b770e44446d79c3c9a8da45f3",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "running_example_truthful_gsp_revenue_comparison": {
+      "accepted_source_role_contract_sha256": "24af3b57d5538434b02162eaed2147ad48cd373b770e44446d79c3c9a8da45f3",
+      "public_source_role_projection_sha256": "24af3b57d5538434b02162eaed2147ad48cd373b770e44446d79c3c9a8da45f3",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "stable_assignment": {
+      "accepted_source_role_contract_sha256": "4a5d5e0481f12028d09716bdc408f7660f44a95750daceeff5b45886ab5c7091",
+      "public_source_role_projection_sha256": "4a5d5e0481f12028d09716bdc408f7660f44a95750daceeff5b45886ab5c7091",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem7_bstar_locally_envy_free": {
+      "accepted_source_role_contract_sha256": "2cf34c715301ebc9b21e07b47b9355e99f508e3ed23a7dc403b9be804f6a0793",
+      "public_source_role_projection_sha256": "2cf34c715301ebc9b21e07b47b9355e99f508e3ed23a7dc403b9be804f6a0793",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem7_bstar_payment_identity": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem7_no_positive_transfer_conclusion": {
+      "accepted_source_role_contract_sha256": "204156d11677d0aa472c955f8fd8674399c5d427a41d5725a04bc60fb03a65bd",
+      "public_source_role_projection_sha256": "b30ace210ce002a55ad47a7859640d5ed1982df540fc496e8697e35d3a3f1400",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "theorem7_ranked_gsp_bstar_mechanism_realizes_bstar_outcome": {
+      "accepted_source_role_contract_sha256": "2cf34c715301ebc9b21e07b47b9355e99f508e3ed23a7dc403b9be804f6a0793",
+      "public_source_role_projection_sha256": "2cf34c715301ebc9b21e07b47b9355e99f508e3ed23a7dc403b9be804f6a0793",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem7_strict_tiebreak_gsp_comparison_conclusion": {
+      "accepted_source_role_contract_sha256": "2cf34c715301ebc9b21e07b47b9355e99f508e3ed23a7dc403b9be804f6a0793",
+      "public_source_role_projection_sha256": "2cf34c715301ebc9b21e07b47b9355e99f508e3ed23a7dc403b9be804f6a0793",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem8_continuous_generalized_english_payoff_game_strict_values_main_conclusion_review": {
+      "accepted_source_role_contract_sha256": "ad66a7c26bcd2a6b51fdfe625abfd147ecd0976194dec9dd2e28968c6dd2a798",
+      "public_source_role_projection_sha256": "625a59776ca4fa2170da153e09368c4385c796c5910b4e8d01a756e41246e30d",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "theorem8_continuous_source_local_best_response_support_unique_review": {
+      "accepted_source_role_contract_sha256": "6fa74d5c87122dd0a10b92405ecbdd0c140314e3a675524863c454d2ed080b98",
+      "public_source_role_projection_sha256": "6fa74d5c87122dd0a10b92405ecbdd0c140314e3a675524863c454d2ed080b98",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem8_dropout_formula_eq_bstar_threshold": {
+      "accepted_source_role_contract_sha256": "088ce5d27e745218e4d08ae1dcf8562d7328f678ffaa357a1cbcb8a5441ce796",
+      "public_source_role_projection_sha256": "088ce5d27e745218e4d08ae1dcf8562d7328f678ffaa357a1cbcb8a5441ce796",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem8_q_continuous_value_review": {
+      "accepted_source_role_contract_sha256": "088ce5d27e745218e4d08ae1dcf8562d7328f678ffaa357a1cbcb8a5441ce796",
+      "public_source_role_projection_sha256": "088ce5d27e745218e4d08ae1dcf8562d7328f678ffaa357a1cbcb8a5441ce796",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem8_q_mem_interval_review": {
+      "accepted_source_role_contract_sha256": "088ce5d27e745218e4d08ae1dcf8562d7328f678ffaa357a1cbcb8a5441ce796",
+      "public_source_role_projection_sha256": "088ce5d27e745218e4d08ae1dcf8562d7328f678ffaa357a1cbcb8a5441ce796",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem8_q_step1_dropping_after_q_review": {
+      "accepted_source_role_contract_sha256": "6fa74d5c87122dd0a10b92405ecbdd0c140314e3a675524863c454d2ed080b98",
+      "public_source_role_projection_sha256": "6fa74d5c87122dd0a10b92405ecbdd0c140314e3a675524863c454d2ed080b98",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem8_q_step2_waiting_before_q_review": {
+      "accepted_source_role_contract_sha256": "6fa74d5c87122dd0a10b92405ecbdd0c140314e3a675524863c454d2ed080b98",
+      "public_source_role_projection_sha256": "6fa74d5c87122dd0a10b92405ecbdd0c140314e3a675524863c454d2ed080b98",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem8_q_strict_mem_interval_review": {
+      "accepted_source_role_contract_sha256": "088ce5d27e745218e4d08ae1dcf8562d7328f678ffaa357a1cbcb8a5441ce796",
+      "public_source_role_projection_sha256": "088ce5d27e745218e4d08ae1dcf8562d7328f678ffaa357a1cbcb8a5441ce796",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem8_strict_values_ex_post_local_deviation": {
+      "accepted_source_role_contract_sha256": "6fa74d5c87122dd0a10b92405ecbdd0c140314e3a675524863c454d2ed080b98",
+      "public_source_role_projection_sha256": "6fa74d5c87122dd0a10b92405ecbdd0c140314e3a675524863c454d2ed080b98",
+      "schema": 1,
+      "withheld_field_paths": []
+    }
+  },
+  "paper": "EOS07GSP",
+  "private_role_material_included": false,
+  "private_source_map_material_sha256": "52558f185eac202514762f934614750a586d0f0a787d26be4c3aba454a2fcdb3",
+  "private_source_map_sha256": "a381fa2f08bc7f17eb15bcf65463eaa8d6c6ac13e53c65c8486d6dbe1a4a092b",
+  "projection_contract_sha256": "ed0964edc9c70f5ce087ce9bf134712ca40c7964ecaefd403309ac9a1b47d34d",
+  "public_display_manifest_material_sha256": "9b5a4a4bc678998626e44772d4822e5e4e087e2d80d06400ffcaed28665c6fdd",
+  "public_display_manifest_sha256": "f107fbc60d64e4c67f9cc0e0fefdd0f2713c93b78c1d72b374ac2b73733d62cf",
+  "public_source_map_material_sha256": "b6b24d702deef0c30e43ae506c0e54ce5a0b2f9e80cc04d7ff3b38a64689362c",
+  "public_source_map_sha256": "7ee21bbba7ac8a2867b1d79aad77fee424bde86d0d1db585ecb09fa32addbbc7",
+  "raw_private_approval_material_included": false,
+  "schema": 1
+}

--- a/papers/FalahatgarEtAl2017MaxingRanking/audit/paper_statement_map.json
+++ b/papers/FalahatgarEtAl2017MaxingRanking/audit/paper_statement_map.json
@@ -1504,6 +1504,11 @@
     "approval_material_included": false,
     "schema": 1
   },
+  "publication_source_display_projection": {
+    "manifest": "audit/public_source_display_projection.json",
+    "raw_source_bytes_included": false,
+    "schema": 1
+  },
   "schema": 1,
   "semantic_contract_schema": 1,
   "semantic_route_schema": 2,

--- a/papers/FalahatgarEtAl2017MaxingRanking/audit/public_source_display_projection.json
+++ b/papers/FalahatgarEtAl2017MaxingRanking/audit/public_source_display_projection.json
@@ -1,15 +1,13 @@
 {
   "generator": "python3 scripts/public_source_display_projection.py",
   "paper_id": "FalahatgarEtAl2017MaxingRanking",
-  "private_source_map_sha256": "f0b0580f46f823b9693d1f23de2488fec6ec9232c176808b2504811b69d30eb5",
+  "private_source_map_sha256": "041533c6b92f17b6dab44c087b5a0373838743b92bf075896c5e57408ab28dd3",
   "public_manifest_path": "papers/FalahatgarEtAl2017MaxingRanking/audit/public_source_display_projection.json",
-  "public_source_map_sha256": "e0322325e87e571855763b8b91aeb969ee4926a494728c513f8bc7795d6a5c06",
+  "public_source_map_sha256": "cb3e550a64bbe162bd8ce31fee2ff2e14634ddff785339c84695c15751edb868",
   "raw_source_artifact_included": false,
   "raw_source_display_material": "selected_byte_pinned_source_anchor_quotes",
   "schema": 1,
   "selected_source_item_ids": [
-    "algorithm2_prune",
-    "algorithm3_opt_maximize",
     "approximate_preference_vocabulary",
     "borda_vocabulary",
     "comparison_model",
@@ -41,30 +39,6 @@
     "theorem9"
   ],
   "selected_source_items": {
-    "algorithm2_prune": {
-      "source_anchors": [
-        {
-          "line_end": 324,
-          "line_start": 308,
-          "publication_locator": "cited publication",
-          "quoted_text": "\fAlgorithm 2 P RUNE\n 1: inputs\n 2:   Set S, element a, size n′ , lower bias εl , upper bias εu , confidence δ.\n 3: t ← 1\n 4: S1 ← S\n                                   2\n 5: while ∣St ∣ > 2n′ and t < log n do\n 6:   Initialize: Qt ← ∅\n 7:   for e in St do\n 8:      if C OMPARE(e, a, εl , εu , δ/2t+1 ) = 1 then\n 9:         Qt ← Qt ⋃{e}\n10:      end if\n11:   end for\n12:   St+1 ← St ∖ Qt\n13:   t←t+1\n14: end while\n15: return St .",
-          "quoted_text_sha256": "87856fad50592758dec7727cf854b466e352adb1a44f78fe97284f416b8a6a16"
-        }
-      ],
-      "source_kind": "algorithm"
-    },
-    "algorithm3_opt_maximize": {
-      "source_anchors": [
-        {
-          "line_end": 391,
-          "line_start": 375,
-          "publication_locator": "cited publication",
-          "quoted_text": "\fAlgorithm 3 O PT-M AXIMIZE\n 1: inputs\n 2:    Set S, bias ε, confidence δ.\n 3: if δ ≤ n1 then\n 4:    return S EQ -E LIMINATE(S, ε, δ)\n 5: end if                    √\n 6: a ← P ICK -A NCHOR(S, 6n log n, ε/3, 4δ )\n                         √\n 7: S ′ ← P RUNE(S, a, 6n log n, ε/3, 2ε/3, 4δ )\n 8: for element e in S ′ do\n 9:    if C OMPARE(e, a, 2ε3\n                                   δ\n                             , ε, 4n ) = 2 then\n10:      return S EQ -E LIMINATE(S ′ , ε, 4δ )\n11:   end if\n12: end for\n13: return a",
-          "quoted_text_sha256": "e5961e520770e304d779876de8b646de0a4098dbde83afabe582064834f3de2e"
-        }
-      ],
-      "source_kind": "algorithm"
-    },
     "approximate_preference_vocabulary": {
       "source_anchors": [
         {

--- a/papers/FalahatgarEtAl2017MaxingRanking/audit/public_source_role_projection.json
+++ b/papers/FalahatgarEtAl2017MaxingRanking/audit/public_source_role_projection.json
@@ -1,0 +1,251 @@
+{
+  "acceptance_credential": false,
+  "accepted_graph_sha256": "5849c9e722f59e767e9d99ae5d3a0a579547d5aba92640ac9fb5507575e461e1",
+  "bindings_by_source_item": {
+    "algorithm1_seq_eliminate": {
+      "accepted_source_role_contract_sha256": "48e39d93ab7e5f12d6c9d8a7a617c398d392fc3c5b98eeb0320c2bb31df88e0a",
+      "public_source_role_projection_sha256": "48e39d93ab7e5f12d6c9d8a7a617c398d392fc3c5b98eeb0320c2bb31df88e0a",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "algorithm2_prune": {
+      "accepted_source_role_contract_sha256": "48e39d93ab7e5f12d6c9d8a7a617c398d392fc3c5b98eeb0320c2bb31df88e0a",
+      "public_source_role_projection_sha256": "48e39d93ab7e5f12d6c9d8a7a617c398d392fc3c5b98eeb0320c2bb31df88e0a",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "algorithm3_opt_maximize": {
+      "accepted_source_role_contract_sha256": "48e39d93ab7e5f12d6c9d8a7a617c398d392fc3c5b98eeb0320c2bb31df88e0a",
+      "public_source_role_projection_sha256": "48e39d93ab7e5f12d6c9d8a7a617c398d392fc3c5b98eeb0320c2bb31df88e0a",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "algorithm4_compare": {
+      "accepted_source_role_contract_sha256": "48e39d93ab7e5f12d6c9d8a7a617c398d392fc3c5b98eeb0320c2bb31df88e0a",
+      "public_source_role_projection_sha256": "48e39d93ab7e5f12d6c9d8a7a617c398d392fc3c5b98eeb0320c2bb31df88e0a",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "algorithm5_pick_anchor": {
+      "accepted_source_role_contract_sha256": "48e39d93ab7e5f12d6c9d8a7a617c398d392fc3c5b98eeb0320c2bb31df88e0a",
+      "public_source_role_projection_sha256": "48e39d93ab7e5f12d6c9d8a7a617c398d392fc3c5b98eeb0320c2bb31df88e0a",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "algorithm6_estimate_probability": {
+      "accepted_source_role_contract_sha256": "48e39d93ab7e5f12d6c9d8a7a617c398d392fc3c5b98eeb0320c2bb31df88e0a",
+      "public_source_role_projection_sha256": "48e39d93ab7e5f12d6c9d8a7a617c398d392fc3c5b98eeb0320c2bb31df88e0a",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "algorithm7_strong_transitivity_ranking": {
+      "accepted_source_role_contract_sha256": "48e39d93ab7e5f12d6c9d8a7a617c398d392fc3c5b98eeb0320c2bb31df88e0a",
+      "public_source_role_projection_sha256": "48e39d93ab7e5f12d6c9d8a7a617c398d392fc3c5b98eeb0320c2bb31df88e0a",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "algorithm8_estimate_borda_score": {
+      "accepted_source_role_contract_sha256": "48e39d93ab7e5f12d6c9d8a7a617c398d392fc3c5b98eeb0320c2bb31df88e0a",
+      "public_source_role_projection_sha256": "48e39d93ab7e5f12d6c9d8a7a617c398d392fc3c5b98eeb0320c2bb31df88e0a",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "algorithm9_borda_ranking": {
+      "accepted_source_role_contract_sha256": "48e39d93ab7e5f12d6c9d8a7a617c398d392fc3c5b98eeb0320c2bb31df88e0a",
+      "public_source_role_projection_sha256": "48e39d93ab7e5f12d6c9d8a7a617c398d392fc3c5b98eeb0320c2bb31df88e0a",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "approximate_preference_vocabulary": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "borda_vocabulary": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "comparison_model": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "exact_preference_vocabulary": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "good_anchor_definition": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lemma1": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lemma10": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lemma11": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lemma12": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lemma13": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lemma14": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lemma15": {
+      "accepted_source_role_contract_sha256": "009c4f26b07caf3191735b63831a205192ff82be5b61d8525e5a2fcb1f9b4632",
+      "public_source_role_projection_sha256": "08f8e126d473951888247e180aaf27c947ec73f3a59d01994f9d06f8c48801f9",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "lemma16": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lemma17": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lemma18": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lemma19": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lemma20": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lemma21": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lemma3": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lemma5": {
+      "accepted_source_role_contract_sha256": "cbb020f963d44aeed401c13a497f5dd4d19edf8ec943d66ebf0473a3ce7a653c",
+      "public_source_role_projection_sha256": "aaebe0192e8e2664c7f2a20aa5a207b145d6fe9c395bc417740fe3cce8235933",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "remark4": {
+      "accepted_source_role_contract_sha256": "ff5a0e099e16c780ec0c807bad8030a1474e5e84b20ee9670ac2ec27355bdb21",
+      "public_source_role_projection_sha256": "ff5a0e099e16c780ec0c807bad8030a1474e5e84b20ee9670ac2ec27355bdb21",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "sst_maximum_ranking_existence": {
+      "accepted_source_role_contract_sha256": "ff5a0e099e16c780ec0c807bad8030a1474e5e84b20ee9670ac2ec27355bdb21",
+      "public_source_role_projection_sha256": "ff5a0e099e16c780ec0c807bad8030a1474e5e84b20ee9670ac2ec27355bdb21",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "strong_stochastic_transitivity": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem2": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem22": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem6": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem7": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem8": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem9": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    }
+  },
+  "paper": "FalahatgarEtAl2017MaxingRanking",
+  "private_role_material_included": false,
+  "private_source_map_material_sha256": "c219ac5be27083b182d564cfba5f62b2c6ba5f321c41b10d314a6617e598731e",
+  "private_source_map_sha256": "041533c6b92f17b6dab44c087b5a0373838743b92bf075896c5e57408ab28dd3",
+  "projection_contract_sha256": "ed0964edc9c70f5ce087ce9bf134712ca40c7964ecaefd403309ac9a1b47d34d",
+  "public_display_manifest_material_sha256": "7b2baa2fb905529db27ca6330e3ff01de3bb67189221f535583dc18b4bafe0d8",
+  "public_display_manifest_sha256": "5f6dd0c2fbb47a075a4a4c3f3dbe759334df9a0a2854ddbef33d9338628b99cc",
+  "public_source_map_material_sha256": "ba3e832d3379fd21f2e6d2820392a967082f15804ffa7155a5265c673814a275",
+  "public_source_map_sha256": "cb3e550a64bbe162bd8ce31fee2ff2e14634ddff785339c84695c15751edb868",
+  "raw_private_approval_material_included": false,
+  "schema": 1
+}

--- a/papers/FreundSchapire1997Hedge/audit/paper_statement_map.json
+++ b/papers/FreundSchapire1997Hedge/audit/paper_statement_map.json
@@ -1309,6 +1309,11 @@
     "approval_material_included": false,
     "schema": 1
   },
+  "publication_source_display_projection": {
+    "manifest": "audit/public_source_display_projection.json",
+    "raw_source_bytes_included": false,
+    "schema": 1
+  },
   "schema": 1,
   "semantic_contract_schema": 1,
   "semantic_route_schema": 2,

--- a/papers/FreundSchapire1997Hedge/audit/public_source_role_projection.json
+++ b/papers/FreundSchapire1997Hedge/audit/public_source_role_projection.json
@@ -1,0 +1,129 @@
+{
+  "acceptance_credential": false,
+  "accepted_graph_sha256": "4180e0183b0ff5ea89961f4efe094316ec6b32a1a420d3e59401b33dd769b852",
+  "bindings_by_source_item": {
+    "equation21_adaboost_binary_kl": {
+      "accepted_source_role_contract_sha256": "e7960301914702af45e2b6b68d20aef532fe8473849db58c6eda39068f6de8d1",
+      "public_source_role_projection_sha256": "e7960301914702af45e2b6b68d20aef532fe8473849db58c6eda39068f6de8d1",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "equation22_adaboost_uniform_edge": {
+      "accepted_source_role_contract_sha256": "e7960301914702af45e2b6b68d20aef532fe8473849db58c6eda39068f6de8d1",
+      "public_source_role_projection_sha256": "e7960301914702af45e2b6b68d20aef532fe8473849db58c6eda39068f6de8d1",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "equation23_adaboost_iteration_budget": {
+      "accepted_source_role_contract_sha256": "e7960301914702af45e2b6b68d20aef532fe8473849db58c6eda39068f6de8d1",
+      "public_source_role_projection_sha256": "e7960301914702af45e2b6b68d20aef532fe8473849db58c6eda39068f6de8d1",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lemma1_weight_potential": {
+      "accepted_source_role_contract_sha256": "b005b5b793062aaed684f79e195507f5430889245bce11b448b5ab2ae6560f2e",
+      "public_source_role_projection_sha256": "fa251a3a73eccc258500b4a90484b05109520549c2b7adb51af34034f41c2e0b",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval"
+      ]
+    },
+    "lemma4_learning_rate_bound": {
+      "accepted_source_role_contract_sha256": "af94d00afee58bec8011e79938e24f8ea56c2a7fd831f41557e7360d7becedc4",
+      "public_source_role_projection_sha256": "5a8151f64df90cb22eeeb94544ac78a0d6b7b82157de06c8e6257710de0445d6",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval"
+      ]
+    },
+    "theorem10_adaboost_m1_error": {
+      "accepted_source_role_contract_sha256": "8574a67d7eab599a924cbe8e307a2eeee5098ba87041d7b9b7e08159c2b5e6c9",
+      "public_source_role_projection_sha256": "c3cea63469d608c1079a67f44eb95fbf9de879f52e0512b3e5c9331dfe99eb23",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval"
+      ]
+    },
+    "theorem11_adaboost_m2_error": {
+      "accepted_source_role_contract_sha256": "3d3bf5dde13eb67cf5790f2cfa5c5de4fe5c4e814b3a3a309f5cf4a71e580d7a",
+      "public_source_role_projection_sha256": "17cc8484bd728921e30033cac5101efe6ba68ad33bcb1139fed039a3f73358b7",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval"
+      ]
+    },
+    "theorem12_adaboost_r_error": {
+      "accepted_source_role_contract_sha256": "7d421e1d292fd46a0cd7901e128e3983f4f756bd41f74547d87293557177011f",
+      "public_source_role_projection_sha256": "573ffabadb20d67982c71dbd5e63f09405f9a035bdac92810ac835c85d0e9822",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval"
+      ]
+    },
+    "theorem13_vovk_boundedness_characterization": {
+      "accepted_source_role_contract_sha256": "20c633df275cabd35f3ea71b10686fa1e6b6fc4981d01fbceffe32fe805444eb",
+      "public_source_role_projection_sha256": "20c633df275cabd35f3ea71b10686fa1e6b6fc4981d01fbceffe32fe805444eb",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem2_hedge_comparator_bounds": {
+      "accepted_source_role_contract_sha256": "fffc37784c8d30acc6b4b8abede6c9ebc1d80aea53cc9f302c9398a0cb5b7bd7",
+      "public_source_role_projection_sha256": "b8288f5226882188dbab28dff4c49fc8320fd83dd1d14c9519c6e5cd8a33ef24",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval"
+      ]
+    },
+    "theorem3_global_allocation_lower_tradeoff": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem5_decision_prediction_general": {
+      "accepted_source_role_contract_sha256": "4603125e40462f9d24eb5f86b218e0bc9781d14b40072bf7d3852d9816d4eb3f",
+      "public_source_role_projection_sha256": "675afa1ef3ea064cfcbd4a1ecddd534107c7320b6d6f28d5eec46f6ce3eb2213",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval"
+      ]
+    },
+    "theorem6_adaboost_error": {
+      "accepted_source_role_contract_sha256": "eea2e728d00d17aed82127a3561579363c1a16a84be1f07d7e834911250deaf5",
+      "public_source_role_projection_sha256": "3b82c28e653e95675e6ac4c8a7a36a07720c17400fb4f877c3b88c5b0f60ed8e",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval"
+      ]
+    },
+    "theorem7_vapnik_generalization_bound": {
+      "accepted_source_role_contract_sha256": "20c633df275cabd35f3ea71b10686fa1e6b6fc4981d01fbceffe32fe805444eb",
+      "public_source_role_projection_sha256": "20c633df275cabd35f3ea71b10686fa1e6b6fc4981d01fbceffe32fe805444eb",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem8_weighted_threshold_vc": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem9_soft_adaboost_error": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    }
+  },
+  "paper": "FreundSchapire1997Hedge",
+  "private_role_material_included": false,
+  "private_source_map_material_sha256": "1625aa6c2e1d243addc1318768a12db01987acce69836a1ed8866790a4ae12ab",
+  "private_source_map_sha256": "d11fc34eb535f4362054eeb740d23fd306eb7c9de5106f81dc389b4aa1da534d",
+  "projection_contract_sha256": "ed0964edc9c70f5ce087ce9bf134712ca40c7964ecaefd403309ac9a1b47d34d",
+  "public_display_manifest_material_sha256": "12986909d24bc8338b3d32032d425d403f6d02af8b64184c9c0f3049ac3ecece",
+  "public_display_manifest_sha256": "d400f054c5b73f9caf95beffc15d620709cff4f9cc3942e4bc0d9ca7276d177a",
+  "public_source_map_material_sha256": "4ed2022a7ca083e8772e736218d60c51b3c7d30c1fbdce2c1611d75e1df8e9ce",
+  "public_source_map_sha256": "4d62b677d9ff6f686727494b9e45d127e200f1c62447e3678b2110f9fe5f89ca",
+  "raw_private_approval_material_included": false,
+  "schema": 1
+}

--- a/papers/GCG24UserItemFairness/audit/paper_statement_map.json
+++ b/papers/GCG24UserItemFairness/audit/paper_statement_map.json
@@ -2858,6 +2858,11 @@
     "approval_material_included": false,
     "schema": 1
   },
+  "publication_source_display_projection": {
+    "manifest": "audit/public_source_display_projection.json",
+    "raw_source_bytes_included": false,
+    "schema": 1
+  },
   "schema": 1,
   "semantic_contract_schema": 1,
   "semantic_route_schema": 2,

--- a/papers/GCG24UserItemFairness/audit/public_source_role_projection.json
+++ b/papers/GCG24UserItemFairness/audit/public_source_role_projection.json
@@ -1,0 +1,473 @@
+{
+  "acceptance_credential": false,
+  "accepted_graph_sha256": "e9df2a6817bef27523e8f49b054f0a47994c0bccb01740d2302dd4c1b6b8b02c",
+  "bindings_by_source_item": {
+    "appendix_c_lemma2_item_fairness_equality_lp_solution_set": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "appendix_c_lemma2_item_fairness_equality_lp_solution_set_proof_presentation": {
+      "accepted_source_role_contract_sha256": "06314758836e13a85a5bfb2b8461b35a83af82fe5dc0672f8fafca8ced1dda74",
+      "public_source_role_projection_sha256": "06314758836e13a85a5bfb2b8461b35a83af82fe5dc0672f8fafca8ced1dda74",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "assumption_positive_recommendation_utilities": {
+      "accepted_source_role_contract_sha256": "10d3b168adc54f4f65034bf4056bf824f46ba8a384f57936a80b50242dd4daa6",
+      "public_source_role_projection_sha256": "10d3b168adc54f4f65034bf4056bf824f46ba8a384f57936a80b50242dd4daa6",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "assumption_theorem3_first_half_alpha_domain": {
+      "accepted_source_role_contract_sha256": "10d3b168adc54f4f65034bf4056bf824f46ba8a384f57936a80b50242dd4daa6",
+      "public_source_role_projection_sha256": "10d3b168adc54f4f65034bf4056bf824f46ba8a384f57936a80b50242dd4daa6",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "assumption_theorem3_opposing_type_model": {
+      "accepted_source_role_contract_sha256": "10d3b168adc54f4f65034bf4056bf824f46ba8a384f57936a80b50242dd4daa6",
+      "public_source_role_projection_sha256": "10d3b168adc54f4f65034bf4056bf824f46ba8a384f57936a80b50242dd4daa6",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "assumption_theorem3_second_half_alpha_domain": {
+      "accepted_source_role_contract_sha256": "10d3b168adc54f4f65034bf4056bf824f46ba8a384f57936a80b50242dd4daa6",
+      "public_source_role_projection_sha256": "10d3b168adc54f4f65034bf4056bf824f46ba8a384f57936a80b50242dd4daa6",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "assumption_theorem4_at_least_three_items": {
+      "accepted_source_role_contract_sha256": "10d3b168adc54f4f65034bf4056bf824f46ba8a384f57936a80b50242dd4daa6",
+      "public_source_role_projection_sha256": "10d3b168adc54f4f65034bf4056bf824f46ba8a384f57936a80b50242dd4daa6",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "assumption_theorem4_cold_start_type_wiring": {
+      "accepted_source_role_contract_sha256": "10d3b168adc54f4f65034bf4056bf824f46ba8a384f57936a80b50242dd4daa6",
+      "public_source_role_projection_sha256": "10d3b168adc54f4f65034bf4056bf824f46ba8a384f57936a80b50242dd4daa6",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "assumption_theorem4_displayed_reduced_models": {
+      "accepted_source_role_contract_sha256": "10d3b168adc54f4f65034bf4056bf824f46ba8a384f57936a80b50242dd4daa6",
+      "public_source_role_projection_sha256": "10d3b168adc54f4f65034bf4056bf824f46ba8a384f57936a80b50242dd4daa6",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "assumption_theorem4_estimated_model_reduction": {
+      "accepted_source_role_contract_sha256": "10d3b168adc54f4f65034bf4056bf824f46ba8a384f57936a80b50242dd4daa6",
+      "public_source_role_projection_sha256": "10d3b168adc54f4f65034bf4056bf824f46ba8a384f57936a80b50242dd4daa6",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "assumption_theorem4_parameter_domain": {
+      "accepted_source_role_contract_sha256": "10d3b168adc54f4f65034bf4056bf824f46ba8a384f57936a80b50242dd4daa6",
+      "public_source_role_projection_sha256": "10d3b168adc54f4f65034bf4056bf824f46ba8a384f57936a80b50242dd4daa6",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "assumption_theorem4_true_model_reduction": {
+      "accepted_source_role_contract_sha256": "10d3b168adc54f4f65034bf4056bf824f46ba8a384f57936a80b50242dd4daa6",
+      "public_source_role_projection_sha256": "10d3b168adc54f4f65034bf4056bf824f46ba8a384f57936a80b50242dd4daa6",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "assumption_theorem4_universal_value_vector": {
+      "accepted_source_role_contract_sha256": "10d3b168adc54f4f65034bf4056bf824f46ba8a384f57936a80b50242dd4daa6",
+      "public_source_role_projection_sha256": "10d3b168adc54f4f65034bf4056bf824f46ba8a384f57936a80b50242dd4daa6",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "audit_appendix_e_lemma15_printed_center_counterexample": {
+      "accepted_source_role_contract_sha256": "2f781ccac18b9456d44bed80028730188e98669be23ab77632dde773d10d03c4",
+      "public_source_role_projection_sha256": "2f781ccac18b9456d44bed80028730188e98669be23ab77632dde773d10d03c4",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "itemFairness": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "itemNormalizer": {
+      "accepted_source_role_contract_sha256": "1013bac0f64d961cf710c45bb3ffa3c3e7f4a01364f2c91a5854886aa5488ca1",
+      "public_source_role_projection_sha256": "1013bac0f64d961cf710c45bb3ffa3c3e7f4a01364f2c91a5854886aa5488ca1",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "model_proposition2_equality_defined_type_partition": {
+      "accepted_source_role_contract_sha256": "cb4c52d7162057fe79d176483b8606eae69ef415544ac40e16cd2b0dd1287867",
+      "public_source_role_projection_sha256": "cb4c52d7162057fe79d176483b8606eae69ef415544ac40e16cd2b0dd1287867",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "normalizedItemUtility": {
+      "accepted_source_role_contract_sha256": "1013bac0f64d961cf710c45bb3ffa3c3e7f4a01364f2c91a5854886aa5488ca1",
+      "public_source_role_projection_sha256": "1013bac0f64d961cf710c45bb3ffa3c3e7f4a01364f2c91a5854886aa5488ca1",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "normalizedUserUtility": {
+      "accepted_source_role_contract_sha256": "1013bac0f64d961cf710c45bb3ffa3c3e7f4a01364f2c91a5854886aa5488ca1",
+      "public_source_role_projection_sha256": "1013bac0f64d961cf710c45bb3ffa3c3e7f4a01364f2c91a5854886aa5488ca1",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "priceOfFairness": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "priceOfFairnessAt": {
+      "accepted_source_role_contract_sha256": "2aaf7c890c1f07219efc7866d58de2054ba340b5c30cc595f524608dd0049f2a",
+      "public_source_role_projection_sha256": "2aaf7c890c1f07219efc7866d58de2054ba340b5c30cc595f524608dd0049f2a",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "priceOfMisestimation": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "problem11BasicFeasible": {
+      "accepted_source_role_contract_sha256": "19f3c3198275beddf106c0578e1b854122d7060121a70a8735b5fbe5ed3acc78",
+      "public_source_role_projection_sha256": "19f3c3198275beddf106c0578e1b854122d7060121a70a8735b5fbe5ed3acc78",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "problem11EqualityFeasibleSet": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "proposition1_symmetric_lp_reduction": {
+      "accepted_source_role_contract_sha256": "64a83a0ae6edbdb2d3cfb6cb84e3bf045734ef9303f62643ff780eff69b02885",
+      "public_source_role_projection_sha256": "64a83a0ae6edbdb2d3cfb6cb84e3bf045734ef9303f62643ff780eff69b02885",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "proposition1_symmetric_lp_reduction_proof_presentation": {
+      "accepted_source_role_contract_sha256": "f6219d29e655cb81f1bbf1cddd4cad8536f81fed7bde5e2a7974535920df7f44",
+      "public_source_role_projection_sha256": "f6219d29e655cb81f1bbf1cddd4cad8536f81fed7bde5e2a7974535920df7f44",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "proposition2_symmetric_optimum_exists": {
+      "accepted_source_role_contract_sha256": "64a83a0ae6edbdb2d3cfb6cb84e3bf045734ef9303f62643ff780eff69b02885",
+      "public_source_role_projection_sha256": "64a83a0ae6edbdb2d3cfb6cb84e3bf045734ef9303f62643ff780eff69b02885",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "proposition2_symmetric_optimum_exists_proof_presentation": {
+      "accepted_source_role_contract_sha256": "f6219d29e655cb81f1bbf1cddd4cad8536f81fed7bde5e2a7974535920df7f44",
+      "public_source_role_projection_sha256": "f6219d29e655cb81f1bbf1cddd4cad8536f81fed7bde5e2a7974535920df7f44",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "rawItemUtility": {
+      "accepted_source_role_contract_sha256": "1013bac0f64d961cf710c45bb3ffa3c3e7f4a01364f2c91a5854886aa5488ca1",
+      "public_source_role_projection_sha256": "1013bac0f64d961cf710c45bb3ffa3c3e7f4a01364f2c91a5854886aa5488ca1",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "rawUserUtility": {
+      "accepted_source_role_contract_sha256": "1013bac0f64d961cf710c45bb3ffa3c3e7f4a01364f2c91a5854886aa5488ca1",
+      "public_source_role_projection_sha256": "1013bac0f64d961cf710c45bb3ffa3c3e7f4a01364f2c91a5854886aa5488ca1",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "recommendationUtility": {
+      "accepted_source_role_contract_sha256": "e8bd731c387f27f23e485836c19e8cd56ab3be13060fd6b4343e29952fe8b856",
+      "public_source_role_projection_sha256": "e8bd731c387f27f23e485836c19e8cd56ab3be13060fd6b4343e29952fe8b856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "solvesProblemOne": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_appendix_c_lemma1_item_fairness_positive": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_appendix_d_lemma10_midpoint_candidate": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_appendix_d_lemma10_midpoint_candidate_proof_presentation": {
+      "accepted_source_role_contract_sha256": "06314758836e13a85a5bfb2b8461b35a83af82fe5dc0672f8fafca8ced1dda74",
+      "public_source_role_projection_sha256": "06314758836e13a85a5bfb2b8461b35a83af82fe5dc0672f8fafca8ced1dda74",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_appendix_d_lemma11_denominator_monotonicity": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_appendix_d_lemma11_denominator_monotonicity_proof_presentation": {
+      "accepted_source_role_contract_sha256": "06314758836e13a85a5bfb2b8461b35a83af82fe5dc0672f8fafca8ced1dda74",
+      "public_source_role_projection_sha256": "06314758836e13a85a5bfb2b8461b35a83af82fe5dc0672f8fafca8ced1dda74",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_appendix_d_lemma3_unconstrained_baseline": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_appendix_d_lemma3_unconstrained_baseline_proof_presentation": {
+      "accepted_source_role_contract_sha256": "06314758836e13a85a5bfb2b8461b35a83af82fe5dc0672f8fafca8ced1dda74",
+      "public_source_role_projection_sha256": "06314758836e13a85a5bfb2b8461b35a83af82fe5dc0672f8fafca8ced1dda74",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_appendix_d_lemma4_problem6_structure": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_appendix_d_lemma4_problem6_structure_proof_presentation": {
+      "accepted_source_role_contract_sha256": "06314758836e13a85a5bfb2b8461b35a83af82fe5dc0672f8fafca8ced1dda74",
+      "public_source_role_projection_sha256": "06314758836e13a85a5bfb2b8461b35a83af82fe5dc0672f8fafca8ced1dda74",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_appendix_d_lemma5_problem6_closed_form": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_appendix_d_lemma5_problem6_closed_form_proof_presentation": {
+      "accepted_source_role_contract_sha256": "06314758836e13a85a5bfb2b8461b35a83af82fe5dc0672f8fafca8ced1dda74",
+      "public_source_role_projection_sha256": "06314758836e13a85a5bfb2b8461b35a83af82fe5dc0672f8fafca8ced1dda74",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_appendix_d_lemma6_mirror_inverse_gap": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_appendix_d_lemma6_mirror_inverse_gap_proof_presentation": {
+      "accepted_source_role_contract_sha256": "06314758836e13a85a5bfb2b8461b35a83af82fe5dc0672f8fafca8ced1dda74",
+      "public_source_role_projection_sha256": "06314758836e13a85a5bfb2b8461b35a83af82fe5dc0672f8fafca8ced1dda74",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_appendix_d_lemma7_pivot_monotonicity": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_appendix_d_lemma7_pivot_monotonicity_proof_presentation": {
+      "accepted_source_role_contract_sha256": "06314758836e13a85a5bfb2b8461b35a83af82fe5dc0672f8fafca8ced1dda74",
+      "public_source_role_projection_sha256": "06314758836e13a85a5bfb2b8461b35a83af82fe5dc0672f8fafca8ced1dda74",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_appendix_d_lemma8_selected_pivot_stitching": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_appendix_d_lemma8_selected_pivot_stitching_proof_presentation": {
+      "accepted_source_role_contract_sha256": "06314758836e13a85a5bfb2b8461b35a83af82fe5dc0672f8fafca8ced1dda74",
+      "public_source_role_projection_sha256": "06314758836e13a85a5bfb2b8461b35a83af82fe5dc0672f8fafca8ced1dda74",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_appendix_d_lemma9_pair_share_algebra": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_appendix_d_lemma9_pair_share_algebra_proof_presentation": {
+      "accepted_source_role_contract_sha256": "06314758836e13a85a5bfb2b8461b35a83af82fe5dc0672f8fafca8ced1dda74",
+      "public_source_role_projection_sha256": "06314758836e13a85a5bfb2b8461b35a83af82fe5dc0672f8fafca8ced1dda74",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_appendix_e_lemma12_symmetrized_policy": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_appendix_e_lemma12_symmetrized_policy_proof_presentation": {
+      "accepted_source_role_contract_sha256": "06314758836e13a85a5bfb2b8461b35a83af82fe5dc0672f8fafca8ced1dda74",
+      "public_source_role_projection_sha256": "06314758836e13a85a5bfb2b8461b35a83af82fe5dc0672f8fafca8ced1dda74",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_appendix_e_lemma13_pivot_support": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_appendix_e_lemma13_pivot_support_proof_presentation": {
+      "accepted_source_role_contract_sha256": "06314758836e13a85a5bfb2b8461b35a83af82fe5dc0672f8fafca8ced1dda74",
+      "public_source_role_projection_sha256": "06314758836e13a85a5bfb2b8461b35a83af82fe5dc0672f8fafca8ced1dda74",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_appendix_e_lemma14_uniqueness": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_appendix_e_lemma14_uniqueness_proof_presentation": {
+      "accepted_source_role_contract_sha256": "06314758836e13a85a5bfb2b8461b35a83af82fe5dc0672f8fafca8ced1dda74",
+      "public_source_role_projection_sha256": "06314758836e13a85a5bfb2b8461b35a83af82fe5dc0672f8fafca8ced1dda74",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_appendix_e_lemma15_closed_formula": {
+      "accepted_source_role_contract_sha256": "b01fe9ae8493431f17ba5f594835acb0ef813c99a1ad7a3ece5934f014b41a2a",
+      "public_source_role_projection_sha256": "eed54ab3457c64bf7501eb1ab8234e0de643ad6da649386a292beb1dd2216c51",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "source_appendix_e_lemma15_closed_formula_proof_presentation": {
+      "accepted_source_role_contract_sha256": "06314758836e13a85a5bfb2b8461b35a83af82fe5dc0672f8fafca8ced1dda74",
+      "public_source_role_projection_sha256": "06314758836e13a85a5bfb2b8461b35a83af82fe5dc0672f8fafca8ced1dda74",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_appendix_e_lemma15_printed_center_formula": {
+      "accepted_source_role_contract_sha256": "7605b117da77dd852c4483d7a1593014f819ef8349fb9e5a5f0c2f92b7a31db0",
+      "public_source_role_projection_sha256": "7605b117da77dd852c4483d7a1593014f819ef8349fb9e5a5f0c2f92b7a31db0",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_appendix_e_lemma16_midpoint_order_algebra": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_appendix_e_lemma17_no_right_half_support": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_appendix_e_lemma17_no_right_half_support_proof_presentation": {
+      "accepted_source_role_contract_sha256": "06314758836e13a85a5bfb2b8461b35a83af82fe5dc0672f8fafca8ced1dda74",
+      "public_source_role_projection_sha256": "06314758836e13a85a5bfb2b8461b35a83af82fe5dc0672f8fafca8ced1dda74",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_example1_diverse_item_fairness": {
+      "accepted_source_role_contract_sha256": "ab2e10bba5209f916b3118da33aecadff0441da901fc2904eb7406db00dd018f",
+      "public_source_role_projection_sha256": "b574ecb5f9b95bbefe00e4ef2aecb0cf599aa24cbde8cd8724b47d4ccedf3357",
+      "schema": 1,
+      "withheld_field_paths": [
+        "user_approved_scope_exclusion.approval_reference",
+        "user_approved_scope_exclusion.source_locator"
+      ]
+    },
+    "source_example1_diverse_user_fairness": {
+      "accepted_source_role_contract_sha256": "ab2e10bba5209f916b3118da33aecadff0441da901fc2904eb7406db00dd018f",
+      "public_source_role_projection_sha256": "b574ecb5f9b95bbefe00e4ef2aecb0cf599aa24cbde8cd8724b47d4ccedf3357",
+      "schema": 1,
+      "withheld_field_paths": [
+        "user_approved_scope_exclusion.approval_reference",
+        "user_approved_scope_exclusion.source_locator"
+      ]
+    },
+    "source_example1_homogeneous_tradeoff": {
+      "accepted_source_role_contract_sha256": "94c82032537876e73f571aefba95d343c89f320e95daef08ebac14029d16a3e7",
+      "public_source_role_projection_sha256": "99a6b13ce49c8bff6817998df935bdf0e38c7095c4d51dbdb0a6c6dbed70d675",
+      "schema": 1,
+      "withheld_field_paths": [
+        "user_approved_scope_exclusion.approval_reference",
+        "user_approved_scope_exclusion.source_locator"
+      ]
+    },
+    "theorem3_price_decreases_first_half": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem3_price_decreases_first_half_proof_presentation": {
+      "accepted_source_role_contract_sha256": "1d239652a90cbe5e5a6acfbc5170f0d2356a133066e0067a00e2dbb97c464b60",
+      "public_source_role_projection_sha256": "1d239652a90cbe5e5a6acfbc5170f0d2356a133066e0067a00e2dbb97c464b60",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem3_price_increases_second_half": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem3_price_increases_second_half_proof_presentation": {
+      "accepted_source_role_contract_sha256": "1d239652a90cbe5e5a6acfbc5170f0d2356a133066e0067a00e2dbb97c464b60",
+      "public_source_role_projection_sha256": "1d239652a90cbe5e5a6acfbc5170f0d2356a133066e0067a00e2dbb97c464b60",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem4_misestimation_tradeoff": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem4_misestimation_tradeoff_proof_presentation": {
+      "accepted_source_role_contract_sha256": "1d239652a90cbe5e5a6acfbc5170f0d2356a133066e0067a00e2dbb97c464b60",
+      "public_source_role_projection_sha256": "1d239652a90cbe5e5a6acfbc5170f0d2356a133066e0067a00e2dbb97c464b60",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem4_misestimation_without_fairness_universal": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "userFairness": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    }
+  },
+  "paper": "GCG24UserItemFairness",
+  "private_role_material_included": false,
+  "private_source_map_material_sha256": "0ead93625f2ce66590e77a67238a5ce08bcd8f1486bda79a82b6559b351f3277",
+  "private_source_map_sha256": "6f5b351d593758acb4d115093cf5d139af970ea267831657d1d9b4a5ad6527d8",
+  "projection_contract_sha256": "ed0964edc9c70f5ce087ce9bf134712ca40c7964ecaefd403309ac9a1b47d34d",
+  "public_display_manifest_material_sha256": "b5859216f0359260fcafbadc02933bacf140e4c17e69d5ce1989a930cde1c9c7",
+  "public_display_manifest_sha256": "9e646c12d62ba6bea8ae533a68302aa1aae3dc7ec98f840463767d7fdb88d6de",
+  "public_source_map_material_sha256": "5094ffceafb1a3a57d260bd66fd7c7869a22c68179d43347277c5aa5b82663bf",
+  "public_source_map_sha256": "6908b7c647ef70c92171f4ef66608c2483acdb96109150a4cd399629e04e6aa6",
+  "raw_private_approval_material_included": false,
+  "schema": 1
+}

--- a/papers/GGRS26CombattingGerrymanderingRCV/audit/paper_statement_map.json
+++ b/papers/GGRS26CombattingGerrymanderingRCV/audit/paper_statement_map.json
@@ -686,6 +686,11 @@
     "GGRS26CombattingGerrymanderingRCV.paper_thiele_party_selected_seat_counts_spec": "pav_party_seat_selector_definition",
     "GGRS26CombattingGerrymanderingRCV.paper_two_party_voter_model": "solid_coalition_voter_model"
   },
+  "publication_source_display_projection": {
+    "manifest": "audit/public_source_display_projection.json",
+    "raw_source_bytes_included": false,
+    "schema": 1
+  },
   "schema": 1,
   "semantic_contract_schema": 1,
   "semantic_route_schema": 2,

--- a/papers/GGRS26CombattingGerrymanderingRCV/audit/public_source_role_projection.json
+++ b/papers/GGRS26CombattingGerrymanderingRCV/audit/public_source_role_projection.json
@@ -1,0 +1,89 @@
+{
+  "acceptance_credential": false,
+  "accepted_graph_sha256": "0f3fdc68ff5454594d71ce605a7faf1dda272944c10c9ee97093003e0faa8ab0",
+  "bindings_by_source_item": {
+    "footnote10_pav_unique_integer_characterization": {
+      "accepted_source_role_contract_sha256": "89dacab7b10d470297c3b013139ddd6b123a5ca7b5d9e1862b2eb933993aa8ea",
+      "public_source_role_projection_sha256": "89dacab7b10d470297c3b013139ddd6b123a5ca7b5d9e1862b2eb933993aa8ea",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lemma_c1_pav_min_argmax_interval": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "map_level_party_share_pigeonhole_and_minority_seat_guarantee": {
+      "accepted_source_role_contract_sha256": "89dacab7b10d470297c3b013139ddd6b123a5ca7b5d9e1862b2eb933993aa8ea",
+      "public_source_role_projection_sha256": "89dacab7b10d470297c3b013139ddd6b123a5ca7b5d9e1862b2eb933993aa8ea",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "pav_party_seat_selector_definition": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "pav_thiele_rule_definition": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "population_tolerance_prose": {
+      "accepted_source_role_contract_sha256": "d80cd02da539720788a835057cd4195ef2209ae3c6ca0339b15a652f317500f4",
+      "public_source_role_projection_sha256": "d80cd02da539720788a835057cd4195ef2209ae3c6ca0339b15a652f317500f4",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "proposition1_stv_pav_rounded_seats": {
+      "accepted_source_role_contract_sha256": "64a83a0ae6edbdb2d3cfb6cb84e3bf045734ef9303f62643ff780eff69b02885",
+      "public_source_role_projection_sha256": "64a83a0ae6edbdb2d3cfb6cb84e3bf045734ef9303f62643ff780eff69b02885",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "proposition1_stv_pav_rounded_seats_appendix_presentation": {
+      "accepted_source_role_contract_sha256": "f6219d29e655cb81f1bbf1cddd4cad8536f81fed7bde5e2a7974535920df7f44",
+      "public_source_role_projection_sha256": "f6219d29e655cb81f1bbf1cddd4cad8536f81fed7bde5e2a7974535920df7f44",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "solid_coalition_voter_model": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "stv_iterative_rule_definition": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "surplus_preserving_transfer_rule_seat_share_formula": {
+      "accepted_source_role_contract_sha256": "89dacab7b10d470297c3b013139ddd6b123a5ca7b5d9e1862b2eb933993aa8ea",
+      "public_source_role_projection_sha256": "89dacab7b10d470297c3b013139ddd6b123a5ca7b5d9e1862b2eb933993aa8ea",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "vote_share_calculation_and_optimization_prose": {
+      "accepted_source_role_contract_sha256": "89dacab7b10d470297c3b013139ddd6b123a5ca7b5d9e1862b2eb933993aa8ea",
+      "public_source_role_projection_sha256": "89dacab7b10d470297c3b013139ddd6b123a5ca7b5d9e1862b2eb933993aa8ea",
+      "schema": 1,
+      "withheld_field_paths": []
+    }
+  },
+  "paper": "GGRS26CombattingGerrymanderingRCV",
+  "private_role_material_included": false,
+  "private_source_map_material_sha256": "870f647ad88debbf136e127c9306f10e550a64d1ed724fae920c198b4633f89e",
+  "private_source_map_sha256": "ca6cd8d4651997c617a634e1da967274b3c94ff3665ee21cc38ff97f714ee9c2",
+  "projection_contract_sha256": "ed0964edc9c70f5ce087ce9bf134712ca40c7964ecaefd403309ac9a1b47d34d",
+  "public_display_manifest_material_sha256": "9e997e2cd1f1f82b38a10556bb011501823baf3355fb9e7b1f3804187e882966",
+  "public_display_manifest_sha256": "e444408970ab32cb0fdf23efe389adb35da92874bb987a4634688f96f8467946",
+  "public_source_map_material_sha256": "0a67dfa19af9becbed08e31e6f3dad25d0b8dfc18d285c6b43d799eb3a86ea41",
+  "public_source_map_sha256": "448394d2661c177e965f67c97af97e4e9b9aeaf00a1960e6d68b1cf151902490",
+  "raw_private_approval_material_included": false,
+  "schema": 1
+}

--- a/papers/GGSG19TopThree/audit/paper_statement_map.json
+++ b/papers/GGSG19TopThree/audit/paper_statement_map.json
@@ -1891,6 +1891,11 @@
     "GGSG19TopThree.rankingPrefixScore": "model_reasonable_positional_scoring_rules",
     "GGSG19TopThree.rankingUniformTieSignalLaw": "model_cumulative_scores_ranking_and_outcome"
   },
+  "publication_source_display_projection": {
+    "manifest": "audit/public_source_display_projection.json",
+    "raw_source_bytes_included": false,
+    "schema": 1
+  },
   "schema": 1,
   "semantic_contract_schema": 1,
   "semantic_route_schema": 2,

--- a/papers/GGSG19TopThree/audit/public_source_display_projection.json
+++ b/papers/GGSG19TopThree/audit/public_source_display_projection.json
@@ -1,9 +1,9 @@
 {
   "generator": "python3 scripts/public_source_display_projection.py",
   "paper_id": "GGSG19TopThree",
-  "private_source_map_sha256": "fd9d6367a5233057875add08f61d901f3181e1b6730d91e657a2068dbd27f555",
+  "private_source_map_sha256": "705b03cfa388ac28e350b152b62d475412f90fe976554aaba63b49ba1fb156c1",
   "public_manifest_path": "papers/GGSG19TopThree/audit/public_source_display_projection.json",
-  "public_source_map_sha256": "349c0e6f566bc1e785e41f174b896a5bdbde952db24ba44f637f977c8d658847",
+  "public_source_map_sha256": "dd603b13942186c41e168c2f6b62f8ddc78fd56a0eb75dd2e221ad2f72dcd3dd",
   "raw_source_artifact_included": false,
   "raw_source_display_material": "selected_byte_pinned_source_anchor_quotes",
   "schema": 1,

--- a/papers/GGSG19TopThree/audit/public_source_role_projection.json
+++ b/papers/GGSG19TopThree/audit/public_source_role_projection.json
@@ -1,0 +1,413 @@
+{
+  "acceptance_credential": false,
+  "accepted_graph_sha256": "be8f45b12fa946920d80e8b0995e44f1b7557987f2c91ac8d85fec352d5427bf",
+  "bindings_by_source_item": {
+    "algorithm_efficient_mallows_arbitrary_pair_joint_location_dp": {
+      "accepted_source_role_contract_sha256": "48e39d93ab7e5f12d6c9d8a7a617c398d392fc3c5b98eeb0320c2bb31df88e0a",
+      "public_source_role_projection_sha256": "48e39d93ab7e5f12d6c9d8a7a617c398d392fc3c5b98eeb0320c2bb31df88e0a",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "assumption_mallows_nontrivial_winner_and_parameter_domain": {
+      "accepted_source_role_contract_sha256": "10d3b168adc54f4f65034bf4056bf824f46ba8a384f57936a80b50242dd4daa6",
+      "public_source_role_projection_sha256": "10d3b168adc54f4f65034bf4056bf824f46ba8a384f57936a80b50242dd4daa6",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "assumption_mallows_repeated_insertion_parameter_domain": {
+      "accepted_source_role_contract_sha256": "10d3b168adc54f4f65034bf4056bf824f46ba8a384f57936a80b50242dd4daa6",
+      "public_source_role_projection_sha256": "10d3b168adc54f4f65034bf4056bf824f46ba8a384f57936a80b50242dd4daa6",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "assumption_nontrivial_k_approval_cutoffs": {
+      "accepted_source_role_contract_sha256": "10d3b168adc54f4f65034bf4056bf824f46ba8a384f57936a80b50242dd4daa6",
+      "public_source_role_projection_sha256": "10d3b168adc54f4f65034bf4056bf824f46ba8a384f57936a80b50242dd4daa6",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "assumption_pairwise_approval_ternary_gap_domain": {
+      "accepted_source_role_contract_sha256": "10d3b168adc54f4f65034bf4056bf824f46ba8a384f57936a80b50242dd4daa6",
+      "public_source_role_projection_sha256": "10d3b168adc54f4f65034bf4056bf824f46ba8a384f57936a80b50242dd4daa6",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "assumption_randomized_mechanism_probability_weights": {
+      "accepted_source_role_contract_sha256": "10d3b168adc54f4f65034bf4056bf824f46ba8a384f57936a80b50242dd4daa6",
+      "public_source_role_projection_sha256": "10d3b168adc54f4f65034bf4056bf824f46ba8a384f57936a80b50242dd4daa6",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "example_disjoint_one_and_two_approval_winners": {
+      "accepted_source_role_contract_sha256": "1a87ebea96d7ccfc07cd02d4e45eca360a7cb83c69ec4fa0692922fb97fb592e",
+      "public_source_role_projection_sha256": "1a87ebea96d7ccfc07cd02d4e45eca360a7cb83c69ec4fa0692922fb97fb592e",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "example_randomization_helps_Durham_numeric": {
+      "accepted_source_role_contract_sha256": "24af3b57d5538434b02162eaed2147ad48cd373b770e44446d79c3c9a8da45f3",
+      "public_source_role_projection_sha256": "24af3b57d5538434b02162eaed2147ad48cd373b770e44446d79c3c9a8da45f3",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "example_randomization_helps_constructed_distribution": {
+      "accepted_source_role_contract_sha256": "1a87ebea96d7ccfc07cd02d4e45eca360a7cb83c69ec4fa0692922fb97fb592e",
+      "public_source_role_projection_sha256": "1a87ebea96d7ccfc07cd02d4e45eca360a7cb83c69ec4fa0692922fb97fb592e",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "formula_approval_one_sided_probabilities": {
+      "accepted_source_role_contract_sha256": "a330329badf1fd97b0f683ad1a79ce3a95f8b10055dc2d728029e12259aff27c",
+      "public_source_role_projection_sha256": "a330329badf1fd97b0f683ad1a79ce3a95f8b10055dc2d728029e12259aff27c",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "formula_outcome_error_QN": {
+      "accepted_source_role_contract_sha256": "a330329badf1fd97b0f683ad1a79ce3a95f8b10055dc2d728029e12259aff27c",
+      "public_source_role_projection_sha256": "a330329badf1fd97b0f683ad1a79ce3a95f8b10055dc2d728029e12259aff27c",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "formula_randomized_pair_and_outcome_rates": {
+      "accepted_source_role_contract_sha256": "a330329badf1fd97b0f683ad1a79ce3a95f8b10055dc2d728029e12259aff27c",
+      "public_source_role_projection_sha256": "a330329badf1fd97b0f683ad1a79ce3a95f8b10055dc2d728029e12259aff27c",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "model_arbitrary_ordered_tier_goal": {
+      "accepted_source_role_contract_sha256": "cb4c52d7162057fe79d176483b8606eae69ef415544ac40e16cd2b0dd1287867",
+      "public_source_role_projection_sha256": "cb4c52d7162057fe79d176483b8606eae69ef415544ac40e16cd2b0dd1287867",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "model_cumulative_scores_ranking_and_outcome": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "model_expected_score_limit_and_tier_outcome": {
+      "accepted_source_role_contract_sha256": "57d1240a50e85ecbfbe1c2bd86229cc96e9d07cbb4be088315502d05b43f78e5",
+      "public_source_role_projection_sha256": "57d1240a50e85ecbfbe1c2bd86229cc96e9d07cbb4be088315502d05b43f78e5",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "model_finite_iid_strict_rankings": {
+      "accepted_source_role_contract_sha256": "cb4c52d7162057fe79d176483b8606eae69ef415544ac40e16cd2b0dd1287867",
+      "public_source_role_projection_sha256": "cb4c52d7162057fe79d176483b8606eae69ef415544ac40e16cd2b0dd1287867",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "model_k_approval_score": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "model_k_ranking_score": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "model_mallows_ranking_mass_and_parameter_domain": {
+      "accepted_source_role_contract_sha256": "cb4c52d7162057fe79d176483b8606eae69ef415544ac40e16cd2b0dd1287867",
+      "public_source_role_projection_sha256": "cb4c52d7162057fe79d176483b8606eae69ef415544ac40e16cd2b0dd1287867",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "model_randomized_scoring_mechanism": {
+      "accepted_source_role_contract_sha256": "cb4c52d7162057fe79d176483b8606eae69ef415544ac40e16cd2b0dd1287867",
+      "public_source_role_projection_sha256": "cb4c52d7162057fe79d176483b8606eae69ef415544ac40e16cd2b0dd1287867",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "model_reasonable_positional_scoring_rules": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "proof_constructed_all_other_cutoffs_worse": {
+      "accepted_source_role_contract_sha256": "b5f4804192214264d69cde3f0680e8ffdbbff8a552d1c1351ffe3d859c5b31d6",
+      "public_source_role_projection_sha256": "b5f4804192214264d69cde3f0680e8ffdbbff8a552d1c1351ffe3d859c5b31d6",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "proof_constructed_design_invariance_and_feasibility": {
+      "accepted_source_role_contract_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "public_source_role_projection_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "proof_constructed_other_pairs_not_pivotal": {
+      "accepted_source_role_contract_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "public_source_role_projection_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "proof_constructed_randomization_strictly_improves_minimum": {
+      "accepted_source_role_contract_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "public_source_role_projection_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "proof_mallows_common_pivotal_pair": {
+      "accepted_source_role_contract_sha256": "7943bb0a1038c9b9ca1ec777a62b2cf0d2afdf222d3ccb832d0d97bcd18dfc6a",
+      "public_source_role_projection_sha256": "7943bb0a1038c9b9ca1ec777a62b2cf0d2afdf222d3ccb832d0d97bcd18dfc6a",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "proof_mallows_four_candidate_approval_probabilities_and_rates": {
+      "accepted_source_role_contract_sha256": "1a87ebea96d7ccfc07cd02d4e45eca360a7cb83c69ec4fa0692922fb97fb592e",
+      "public_source_role_projection_sha256": "1a87ebea96d7ccfc07cd02d4e45eca360a7cb83c69ec4fa0692922fb97fb592e",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "proof_mallows_four_candidate_joint_location_matrix": {
+      "accepted_source_role_contract_sha256": "e7960301914702af45e2b6b68d20aef532fe8473849db58c6eda39068f6de8d1",
+      "public_source_role_projection_sha256": "e7960301914702af45e2b6b68d20aef532fe8473849db58c6eda39068f6de8d1",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "proof_mallows_repeated_insertion_probability": {
+      "accepted_source_role_contract_sha256": "7943bb0a1038c9b9ca1ec777a62b2cf0d2afdf222d3ccb832d0d97bcd18dfc6a",
+      "public_source_role_projection_sha256": "7943bb0a1038c9b9ca1ec777a62b2cf0d2afdf222d3ccb832d0d97bcd18dfc6a",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "proof_prop1_cutoff_rule_witness": {
+      "accepted_source_role_contract_sha256": "b5f4804192214264d69cde3f0680e8ffdbbff8a552d1c1351ffe3d859c5b31d6",
+      "public_source_role_projection_sha256": "b5f4804192214264d69cde3f0680e8ffdbbff8a552d1c1351ffe3d859c5b31d6",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "proof_prop1_expected_gap_and_slln": {
+      "accepted_source_role_contract_sha256": "b5f4804192214264d69cde3f0680e8ffdbbff8a552d1c1351ffe3d859c5b31d6",
+      "public_source_role_projection_sha256": "b5f4804192214264d69cde3f0680e8ffdbbff8a552d1c1351ffe3d859c5b31d6",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "proof_prop1_score_summation_by_parts": {
+      "accepted_source_role_contract_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "public_source_role_projection_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "proof_prop2_chernoff_chain": {
+      "accepted_source_role_contract_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "public_source_role_projection_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "proof_prop2_ldp_identity": {
+      "accepted_source_role_contract_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "public_source_role_projection_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "proof_prop2_log_mgf_and_rate": {
+      "accepted_source_role_contract_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "public_source_role_projection_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "proof_prop2_sample_size_formula": {
+      "accepted_source_role_contract_sha256": "b5f4804192214264d69cde3f0680e8ffdbbff8a552d1c1351ffe3d859c5b31d6",
+      "public_source_role_projection_sha256": "b5f4804192214264d69cde3f0680e8ffdbbff8a552d1c1351ffe3d859c5b31d6",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "proof_prop2_score_gap_random_variable": {
+      "accepted_source_role_contract_sha256": "b5f4804192214264d69cde3f0680e8ffdbbff8a552d1c1351ffe3d859c5b31d6",
+      "public_source_role_projection_sha256": "b5f4804192214264d69cde3f0680e8ffdbbff8a552d1c1351ffe3d859c5b31d6",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "proof_prop3_closed_rate_substitution": {
+      "accepted_source_role_contract_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "public_source_role_projection_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "proof_prop3_optimizer": {
+      "accepted_source_role_contract_sha256": "b5f4804192214264d69cde3f0680e8ffdbbff8a552d1c1351ffe3d859c5b31d6",
+      "public_source_role_projection_sha256": "b5f4804192214264d69cde3f0680e8ffdbbff8a552d1c1351ffe3d859c5b31d6",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "proof_prop3_ternary_log_mgf": {
+      "accepted_source_role_contract_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "public_source_role_projection_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "proof_prop3_ternary_score_gap_law": {
+      "accepted_source_role_contract_sha256": "b5f4804192214264d69cde3f0680e8ffdbbff8a552d1c1351ffe3d859c5b31d6",
+      "public_source_role_projection_sha256": "b5f4804192214264d69cde3f0680e8ffdbbff8a552d1c1351ffe3d859c5b31d6",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "proof_prop4_finite_log_sum_min_rate": {
+      "accepted_source_role_contract_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "public_source_role_projection_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "proof_prop4_union_bound_and_M_sq": {
+      "accepted_source_role_contract_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "public_source_role_projection_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "proof_theorem1_convexity_jensen_step": {
+      "accepted_source_role_contract_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "public_source_role_projection_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "proof_theorem1_hessian_psd_calculation": {
+      "accepted_source_role_contract_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "public_source_role_projection_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "proof_theorem1_randomized_pair_mgf": {
+      "accepted_source_role_contract_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "public_source_role_projection_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "proof_theorem1_static_pair_rate": {
+      "accepted_source_role_contract_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "public_source_role_projection_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "proof_theorem1_uniform_pair_to_goal_step": {
+      "accepted_source_role_contract_sha256": "b5f4804192214264d69cde3f0680e8ffdbbff8a552d1c1351ffe3d859c5b31d6",
+      "public_source_role_projection_sha256": "b5f4804192214264d69cde3f0680e8ffdbbff8a552d1c1351ffe3d859c5b31d6",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "proof_theorem2_convex_average_to_max_component": {
+      "accepted_source_role_contract_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "public_source_role_projection_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "proof_theorem2_convex_composition": {
+      "accepted_source_role_contract_sha256": "b5f4804192214264d69cde3f0680e8ffdbbff8a552d1c1351ffe3d859c5b31d6",
+      "public_source_role_projection_sha256": "b5f4804192214264d69cde3f0680e8ffdbbff8a552d1c1351ffe3d859c5b31d6",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "proof_theorem2_mixed_approval_probabilities": {
+      "accepted_source_role_contract_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "public_source_role_projection_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "remark_approval_rate_monotonicity": {
+      "accepted_source_role_contract_sha256": "581440dfd564e79e623e51ab1405cee6a60dc9d12e4e8765d870fb79460b2da5",
+      "public_source_role_projection_sha256": "581440dfd564e79e623e51ab1405cee6a60dc9d12e4e8765d870fb79460b2da5",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_corollary_mallows_randomization_no_improvement_positive_noise": {
+      "accepted_source_role_contract_sha256": "f4254796949514af697b1a57a525740c36a37b17d9eafef0da4f0bb27d637328",
+      "public_source_role_projection_sha256": "f4254796949514af697b1a57a525740c36a37b17d9eafef0da4f0bb27d637328",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_corollary_mallows_randomization_no_improvement_zero_noise": {
+      "accepted_source_role_contract_sha256": "f4254796949514af697b1a57a525740c36a37b17d9eafef0da4f0bb27d637328",
+      "public_source_role_projection_sha256": "f4254796949514af697b1a57a525740c36a37b17d9eafef0da4f0bb27d637328",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_definition1_design_invariance": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_definition2_large_deviation_rate": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_definition3_rate_optimality": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_proposition1_design_invariance_iff_strict_prefix_separation": {
+      "accepted_source_role_contract_sha256": "64a83a0ae6edbdb2d3cfb6cb84e3bf045734ef9303f62643ff780eff69b02885",
+      "public_source_role_projection_sha256": "64a83a0ae6edbdb2d3cfb6cb84e3bf045734ef9303f62643ff780eff69b02885",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_proposition2_pairwise_learning_rate_and_bound": {
+      "accepted_source_role_contract_sha256": "64a83a0ae6edbdb2d3cfb6cb84e3bf045734ef9303f62643ff780eff69b02885",
+      "public_source_role_projection_sha256": "64a83a0ae6edbdb2d3cfb6cb84e3bf045734ef9303f62643ff780eff69b02885",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_proposition3_k_approval_closed_pairwise_rate": {
+      "accepted_source_role_contract_sha256": "64a83a0ae6edbdb2d3cfb6cb84e3bf045734ef9303f62643ff780eff69b02885",
+      "public_source_role_projection_sha256": "64a83a0ae6edbdb2d3cfb6cb84e3bf045734ef9303f62643ff780eff69b02885",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_proposition4_finite_sample_M_sq_bound": {
+      "accepted_source_role_contract_sha256": "64a83a0ae6edbdb2d3cfb6cb84e3bf045734ef9303f62643ff780eff69b02885",
+      "public_source_role_projection_sha256": "64a83a0ae6edbdb2d3cfb6cb84e3bf045734ef9303f62643ff780eff69b02885",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_proposition4_outcome_exact_minimum_rate": {
+      "accepted_source_role_contract_sha256": "64a83a0ae6edbdb2d3cfb6cb84e3bf045734ef9303f62643ff780eff69b02885",
+      "public_source_role_projection_sha256": "64a83a0ae6edbdb2d3cfb6cb84e3bf045734ef9303f62643ff780eff69b02885",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_theorem1_randomized_scoring_no_improvement": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_theorem2_randomized_k_approval_fixed_pair_no_improvement": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_theorem_mallows_W_approval_not_rate_optimal": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_theorem_randomized_approval_can_help_W_selection": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    }
+  },
+  "paper": "GGSG19TopThree",
+  "private_role_material_included": false,
+  "private_source_map_material_sha256": "973aa042f788859424fb333c79095f0e5e1850dc08e9b67305b5e7ce03ef2665",
+  "private_source_map_sha256": "705b03cfa388ac28e350b152b62d475412f90fe976554aaba63b49ba1fb156c1",
+  "projection_contract_sha256": "ed0964edc9c70f5ce087ce9bf134712ca40c7964ecaefd403309ac9a1b47d34d",
+  "public_display_manifest_material_sha256": "c6357e3fc9e9fe3e6f9fa89d3aec5ffff44402084253eeb567c6b73200b31152",
+  "public_display_manifest_sha256": "d4ff6154f80a2806c399b9f62b2562cb9434b5c8fa6036ce3e63e7564d595e2a",
+  "public_source_map_material_sha256": "17fbd6124ceade451ed0dbc334e85ee1ddb74af26609ad7d7a0db53f5d5f9ce5",
+  "public_source_map_sha256": "dd603b13942186c41e168c2f6b62f8ddc78fd56a0eb75dd2e221ad2f72dcd3dd",
+  "raw_private_approval_material_included": false,
+  "schema": 1
+}

--- a/papers/GHKR22BiasBounties/audit/paper_statement_map.json
+++ b/papers/GHKR22BiasBounties/audit/paper_statement_map.json
@@ -1318,6 +1318,11 @@
     "approval_material_included": false,
     "schema": 1
   },
+  "publication_source_display_projection": {
+    "manifest": "audit/public_source_display_projection.json",
+    "raw_source_bytes_included": false,
+    "schema": 1
+  },
   "schema": 1,
   "semantic_contract_schema": 1,
   "semantic_route_schema": 2,

--- a/papers/GHKR22BiasBounties/audit/public_source_role_projection.json
+++ b/papers/GHKR22BiasBounties/audit/public_source_role_projection.json
@@ -1,0 +1,233 @@
+{
+  "acceptance_credential": false,
+  "accepted_graph_sha256": "2d39f396df2edad8426ee12337a403c58a4c405125c9a632191bfc88a47ecd65",
+  "bindings_by_source_item": {
+    "algorithm_1_list_update": {
+      "accepted_source_role_contract_sha256": "48e39d93ab7e5f12d6c9d8a7a617c398d392fc3c5b98eeb0320c2bb31df88e0a",
+      "public_source_role_projection_sha256": "48e39d93ab7e5f12d6c9d8a7a617c398d392fc3c5b98eeb0320c2bb31df88e0a",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "algorithm_2_certificate_checker": {
+      "accepted_source_role_contract_sha256": "48e39d93ab7e5f12d6c9d8a7a617c398d392fc3c5b98eeb0320c2bb31df88e0a",
+      "public_source_role_projection_sha256": "48e39d93ab7e5f12d6c9d8a7a617c398d392fc3c5b98eeb0320c2bb31df88e0a",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "algorithm_3_falsify_and_update": {
+      "accepted_source_role_contract_sha256": "48e39d93ab7e5f12d6c9d8a7a617c398d392fc3c5b98eeb0320c2bb31df88e0a",
+      "public_source_role_projection_sha256": "48e39d93ab7e5f12d6c9d8a7a617c398d392fc3c5b98eeb0320c2bb31df88e0a",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "algorithm_4_monotone_falsify_and_update": {
+      "accepted_source_role_contract_sha256": "9f096591ff1ae8128e0efb12b396b6e9f405d23586155d32002493a6190c88d9",
+      "public_source_role_projection_sha256": "69f1978c3c1894a99b2f13ddfac5e6964ce33f4288b6e332177ad67f73909dce",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "algorithm_5_train_by_opt": {
+      "accepted_source_role_contract_sha256": "1e7daaa91a940817b68be2fb73abba9e5fa8a16967b52812da2c505b229605fd",
+      "public_source_role_projection_sha256": "978c2fb67f482b84a9a1ab2f96b904ef6ddf46e393cd3ae902e800d61f04e6fc",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "algorithm_6_alternating_maximization": {
+      "accepted_source_role_contract_sha256": "832e435b78047952af97fd3ac2b94949c36cb54615e591b513b0803804bfc969",
+      "public_source_role_projection_sha256": "f8c1e6120b95e8934bdae2d4e584b48679a7f3906e2167b660861e32a4eea77a",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "certificate_optimization_objective": {
+      "accepted_source_role_contract_sha256": "e7960301914702af45e2b6b68d20aef532fe8473849db58c6eda39068f6de8d1",
+      "public_source_role_projection_sha256": "e7960301914702af45e2b6b68d20aef532fe8473849db58c6eda39068f6de8d1",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition_17_derived_certificate": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition_18_cost_sensitive_minimizer": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition_19_induced_cost": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition_1_subgroups": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition_2_model_loss": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition_3_bayes_optimal": {
+      "accepted_source_role_contract_sha256": "6a0740da7651c4b97975f94a03fa25f7e4bbfd604760e4a671ec4dc6b6fda287",
+      "public_source_role_projection_sha256": "2cb8fe520f8fce28c39f89bdb5a1834247908a98a65b5b965620bd15e5e17da6",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "definition_5_approximate_bayes_optimal": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition_7_certificate": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lemma_15_vc_uniform_convergence": {
+      "accepted_source_role_contract_sha256": "d420fa11d6f4b16977d4b3cfade936796796a6f72c76ead6e69aa1d6c9ec0847",
+      "public_source_role_projection_sha256": "be8bf98e074f2613931b52e692bc31fee0ac24fadc97b4959539167eb6c66f66",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "lemma_21_fixed_group_erm": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lemma_22_fixed_model_erm": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "observation_4_bayes_groupwise": {
+      "accepted_source_role_contract_sha256": "9cc1040211ff3810bbd9c75c093b52d26fad72ce98705845d11c45f9836d71dd",
+      "public_source_role_projection_sha256": "ce9352541488c0a00c2884eac628c4b1f56a0db4c33732e913916d63da2737c7",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "remark_13_complexity_independence": {
+      "accepted_source_role_contract_sha256": "ff5a0e099e16c780ec0c807bad8030a1474e5e84b20ee9670ac2ec27355bdb21",
+      "public_source_role_projection_sha256": "ff5a0e099e16c780ec0c807bad8030a1474e5e84b20ee9670ac2ec27355bdb21",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "remark_6_inverse_mass_scaling": {
+      "accepted_source_role_contract_sha256": "b80fe69bf2a80f208a6d16eb4f567e205217849acf01414c00cec3f1d30f6c44",
+      "public_source_role_projection_sha256": "b80fe69bf2a80f208a6d16eb4f567e205217849acf01414c00cec3f1d30f6c44",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_model_supervised_learning": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem_10_update_bound": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem_11_adaptive_checker": {
+      "accepted_source_role_contract_sha256": "29be074f601055720781ed29740e4a5f0570c7961735ea4c9a584ac63f3ad582",
+      "public_source_role_projection_sha256": "bf4db6b512ec84c17838d94bf22debed97b3cc70a5427ebe52ae9e83c7666f14",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "theorem_12_falsify_and_update": {
+      "accepted_source_role_contract_sha256": "36e02130c073350e1b62a3144f7998fd2d64d525e5b2c52304c3efcb5eccd1db",
+      "public_source_role_projection_sha256": "e91cc0ffdcbaac9c4d94fe702b04a92ab957a85ad8184512ec8d67c3337e84c0",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "theorem_14_monotone_bounty": {
+      "accepted_source_role_contract_sha256": "dd06835c9c3c34945b962e7db875a70b3ff89a2c785a65b63adcafd34904a954",
+      "public_source_role_projection_sha256": "05ea92d46106521f952bc73df85c93e7458f1d3f49c0250615dfbcd31acbe08a",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "theorem_16_train_by_opt": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem_20_ternary_reduction": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem_23_coordinate_ascent": {
+      "accepted_source_role_contract_sha256": "32362e5216d999a99387fc5216430b9a8cfd2683347d54fa9211a0e34f945c8e",
+      "public_source_role_projection_sha256": "55f32c4a5b29e99cfcbc912ce26421b09fa61d9766861ebe645a59ca760a1071",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "theorem_8_certificate_characterization": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem_9_list_update_progress": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    }
+  },
+  "paper": "GHKR22BiasBounties",
+  "private_role_material_included": false,
+  "private_source_map_material_sha256": "8963ece0b865177dea467877d99c72e9a283ae0f9c79b187a9e97e1a25ff2f0f",
+  "private_source_map_sha256": "9ead3ad3288764958fac2f02b66e49f8a3e1fa6234f3452b29df5702bb97b9f8",
+  "projection_contract_sha256": "ed0964edc9c70f5ce087ce9bf134712ca40c7964ecaefd403309ac9a1b47d34d",
+  "public_display_manifest_material_sha256": "32bb92b8e9e33411e029f288b53c4dffaf8e315967614b51032b2a2ddd995bbd",
+  "public_display_manifest_sha256": "6e47cd813919a7b1d3e0049e90ff8f46ea0ecca8f21e398a277d41801f44c982",
+  "public_source_map_material_sha256": "f2dd726dde6b580e6800209172f5f989059f8c5132f6ba4e67ecb7a2bca0e140",
+  "public_source_map_sha256": "c6eaecd32e495c5e3b485d56d8766cbabfb17fad6cb6f2bb1e4cd0fede5ffc7f",
+  "raw_private_approval_material_included": false,
+  "schema": 1
+}

--- a/papers/GHW01DigitalGoods/audit/paper_statement_map.json
+++ b/papers/GHW01DigitalGoods/audit/paper_statement_map.json
@@ -4404,6 +4404,11 @@
     "approval_material_included": false,
     "schema": 1
   },
+  "publication_source_display_projection": {
+    "manifest": "audit/public_source_display_projection.json",
+    "raw_source_bytes_included": false,
+    "schema": 1
+  },
   "schema": 1,
   "semantic_contract_schema": 1,
   "semantic_route_schema": 2,

--- a/papers/GHW01DigitalGoods/audit/public_source_role_projection.json
+++ b/papers/GHW01DigitalGoods/audit/public_source_role_projection.json
@@ -1,0 +1,389 @@
+{
+  "acceptance_credential": false,
+  "accepted_graph_sha256": "1aeefb91212c6a3155f1ea5600ca20e7e7b35dff12f4d9010abaa0526c2f3abb",
+  "bindings_by_source_item": {
+    "assumption_bounded_supply_alpha_h_lt_Fk": {
+      "accepted_source_role_contract_sha256": "f10959bfcbdee741f53823d96ce6c7546c2e9c1fb3c549ffffc9a1e4b36ffdd7",
+      "public_source_role_projection_sha256": "f10959bfcbdee741f53823d96ce6c7546c2e9c1fb3c549ffffc9a1e4b36ffdd7",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition_auction_correctness": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition_auction_mechanisms": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition_auction_outcome": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition_bid_extrema": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition_bid_independent_auction": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition_bidder_count": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition_bidder_profit": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition_bounded_supply_fixed_price_benchmark": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition_bounded_supply_optimal_threshold": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition_bounded_supply_top_k_total": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition_competitive_auction": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition_deterministic_optimal_threshold_auction": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition_dual_price_sampling_auction": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition_exact_half_optimal_threshold": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition_fixed_price_benchmark": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition_fixed_pricing": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition_independent_half_analysis_model": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition_k_item_vickrey": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition_optimal_threshold": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition_performance_convention": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition_price_classes": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition_random_sampling_auction": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition_revenue": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition_scale_conditions": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition_scarce_supply": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition_single_price_revenue": {
+      "accepted_source_role_contract_sha256": "b03be44aee1045ec135ecba63850242d11979b5638f12ae1892adcb8d8ca3c46",
+      "public_source_role_projection_sha256": "b03be44aee1045ec135ecba63850242d11979b5638f12ae1892adcb8d8ca3c46",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition_threshold_boundary_convention": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition_total_value": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition_truthfulness": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition_two_winner_benchmark_bridge": {
+      "accepted_source_role_contract_sha256": "82c5a432e9297547045cf8778a39a972a95b90fbc60221ac5bddaf701eb78f9e",
+      "public_source_role_projection_sha256": "82c5a432e9297547045cf8778a39a972a95b90fbc60221ac5bddaf701eb78f9e",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition_unlimited_vickrey_family": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition_weighted_pairing_auction": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition_weighted_pairing_revenue": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "model_bidder_values_and_bids": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "model_bounded_dual_price_sampling_auction": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "model_bounded_single_price_sampling_auction": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "model_bounded_supply_capacity": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "model_sorted_bid_convention": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "model_unlimited_supply": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "result_bounded_deterministic_optimal_threshold_extension": {
+      "accepted_source_role_contract_sha256": "f10959bfcbdee741f53823d96ce6c7546c2e9c1fb3c549ffffc9a1e4b36ffdd7",
+      "public_source_role_projection_sha256": "f10959bfcbdee741f53823d96ce6c7546c2e9c1fb3c549ffffc9a1e4b36ffdd7",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "result_bounded_dual_price_competitive": {
+      "accepted_source_role_contract_sha256": "f10959bfcbdee741f53823d96ce6c7546c2e9c1fb3c549ffffc9a1e4b36ffdd7",
+      "public_source_role_projection_sha256": "f10959bfcbdee741f53823d96ce6c7546c2e9c1fb3c549ffffc9a1e4b36ffdd7",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "result_bounded_dual_price_truthful": {
+      "accepted_source_role_contract_sha256": "f10959bfcbdee741f53823d96ce6c7546c2e9c1fb3c549ffffc9a1e4b36ffdd7",
+      "public_source_role_projection_sha256": "f10959bfcbdee741f53823d96ce6c7546c2e9c1fb3c549ffffc9a1e4b36ffdd7",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "result_bounded_single_price_sampling_competitive": {
+      "accepted_source_role_contract_sha256": "f10959bfcbdee741f53823d96ce6c7546c2e9c1fb3c549ffffc9a1e4b36ffdd7",
+      "public_source_role_projection_sha256": "f10959bfcbdee741f53823d96ce6c7546c2e9c1fb3c549ffffc9a1e4b36ffdd7",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "result_bounded_single_price_small_rejection_probability": {
+      "accepted_source_role_contract_sha256": "f10959bfcbdee741f53823d96ce6c7546c2e9c1fb3c549ffffc9a1e4b36ffdd7",
+      "public_source_role_projection_sha256": "f10959bfcbdee741f53823d96ce6c7546c2e9c1fb3c549ffffc9a1e4b36ffdd7",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "result_bounded_supply_fixed_price_lower_bound": {
+      "accepted_source_role_contract_sha256": "f10959bfcbdee741f53823d96ce6c7546c2e9c1fb3c549ffffc9a1e4b36ffdd7",
+      "public_source_role_projection_sha256": "f10959bfcbdee741f53823d96ce6c7546c2e9c1fb3c549ffffc9a1e4b36ffdd7",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "result_corollary4_2": {
+      "accepted_source_role_contract_sha256": "9b36b6bd38fc1030363142829051ca3d778b6a0ee10c51121dbbc62c13b755ce",
+      "public_source_role_projection_sha256": "5a7586dc0a39abd50764aa25326bb69eac7dcc98ae145f88762c8ed6085cf82c",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "result_lemma6_1_fixed_size_lower_tail": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "result_lemma8_1_monotone_allocation": {
+      "accepted_source_role_contract_sha256": "474343ab20a2fce69013c5894588e6ddaa6c3baa71db51ab847086b64bd5cff4",
+      "public_source_role_projection_sha256": "6cab781209860f399a0684492c4de44f0a0bc902fcf6ed188afe28de430ddba8",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "result_lemma9_2_bid_independence": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "result_theorem4_1": {
+      "accepted_source_role_contract_sha256": "3f2852081e0838818b84bd71e8a8f8bef8261869b41c4e03469e270014fc9156",
+      "public_source_role_projection_sha256": "fcfd6caed0a03ee193c1fbadaca7d4509fb2446764482852c0e43a0838cd9906",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "result_theorem6_2_random_sampling": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "result_theorem7_1_weighted_pairing": {
+      "accepted_source_role_contract_sha256": "006157724e0a4b7edb5576a1932c8b616c9daaeac86af6f7fa8de14a23d800fe",
+      "public_source_role_projection_sha256": "3a75587c6cd73f3c532ac53f088d33aa6060655ccd36cf6af090d6436b46978c",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "result_theorem7_2_lower_bound": {
+      "accepted_source_role_contract_sha256": "f36158ce01dca236d4e2a81bbab4dd71d69c8c3d2ea4376388abb87eb5263631",
+      "public_source_role_projection_sha256": "8245852046447d0fb355a7f3e58a2f6788e37bd46182e16c5aad412088d45b21",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "result_theorem7_2_tightness": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "result_theorem8_2_journal_revenue_upper_bound": {
+      "accepted_source_role_contract_sha256": "3ff7ead084be38086ee2be567521c8826b4b423b39c6ada3985cd93502da4e5d",
+      "public_source_role_projection_sha256": "6fd174b3eb56cc5039bf28ea6b76e8e435dbb924ba31501c97107c385d3fd8c0",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "result_theorem9_1_bid_independent_lower_bound": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "result_theorem9_3_deterministic_lower_bound": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "result_unlimited_upper_bounds_extend_bounded": {
+      "accepted_source_role_contract_sha256": "f10959bfcbdee741f53823d96ce6c7546c2e9c1fb3c549ffffc9a1e4b36ffdd7",
+      "public_source_role_projection_sha256": "f10959bfcbdee741f53823d96ce6c7546c2e9c1fb3c549ffffc9a1e4b36ffdd7",
+      "schema": 1,
+      "withheld_field_paths": []
+    }
+  },
+  "paper": "GHW01DigitalGoods",
+  "private_role_material_included": false,
+  "private_source_map_material_sha256": "ba9c0f824a94a64d159693f0a034de0d11f140de40ba8bcb90e11a74b98b8457",
+  "private_source_map_sha256": "3c181e698d2bc474699c440512a1742f97dc038a7bb7c0e34b8140f196d642a8",
+  "projection_contract_sha256": "ed0964edc9c70f5ce087ce9bf134712ca40c7964ecaefd403309ac9a1b47d34d",
+  "public_display_manifest_material_sha256": "0eca4794bfd8f21d847f05e6e2727ddce50ce4b1945f0002869cf4298cc617d2",
+  "public_display_manifest_sha256": "e8788439a2a5060cabe65c0b0d6127ff86a4bacdc12aea6f54d1a408d78c9087",
+  "public_source_map_material_sha256": "26a5a55066e24f81855ceb9b9d2605a7797da0325b5d3d56a41c688c38342690",
+  "public_source_map_sha256": "dd0424eee4e0e5183d84192afa197560dfa400e11b9ba09520c728ce8c11dc66",
+  "raw_private_approval_material_included": false,
+  "schema": 1
+}

--- a/papers/GJ18InformativeRatingSystems/audit/paper_statement_map.json
+++ b/papers/GJ18InformativeRatingSystems/audit/paper_statement_map.json
@@ -1032,6 +1032,11 @@
     "approval_material_included": false,
     "schema": 1
   },
+  "publication_source_display_projection": {
+    "manifest": "audit/public_source_display_projection.json",
+    "raw_source_bytes_included": false,
+    "schema": 1
+  },
   "schema": 1,
   "semantic_contract_schema": 1,
   "semantic_route_schema": 2,

--- a/papers/GJ18InformativeRatingSystems/audit/public_source_role_projection.json
+++ b/papers/GJ18InformativeRatingSystems/audit/public_source_role_projection.json
@@ -1,0 +1,161 @@
+{
+  "acceptance_credential": false,
+  "accepted_graph_sha256": "6ac6b1793a255c77dd7ed3e192bef6dc3d0489c5a6d7469c7a6e50e3dfaabb24",
+  "bindings_by_source_item": {
+    "author_approved_corrected_finite_chain_model": {
+      "accepted_source_role_contract_sha256": "e8bd731c387f27f23e485836c19e8cd56ab3be13060fd6b4343e29952fe8b856",
+      "public_source_role_projection_sha256": "e8bd731c387f27f23e485836c19e8cd56ab3be13060fd6b4343e29952fe8b856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "author_approved_corrected_model_theorem1_finite_real_rate": {
+      "accepted_source_role_contract_sha256": "e5f2d50acc3985389e56a6903386126852be4588141a0f9e64ce0334ae4d6183",
+      "public_source_role_projection_sha256": "c2565296881b228cef8cff76285cd9f7039d139eb5242f7b9a06eb6370f04c08",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "author_confirmed_clarified_iid_state_law": {
+      "accepted_source_role_contract_sha256": "03b3694d32f6fa7815d209b966fc408255cbec2fa53816704d8449f69e822b23",
+      "public_source_role_projection_sha256": "03b3694d32f6fa7815d209b966fc408255cbec2fa53816704d8449f69e822b23",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "author_confirmed_clarified_model_theorem1_state_rate": {
+      "accepted_source_role_contract_sha256": "d895cd17b85e0fc6e6d02e6a356668ad95a59127b5ddd65456ee19429f2dd75c",
+      "public_source_role_projection_sha256": "d895cd17b85e0fc6e6d02e6a356668ad95a59127b5ddd65456ee19429f2dd75c",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "author_confirmed_clarified_uniform_type_prior": {
+      "accepted_source_role_contract_sha256": "03b3694d32f6fa7815d209b966fc408255cbec2fa53816704d8449f69e822b23",
+      "public_source_role_projection_sha256": "03b3694d32f6fa7815d209b966fc408255cbec2fa53816704d8449f69e822b23",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_appendix_pk_ld_complement_rate_iid_completion": {
+      "accepted_source_role_contract_sha256": "ee9f1b47e4f0b467c072446a8a876d8f56fbcbec99a3a791f1875f705ebab18c",
+      "public_source_role_projection_sha256": "7c93f71cfa23c0f690d70e87ef4f454d05494c9184babab7923b59d99aee56bc",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "source_appendix_problessthan_score_gap_rate_iid_completion": {
+      "accepted_source_role_contract_sha256": "1916479851b6adb57b531e4600a0d0990a7eadba1aa78835db6fdb907d26c76d",
+      "public_source_role_projection_sha256": "2bf76ba80a0d4574a7224aabe10671b98802e28e882fb5edeb133f32b6cdb79c",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "source_definition_aggregate_score_formula": {
+      "accepted_source_role_contract_sha256": "d3cd85cd8a8efa9bf065e7c234a699a8f1b7e31508267a7d585da59f310492b4",
+      "public_source_role_projection_sha256": "85951d3ee3c8597237da156012b733d1b6086c1fb760a0712d6aa8df375aa857",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "source_definition_extended_rate_function_formula": {
+      "accepted_source_role_contract_sha256": "1013bac0f64d961cf710c45bb3ffa3c3e7f4a01364f2c91a5854886aa5488ca1",
+      "public_source_role_projection_sha256": "1013bac0f64d961cf710c45bb3ffa3c3e7f4a01364f2c91a5854886aa5488ca1",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_definition_floor_sample_count_formula": {
+      "accepted_source_role_contract_sha256": "1013bac0f64d961cf710c45bb3ffa3c3e7f4a01364f2c91a5854886aa5488ca1",
+      "public_source_role_projection_sha256": "1013bac0f64d961cf710c45bb3ffa3c3e7f4a01364f2c91a5854886aa5488ca1",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_definition_log_mgf_formula": {
+      "accepted_source_role_contract_sha256": "1013bac0f64d961cf710c45bb3ffa3c3e7f4a01364f2c91a5854886aa5488ca1",
+      "public_source_role_projection_sha256": "1013bac0f64d961cf710c45bb3ffa3c3e7f4a01364f2c91a5854886aa5488ca1",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_definition_pairwise_objective_formula": {
+      "accepted_source_role_contract_sha256": "1013bac0f64d961cf710c45bb3ffa3c3e7f4a01364f2c91a5854886aa5488ca1",
+      "public_source_role_projection_sha256": "1013bac0f64d961cf710c45bb3ffa3c3e7f4a01364f2c91a5854886aa5488ca1",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_definition_rate_function_formula": {
+      "accepted_source_role_contract_sha256": "1013bac0f64d961cf710c45bb3ffa3c3e7f4a01364f2c91a5854886aa5488ca1",
+      "public_source_role_projection_sha256": "1013bac0f64d961cf710c45bb3ffa3c3e7f4a01364f2c91a5854886aa5488ca1",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_definition_uniform_ranking_normalization": {
+      "accepted_source_role_contract_sha256": "7f455481291f956a421d120b6c70436f733349dd65b44d7513c98b31b5dea869",
+      "public_source_role_projection_sha256": "7f455481291f956a421d120b6c70436f733349dd65b44d7513c98b31b5dea869",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_definition_uniform_ranking_objective_formula": {
+      "accepted_source_role_contract_sha256": "1013bac0f64d961cf710c45bb3ffa3c3e7f4a01364f2c91a5854886aa5488ca1",
+      "public_source_role_projection_sha256": "1013bac0f64d961cf710c45bb3ffa3c3e7f4a01364f2c91a5854886aa5488ca1",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_fidelity_diagnostic_unrestricted_real_pairwise_rate_mismatch": {
+      "accepted_source_role_contract_sha256": "d14f0162c3c2236c7a0bf53ef5a1c9c7cfb574a392c85dc582f08b8551353b7b",
+      "public_source_role_projection_sha256": "d14f0162c3c2236c7a0bf53ef5a1c9c7cfb574a392c85dc582f08b8551353b7b",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_iid_completion_pairwise_objective_bridge": {
+      "accepted_source_role_contract_sha256": "7e1bcd68f89299e3b79beb7596e5ea77dff3c8b80e47d539627d169faadc2ee4",
+      "public_source_role_projection_sha256": "7e1bcd68f89299e3b79beb7596e5ea77dff3c8b80e47d539627d169faadc2ee4",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_iid_completion_uniform_ranking_objective_bridge": {
+      "accepted_source_role_contract_sha256": "7e1bcd68f89299e3b79beb7596e5ea77dff3c8b80e47d539627d169faadc2ee4",
+      "public_source_role_projection_sha256": "7e1bcd68f89299e3b79beb7596e5ea77dff3c8b80e47d539627d169faadc2ee4",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_iid_completion_weak_inversion_bridge": {
+      "accepted_source_role_contract_sha256": "7e1bcd68f89299e3b79beb7596e5ea77dff3c8b80e47d539627d169faadc2ee4",
+      "public_source_role_projection_sha256": "7e1bcd68f89299e3b79beb7596e5ea77dff3c8b80e47d539627d169faadc2ee4",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_pairwise_objective_tendsto_one_iid_completion": {
+      "accepted_source_role_contract_sha256": "0269b1deec650640d447ae495973eda8547841d25ea336112bae1a30dd563d66",
+      "public_source_role_projection_sha256": "0269b1deec650640d447ae495973eda8547841d25ea336112bae1a30dd563d66",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_theorem1_informative_rating_system_rate_iid_completion": {
+      "accepted_source_role_contract_sha256": "d895cd17b85e0fc6e6d02e6a356668ad95a59127b5ddd65456ee19429f2dd75c",
+      "public_source_role_projection_sha256": "d895cd17b85e0fc6e6d02e6a356668ad95a59127b5ddd65456ee19429f2dd75c",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_uniform_ranking_objective_tendsto_one_iid_completion": {
+      "accepted_source_role_contract_sha256": "0269b1deec650640d447ae495973eda8547841d25ea336112bae1a30dd563d66",
+      "public_source_role_projection_sha256": "0269b1deec650640d447ae495973eda8547841d25ea336112bae1a30dd563d66",
+      "schema": 1,
+      "withheld_field_paths": []
+    }
+  },
+  "paper": "GJ18InformativeRatingSystems",
+  "private_role_material_included": false,
+  "private_source_map_material_sha256": "c006370595f5a9a679536559731ec57b6270a651b06351e59de304b78ccb5bc8",
+  "private_source_map_sha256": "b618624b4423fe83cfe2586b9667a681663e1a416c62ce3e7ea4c61eaec1a37c",
+  "projection_contract_sha256": "ed0964edc9c70f5ce087ce9bf134712ca40c7964ecaefd403309ac9a1b47d34d",
+  "public_display_manifest_material_sha256": "19919be4744589679e6f35e9cd63d5bb25d19946ff006d608cc85fbac4e1da76",
+  "public_display_manifest_sha256": "d6a0fa07dfa77ff7bb40bde8478af07a44eeeb827360089b29000b405096df91",
+  "public_source_map_material_sha256": "5cbc97c9a509cc025ce250b5418b5c4b1f6f6342115a698b21c8f2be05f7d6a8",
+  "public_source_map_sha256": "0de6effb039be3d8fd405912bb623e648ae2214863cbc420f85b4709d5cffc16",
+  "raw_private_approval_material_included": false,
+  "schema": 1
+}

--- a/papers/GJ19OptimalBinaryRatingSystems/audit/paper_statement_map.json
+++ b/papers/GJ19OptimalBinaryRatingSystems/audit/paper_statement_map.json
@@ -3019,6 +3019,11 @@
     "GJ19OptimalBinaryRatingSystems.spearmanLinearWeightOrderedPairIntervalObjective": "definitionC1_kendall_spearman",
     "GJ19OptimalBinaryRatingSystems.theorem32WeightedNestedBisectionOutput": "algorithm1_high_level"
   },
+  "publication_source_display_projection": {
+    "manifest": "audit/public_source_display_projection.json",
+    "raw_source_bytes_included": false,
+    "schema": 1
+  },
   "schema": 1,
   "semantic_contract_schema": 1,
   "semantic_route_schema": 2,

--- a/papers/GJ19OptimalBinaryRatingSystems/audit/public_source_role_projection.json
+++ b/papers/GJ19OptimalBinaryRatingSystems/audit/public_source_role_projection.json
@@ -1,0 +1,512 @@
+{
+  "acceptance_credential": false,
+  "accepted_graph_sha256": "747b5452b39547b2ad70615090aa8fbd47d7cf1991dd013e11a34ab3857d4956",
+  "bindings_by_source_item": {
+    "algorithm1_bisect_next_level": {
+      "accepted_source_role_contract_sha256": "542a8edab99fe7ae92184dbbc9611804cfb7900f01fd8d788b3e25bec732afbb",
+      "public_source_role_projection_sha256": "542a8edab99fe7ae92184dbbc9611804cfb7900f01fd8d788b3e25bec732afbb",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "algorithm1_calculate_other_levels": {
+      "accepted_source_role_contract_sha256": "542a8edab99fe7ae92184dbbc9611804cfb7900f01fd8d788b3e25bec732afbb",
+      "public_source_role_projection_sha256": "542a8edab99fe7ae92184dbbc9611804cfb7900f01fd8d788b3e25bec732afbb",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "algorithm1_detailed_main": {
+      "accepted_source_role_contract_sha256": "542a8edab99fe7ae92184dbbc9611804cfb7900f01fd8d788b3e25bec732afbb",
+      "public_source_role_projection_sha256": "542a8edab99fe7ae92184dbbc9611804cfb7900f01fd8d788b3e25bec732afbb",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "algorithm1_high_level": {
+      "accepted_source_role_contract_sha256": "48e39d93ab7e5f12d6c9d8a7a617c398d392fc3c5b98eeb0320c2bb31df88e0a",
+      "public_source_role_projection_sha256": "48e39d93ab7e5f12d6c9d8a7a617c398d392fc3c5b98eeb0320c2bb31df88e0a",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "algorithm1_pairwise_rate": {
+      "accepted_source_role_contract_sha256": "542a8edab99fe7ae92184dbbc9611804cfb7900f01fd8d788b3e25bec732afbb",
+      "public_source_role_projection_sha256": "542a8edab99fe7ae92184dbbc9611804cfb7900f01fd8d788b3e25bec732afbb",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "appendixB1_active_set": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "appendixB1_state_update": {
+      "accepted_source_role_contract_sha256": "7943bb0a1038c9b9ca1ec777a62b2cf0d2afdf222d3ccb832d0d97bcd18dfc6a",
+      "public_source_role_projection_sha256": "7943bb0a1038c9b9ca1ec777a62b2cf0d2afdf222d3ccb832d0d97bcd18dfc6a",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "appendixB1_transition_kernel": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "appendixC5_rate_notation_eq23": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "corollaryC1_rate_tends_to_zero": {
+      "accepted_source_role_contract_sha256": "f4254796949514af697b1a57a525740c36a37b17d9eafef0da4f0bb27d637328",
+      "public_source_role_projection_sha256": "f4254796949514af697b1a57a525740c36a37b17d9eafef0da4f0bb27d637328",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "corollaryC2_mesh_tends_to_zero": {
+      "accepted_source_role_contract_sha256": "f4254796949514af697b1a57a525740c36a37b17d9eafef0da4f0bb27d637328",
+      "public_source_role_projection_sha256": "f4254796949514af697b1a57a525740c36a37b17d9eafef0da4f0bb27d637328",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "corollaryC3_monotone_first_level_bound": {
+      "accepted_source_role_contract_sha256": "f4254796949514af697b1a57a525740c36a37b17d9eafef0da4f0bb27d637328",
+      "public_source_role_projection_sha256": "f4254796949514af697b1a57a525740c36a37b17d9eafef0da4f0bb27d637328",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "corollaryC4_kendall_spearman_subsequence": {
+      "accepted_source_role_contract_sha256": "f4254796949514af697b1a57a525740c36a37b17d9eafef0da4f0bb27d637328",
+      "public_source_role_projection_sha256": "f4254796949514af697b1a57a525740c36a37b17d9eafef0da4f0bb27d637328",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definitionC1_kendall_spearman": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition_bernoulli_kl": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition_large_deviation_rate": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition_lexicographic_objective": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition_pairwise_accuracy_eq1": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition_step_rule_partition_levels": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition_weighted_objective_eq2": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "experiment_empirical_question_response": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "experiment_random_question_observations": {
+      "accepted_source_role_contract_sha256": "48e39d93ab7e5f12d6c9d8a7a617c398d392fc3c5b98eeb0320c2bb31df88e0a",
+      "public_source_role_projection_sha256": "48e39d93ab7e5f12d6c9d8a7a617c398d392fc3c5b98eeb0320c2bb31df88e0a",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "known_type_experiment_definition": {
+      "accepted_source_role_contract_sha256": "48e39d93ab7e5f12d6c9d8a7a617c398d392fc3c5b98eeb0320c2bb31df88e0a",
+      "public_source_role_projection_sha256": "48e39d93ab7e5f12d6c9d8a7a617c398d392fc3c5b98eeb0320c2bb31df88e0a",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "known_type_neighbor_extension": {
+      "accepted_source_role_contract_sha256": "542a8edab99fe7ae92184dbbc9611804cfb7900f01fd8d788b3e25bec732afbb",
+      "public_source_role_projection_sha256": "542a8edab99fe7ae92184dbbc9611804cfb7900f01fd8d788b3e25bec732afbb",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lemma31_closed_adjacent_rate": {
+      "accepted_source_role_contract_sha256": "7943bb0a1038c9b9ca1ec777a62b2cf0d2afdf222d3ccb832d0d97bcd18dfc6a",
+      "public_source_role_projection_sha256": "7943bb0a1038c9b9ca1ec777a62b2cf0d2afdf222d3ccb832d0d97bcd18dfc6a",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lemma31_equalization_eq4": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lemma31_equalization_uniqueness_proof": {
+      "accepted_source_role_contract_sha256": "5d52e39bde3dcc7bb430024f7642dd44a50b945d19a2894c8fae93e97b984c00",
+      "public_source_role_projection_sha256": "5d52e39bde3dcc7bb430024f7642dd44a50b945d19a2894c8fae93e97b984c00",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lemma31_threshold_equations21_22": {
+      "accepted_source_role_contract_sha256": "5d52e39bde3dcc7bb430024f7642dd44a50b945d19a2894c8fae93e97b984c00",
+      "public_source_role_projection_sha256": "5d52e39bde3dcc7bb430024f7642dd44a50b945d19a2894c8fae93e97b984c00",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lemmaB1_matching_rate_shift": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lemmaB2_fixed_finite_slln_step": {
+      "accepted_source_role_contract_sha256": "ff5a0e099e16c780ec0c807bad8030a1474e5e84b20ee9670ac2ec27355bdb21",
+      "public_source_role_projection_sha256": "ff5a0e099e16c780ec0c807bad8030a1474e5e84b20ee9670ac2ec27355bdb21",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lemmaB2_known_type_learning": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lemmaB3_fixed_finite_slln_ranking_step": {
+      "accepted_source_role_contract_sha256": "ff5a0e099e16c780ec0c807bad8030a1474e5e84b20ee9670ac2ec27355bdb21",
+      "public_source_role_projection_sha256": "ff5a0e099e16c780ec0c807bad8030a1474e5e84b20ee9670ac2ec27355bdb21",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lemmaB3_unknown_type_learning": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lemmaC10_spearman_reduction": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lemmaC11_kendall_equispaced": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lemmaC12_spearman_equispaced": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lemmaC1_mgf_ldp_equations1_3": {
+      "accepted_source_role_contract_sha256": "5d52e39bde3dcc7bb430024f7642dd44a50b945d19a2894c8fae93e97b984c00",
+      "public_source_role_projection_sha256": "5d52e39bde3dcc7bb430024f7642dd44a50b945d19a2894c8fae93e97b984c00",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lemmaC1_pairwise_error_rate": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lemmaC1_transcript_repeated_label": {
+      "accepted_source_role_contract_sha256": "06314758836e13a85a5bfb2b8461b35a83af82fe5dc0672f8fafca8ced1dda74",
+      "public_source_role_projection_sha256": "06314758836e13a85a5bfb2b8461b35a83af82fe5dc0672f8fafca8ced1dda74",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lemmaC2_binary_complement_rate": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lemmaC3_piecewise_constant_rate": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lemmaC3_proof_equations7_15": {
+      "accepted_source_role_contract_sha256": "5d52e39bde3dcc7bb430024f7642dd44a50b945d19a2894c8fae93e97b984c00",
+      "public_source_role_projection_sha256": "5d52e39bde3dcc7bb430024f7642dd44a50b945d19a2894c8fae93e97b984c00",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lemmaC4_positive_rate_iff_step": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lemmaC4_proof_equations16_18": {
+      "accepted_source_role_contract_sha256": "5d52e39bde3dcc7bb430024f7642dd44a50b945d19a2894c8fae93e97b984c00",
+      "public_source_role_projection_sha256": "5d52e39bde3dcc7bb430024f7642dd44a50b945d19a2894c8fae93e97b984c00",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lemmaC5_refinement_equations24_25": {
+      "accepted_source_role_contract_sha256": "e7960301914702af45e2b6b68d20aef532fe8473849db58c6eda39068f6de8d1",
+      "public_source_role_projection_sha256": "e7960301914702af45e2b6b68d20aef532fe8473849db58c6eda39068f6de8d1",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lemmaC5_transcript_repeated_label_3071": {
+      "accepted_source_role_contract_sha256": "06314758836e13a85a5bfb2b8461b35a83af82fe5dc0672f8fafca8ced1dda74",
+      "public_source_role_projection_sha256": "06314758836e13a85a5bfb2b8461b35a83af82fe5dc0672f8fafca8ced1dda74",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lemmaC5_transcript_repeated_label_3197": {
+      "accepted_source_role_contract_sha256": "06314758836e13a85a5bfb2b8461b35a83af82fe5dc0672f8fafca8ced1dda74",
+      "public_source_role_projection_sha256": "06314758836e13a85a5bfb2b8461b35a83af82fe5dc0672f8fafca8ced1dda74",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lemmaC5_transcript_repeated_label_3530": {
+      "accepted_source_role_contract_sha256": "06314758836e13a85a5bfb2b8461b35a83af82fe5dc0672f8fafca8ced1dda74",
+      "public_source_role_projection_sha256": "06314758836e13a85a5bfb2b8461b35a83af82fe5dc0672f8fafca8ced1dda74",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lemmaC5_transcript_repeated_label_3567": {
+      "accepted_source_role_contract_sha256": "06314758836e13a85a5bfb2b8461b35a83af82fe5dc0672f8fafca8ced1dda74",
+      "public_source_role_projection_sha256": "06314758836e13a85a5bfb2b8461b35a83af82fe5dc0672f8fafca8ced1dda74",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lemmaC5_uniform_doubled_chain": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lemmaC6_monotone_penultimate_bound": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lemmaC7_uniform_refinement_rate": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lemmaC8_uniform_first_level_bound": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lemmaC9_nested_bisection_runtime": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "model_binary_response": {
+      "accepted_source_role_contract_sha256": "25ae0445cbad5700740ca0d901cdb22fa81678daaa2adcfa53e3e0db581adee2",
+      "public_source_role_projection_sha256": "25ae0445cbad5700740ca0d901cdb22fa81678daaa2adcfa53e3e0db581adee2",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "model_empirical_reputation_distribution": {
+      "accepted_source_role_contract_sha256": "0c2028098511fdaf97110b8f57eb8ed7c4664a4964e7f2a3f72923d022b21220",
+      "public_source_role_projection_sha256": "0c2028098511fdaf97110b8f57eb8ed7c4664a4964e7f2a3f72923d022b21220",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "model_empirical_reputation_score": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "model_matching_counts": {
+      "accepted_source_role_contract_sha256": "e8bd731c387f27f23e485836c19e8cd56ab3be13060fd6b4343e29952fe8b856",
+      "public_source_role_projection_sha256": "e8bd731c387f27f23e485836c19e8cd56ab3be13060fd6b4343e29952fe8b856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "model_matching_function_conditions": {
+      "accepted_source_role_contract_sha256": "e8bd731c387f27f23e485836c19e8cd56ab3be13060fd6b4343e29952fe8b856",
+      "public_source_role_projection_sha256": "e8bd731c387f27f23e485836c19e8cd56ab3be13060fd6b4343e29952fe8b856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "model_quality_continuum": {
+      "accepted_source_role_contract_sha256": "e8bd731c387f27f23e485836c19e8cd56ab3be13060fd6b4343e29952fe8b856",
+      "public_source_role_projection_sha256": "e8bd731c387f27f23e485836c19e8cd56ab3be13060fd6b4343e29952fe8b856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "model_state_measure": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "model_uniform_quality_rank": {
+      "accepted_source_role_contract_sha256": "25ae0445cbad5700740ca0d901cdb22fa81678daaa2adcfa53e3e0db581adee2",
+      "public_source_role_projection_sha256": "25ae0445cbad5700740ca0d901cdb22fa81678daaa2adcfa53e3e0db581adee2",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "remarkC1_full_square_application": {
+      "accepted_source_role_contract_sha256": "5b9116a06fb2724bf8a0cd63d16df17a2d372beee0e554b0aee42a69373deb9d",
+      "public_source_role_projection_sha256": "5b9116a06fb2724bf8a0cd63d16df17a2d372beee0e554b0aee42a69373deb9d",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "remarkC2_kl_convexity": {
+      "accepted_source_role_contract_sha256": "256d06dd4d6feffd0b92decca07ae72f0923410de80864af8adf346bf1aebd8f",
+      "public_source_role_projection_sha256": "256d06dd4d6feffd0b92decca07ae72f0923410de80864af8adf346bf1aebd8f",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "section4_induced_binary_response": {
+      "accepted_source_role_contract_sha256": "7943bb0a1038c9b9ca1ec777a62b2cf0d2afdf222d3ccb832d0d97bcd18dfc6a",
+      "public_source_role_projection_sha256": "7943bb0a1038c9b9ca1ec777a62b2cf0d2afdf222d3ccb832d0d97bcd18dfc6a",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "section4_l1_design_eq5": {
+      "accepted_source_role_contract_sha256": "7943bb0a1038c9b9ca1ec777a62b2cf0d2afdf222d3ccb832d0d97bcd18dfc6a",
+      "public_source_role_projection_sha256": "7943bb0a1038c9b9ca1ec777a62b2cf0d2afdf222d3ccb832d0d97bcd18dfc6a",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "section4_question_design_minimizer": {
+      "accepted_source_role_contract_sha256": "48e39d93ab7e5f12d6c9d8a7a617c398d392fc3c5b98eeb0320c2bb31df88e0a",
+      "public_source_role_projection_sha256": "48e39d93ab7e5f12d6c9d8a7a617c398d392fc3c5b98eeb0320c2bb31df88e0a",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "section4_response_mixture": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem31_adjacent_rate_eq3": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem31_cell_matching_rate_definition": {
+      "accepted_source_role_contract_sha256": "7943bb0a1038c9b9ca1ec777a62b2cf0d2afdf222d3ccb832d0d97bcd18dfc6a",
+      "public_source_role_projection_sha256": "7943bb0a1038c9b9ca1ec777a62b2cf0d2afdf222d3ccb832d0d97bcd18dfc6a",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem31_discretization_value": {
+      "accepted_source_role_contract_sha256": "e281467186a58103a75639fd10781fb40b5373904f9348f286e6cff163007165",
+      "public_source_role_projection_sha256": "419ef9cbdce8c94dfc2cbd88b76791764c817b164ecbff07330e9ec45adbb4fd",
+      "schema": 1,
+      "withheld_field_paths": [
+        "user_approved_scope_exclusion.approval_reference",
+        "user_approved_scope_exclusion.source_locator"
+      ]
+    },
+    "theorem31_limit_equations19_20": {
+      "accepted_source_role_contract_sha256": "5d52e39bde3dcc7bb430024f7642dd44a50b945d19a2894c8fae93e97b984c00",
+      "public_source_role_projection_sha256": "5d52e39bde3dcc7bb430024f7642dd44a50b945d19a2894c8fae93e97b984c00",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem32_approximation_runtime": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem32_multiplicative_extension": {
+      "accepted_source_role_contract_sha256": "e8d9ea626c6796bf5c210b65cb2804170df6e599af23ff246323c14b850e4133",
+      "public_source_role_projection_sha256": "e8d9ea626c6796bf5c210b65cb2804170df6e599af23ff246323c14b850e4133",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem32_proof_and_error_runtime": {
+      "accepted_source_role_contract_sha256": "5d52e39bde3dcc7bb430024f7642dd44a50b945d19a2894c8fae93e97b984c00",
+      "public_source_role_projection_sha256": "5d52e39bde3dcc7bb430024f7642dd44a50b945d19a2894c8fae93e97b984c00",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theoremB1_proof_restatement": {
+      "accepted_source_role_contract_sha256": "1d239652a90cbe5e5a6acfbc5170f0d2356a133066e0067a00e2dbb97c464b60",
+      "public_source_role_projection_sha256": "1d239652a90cbe5e5a6acfbc5170f0d2356a133066e0067a00e2dbb97c464b60",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theoremB1_proof_selector_nesting": {
+      "accepted_source_role_contract_sha256": "e7960301914702af45e2b6b68d20aef532fe8473849db58c6eda39068f6de8d1",
+      "public_source_role_projection_sha256": "e7960301914702af45e2b6b68d20aef532fe8473849db58c6eda39068f6de8d1",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theoremB1_quantile_representation": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theoremB1_uniform_subsequence": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theoremC1_laplace_principle": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "unknown_type_experiment_definition": {
+      "accepted_source_role_contract_sha256": "48e39d93ab7e5f12d6c9d8a7a617c398d392fc3c5b98eeb0320c2bb31df88e0a",
+      "public_source_role_projection_sha256": "48e39d93ab7e5f12d6c9d8a7a617c398d392fc3c5b98eeb0320c2bb31df88e0a",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "unknown_type_percentile_extension": {
+      "accepted_source_role_contract_sha256": "542a8edab99fe7ae92184dbbc9611804cfb7900f01fd8d788b3e25bec732afbb",
+      "public_source_role_projection_sha256": "542a8edab99fe7ae92184dbbc9611804cfb7900f01fd8d788b3e25bec732afbb",
+      "schema": 1,
+      "withheld_field_paths": []
+    }
+  },
+  "paper": "GJ19OptimalBinaryRatingSystems",
+  "private_role_material_included": false,
+  "private_source_map_material_sha256": "1ee892f8a938180edbe37ff398ae99476df3d99e278effb8c74c30110267e7b4",
+  "private_source_map_sha256": "414134bc480d3debb06804b2a5f34210bf168778a4ee9195df227b8cc3b2ab28",
+  "projection_contract_sha256": "ed0964edc9c70f5ce087ce9bf134712ca40c7964ecaefd403309ac9a1b47d34d",
+  "public_display_manifest_material_sha256": "ad50c106c30be6241ff879232df919860a8fb69c96ed7023ec50de8a6ace6e7a",
+  "public_display_manifest_sha256": "d1e386b08ff4c7577d095988a14897e256f77ade1ddb639365be8e7f30fa83e2",
+  "public_source_map_material_sha256": "64bbfdda87c1a1dc1ab0261d39187a9c5cfa5768b82c285ae9f824bb80e267e5",
+  "public_source_map_sha256": "5be1ee56b28b65cc4a250ca4bf202703c65627591875e5ce3b59b5ee7faa2361",
+  "raw_private_approval_material_included": false,
+  "schema": 1
+}

--- a/papers/GKGMM19IterativeLocalVoting/audit/paper_statement_map.json
+++ b/papers/GKGMM19IterativeLocalVoting/audit/paper_statement_map.json
@@ -1910,6 +1910,11 @@
     "GKGMM19IterativeLocalVoting.utilityBoundedOnSolutionSpaceFormulaData": "ilv_background_geometry_and_bounded_utility_formula",
     "GKGMM19IterativeLocalVoting.weightedEuclideanJointSampleFormulaData": "definition2_weighted_euclidean_utilities_formula"
   },
+  "publication_source_display_projection": {
+    "manifest": "audit/public_source_display_projection.json",
+    "raw_source_bytes_included": false,
+    "schema": 1
+  },
   "schema": 1,
   "semantic_contract_schema": 1,
   "semantic_route_schema": 2,

--- a/papers/GKGMM19IterativeLocalVoting/audit/public_source_role_projection.json
+++ b/papers/GKGMM19IterativeLocalVoting/audit/public_source_role_projection.json
@@ -1,0 +1,197 @@
+{
+  "acceptance_credential": false,
+  "accepted_graph_sha256": "1c10acd9ec32d9bb2d37fa53d24794a28e7618989d0e8d8e647cf6dfd9d556ae",
+  "bindings_by_source_item": {
+    "algorithm1_ilv": {
+      "accepted_source_role_contract_sha256": "393c3fe3e567f2b28ca0a160422fe3f05bd6b4abce06903388a23f71b314f7a5",
+      "public_source_role_projection_sha256": "393c3fe3e567f2b28ca0a160422fe3f05bd6b4abce06903388a23f71b314f7a5",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "appendix_lemma1_proof_restatement": {
+      "accepted_source_role_contract_sha256": "f712a128a06b4e15ff2d16311dbbb7cbc3920b95aeae2da76ba5083d135d267f",
+      "public_source_role_projection_sha256": "f712a128a06b4e15ff2d16311dbbb7cbc3920b95aeae2da76ba5083d135d267f",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "appendix_lemma4_proof_restatement": {
+      "accepted_source_role_contract_sha256": "f712a128a06b4e15ff2d16311dbbb7cbc3920b95aeae2da76ba5083d135d267f",
+      "public_source_role_projection_sha256": "f712a128a06b4e15ff2d16311dbbb7cbc3920b95aeae2da76ba5083d135d267f",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "appendix_proposition1_restatement": {
+      "accepted_source_role_contract_sha256": "16cfcd287e08ec46601a9221bff6cf8e13fdf5eb096f17c2d9894d3b40f27e7a",
+      "public_source_role_projection_sha256": "16cfcd287e08ec46601a9221bff6cf8e13fdf5eb096f17c2d9894d3b40f27e7a",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "appendix_proposition2_restatement": {
+      "accepted_source_role_contract_sha256": "16cfcd287e08ec46601a9221bff6cf8e13fdf5eb096f17c2d9894d3b40f27e7a",
+      "public_source_role_projection_sha256": "16cfcd287e08ec46601a9221bff6cf8e13fdf5eb096f17c2d9894d3b40f27e7a",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "appendix_theorem1_restatement": {
+      "accepted_source_role_contract_sha256": "18678200494b5733d8d94d1998063f9d55ccb348125ea070c4daab4102dab5e7",
+      "public_source_role_projection_sha256": "18678200494b5733d8d94d1998063f9d55ccb348125ea070c4daab4102dab5e7",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "appendix_theorem2_restatement": {
+      "accepted_source_role_contract_sha256": "18678200494b5733d8d94d1998063f9d55ccb348125ea070c4daab4102dab5e7",
+      "public_source_role_projection_sha256": "18678200494b5733d8d94d1998063f9d55ccb348125ea070c4daab4102dab5e7",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "appendix_theorem3_restatement": {
+      "accepted_source_role_contract_sha256": "18678200494b5733d8d94d1998063f9d55ccb348125ea070c4daab4102dab5e7",
+      "public_source_role_projection_sha256": "18678200494b5733d8d94d1998063f9d55ccb348125ea070c4daab4102dab5e7",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "conditions_c123_formula": {
+      "accepted_source_role_contract_sha256": "e8bd731c387f27f23e485836c19e8cd56ab3be13060fd6b4343e29952fe8b856",
+      "public_source_role_projection_sha256": "e8bd731c387f27f23e485836c19e8cd56ab3be13060fd6b4343e29952fe8b856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition1_lp_normed_utilities_formula": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition2_weighted_euclidean_utilities_formula": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition3_decomposable_utilities_formula": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "finite_c123_execution_model": {
+      "accepted_source_role_contract_sha256": "e8bd731c387f27f23e485836c19e8cd56ab3be13060fd6b4343e29952fe8b856",
+      "public_source_role_projection_sha256": "e8bd731c387f27f23e485836c19e8cd56ab3be13060fd6b4343e29952fe8b856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "ilv_background_geometry_and_bounded_utility_formula": {
+      "accepted_source_role_contract_sha256": "e8bd731c387f27f23e485836c19e8cd56ab3be13060fd6b4343e29952fe8b856",
+      "public_source_role_projection_sha256": "e8bd731c387f27f23e485836c19e8cd56ab3be13060fd6b4343e29952fe8b856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lemma3_finite_holder_dual_gradient_candidate_norm_formula": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "modelA_response_formula": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "modelB_finite_response_formula": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "proposition1_weighted_euclidean_l2": {
+      "accepted_source_role_contract_sha256": "64a83a0ae6edbdb2d3cfb6cb84e3bf045734ef9303f62643ff780eff69b02885",
+      "public_source_role_projection_sha256": "64a83a0ae6edbdb2d3cfb6cb84e3bf045734ef9303f62643ff780eff69b02885",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "proposition2_decomposable_linf_medians": {
+      "accepted_source_role_contract_sha256": "64a83a0ae6edbdb2d3cfb6cb84e3bf045734ef9303f62643ff780eff69b02885",
+      "public_source_role_projection_sha256": "64a83a0ae6edbdb2d3cfb6cb84e3bf045734ef9303f62643ff780eff69b02885",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "raw_utility_query_domain": {
+      "accepted_source_role_contract_sha256": "e8bd731c387f27f23e485836c19e8cd56ab3be13060fd6b4343e29952fe8b856",
+      "public_source_role_projection_sha256": "e8bd731c387f27f23e485836c19e8cd56ab3be13060fd6b4343e29952fe8b856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_appendix_lemma1_uniform_direction_error": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_appendix_lemma2_bad_event_linear_rate": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_appendix_lemma4_weighted_bad_event_linear_rate": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_appendix_theorem4_expected_subgradient": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_appendix_theorem5_ssgm_convergence": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_definition4_dlcd": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem1_lp_normed_dual_cases": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem2_modelB_holder_dual_norms": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem3_convergent_l2_modelB_is_directional_equilibrium": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem3_projected_source_model": {
+      "accepted_source_role_contract_sha256": "e8bd731c387f27f23e485836c19e8cd56ab3be13060fd6b4343e29952fe8b856",
+      "public_source_role_projection_sha256": "e8bd731c387f27f23e485836c19e8cd56ab3be13060fd6b4343e29952fe8b856",
+      "schema": 1,
+      "withheld_field_paths": []
+    }
+  },
+  "paper": "GKGMM19IterativeLocalVoting",
+  "private_role_material_included": false,
+  "private_source_map_material_sha256": "b3d3c4e7046b5ada4e2dfc82570aa3497f190164484ce4f2e1af10655fb7cad0",
+  "private_source_map_sha256": "fa64599f8163036dce602b076dc8831c0f34ee63b250a494a0c31fa4b5c2fb60",
+  "projection_contract_sha256": "ed0964edc9c70f5ce087ce9bf134712ca40c7964ecaefd403309ac9a1b47d34d",
+  "public_display_manifest_material_sha256": "3fc457c7306c8465aa4227a5072a2db941d3d74d0c236a9ad31be402ef852798",
+  "public_display_manifest_sha256": "ce610a3279336498e3fd19b184add3aafc8f94b1dfa04701c3e69710d3198acd",
+  "public_source_map_material_sha256": "784a3c1397ae43f657bf24c4fa1cd0c6307e77fba6e297d7f97504426833162a",
+  "public_source_map_sha256": "685d910b26379959d1dfc6cc1c102f9c52fce805fce4fece21c6492800e54842",
+  "raw_private_approval_material_included": false,
+  "schema": 1
+}

--- a/papers/GN21DriverSurgePricing/audit/paper_statement_map.json
+++ b/papers/GN21DriverSurgePricing/audit/paper_statement_map.json
@@ -1911,6 +1911,11 @@
     "GN21DriverSurgePricing.paper_lemma1_stochastic_dynamic_reward_decomposition_of_actual_calendar": "model_dynamic_iid_renewal_cycle_bridge",
     "GN21DriverSurgePricing.paper_lemma3_stochastic_time_fraction_formula_of_actual_calendar": "model_dynamic_iid_renewal_cycle_bridge"
   },
+  "publication_source_display_projection": {
+    "manifest": "audit/public_source_display_projection.json",
+    "raw_source_bytes_included": false,
+    "schema": 1
+  },
   "schema": 1,
   "semantic_contract_schema": 1,
   "semantic_route_schema": 2,

--- a/papers/GN21DriverSurgePricing/audit/public_source_display_projection.json
+++ b/papers/GN21DriverSurgePricing/audit/public_source_display_projection.json
@@ -1,9 +1,9 @@
 {
   "generator": "python3 scripts/public_source_display_projection.py",
   "paper_id": "GN21DriverSurgePricing",
-  "private_source_map_sha256": "8533e36ee10f0eadc60ef0d110fa512f80f730a99cbf4c373c1004e6a9e9b765",
+  "private_source_map_sha256": "a9d3c6228db98112a39c95482beee91e91b803e5a91c6750836f007470dc0d7b",
   "public_manifest_path": "papers/GN21DriverSurgePricing/audit/public_source_display_projection.json",
-  "public_source_map_sha256": "1c445d55a863421d362e5973dc9232a198af1ffc5d9930587fef77f0913d733b",
+  "public_source_map_sha256": "e1c9f52e5f9db748e5f5096155a7b5679a601daf60ea29fa4d0c1f1c34e29e4e",
   "raw_source_artifact_included": false,
   "raw_source_display_material": "selected_byte_pinned_source_anchor_quotes",
   "schema": 1,

--- a/papers/GN21DriverSurgePricing/audit/public_source_role_projection.json
+++ b/papers/GN21DriverSurgePricing/audit/public_source_role_projection.json
@@ -1,0 +1,329 @@
+{
+  "acceptance_credential": false,
+  "accepted_graph_sha256": "94cc0dfbd1f171eae519eb6b6de86530d73efc04283a804a6b7e40eb62cbf139",
+  "bindings_by_source_item": {
+    "assumption_affine_response_shape_domains": {
+      "accepted_source_role_contract_sha256": "4eb7d0ddb7e5eb47740d27e1726cffa809d85a00ebec41705e582883d0b99a65",
+      "public_source_role_projection_sha256": "4eb7d0ddb7e5eb47740d27e1726cffa809d85a00ebec41705e582883d0b99a65",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "assumption_affine_single_state_parameter_domain": {
+      "accepted_source_role_contract_sha256": "4eb7d0ddb7e5eb47740d27e1726cffa809d85a00ebec41705e582883d0b99a65",
+      "public_source_role_projection_sha256": "4eb7d0ddb7e5eb47740d27e1726cffa809d85a00ebec41705e582883d0b99a65",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "assumption_dynamic_time_fraction_denominators": {
+      "accepted_source_role_contract_sha256": "4eb7d0ddb7e5eb47740d27e1726cffa809d85a00ebec41705e582883d0b99a65",
+      "public_source_role_projection_sha256": "4eb7d0ddb7e5eb47740d27e1726cffa809d85a00ebec41705e582883d0b99a65",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "assumption_fixed_response_policy_form_conditions": {
+      "accepted_source_role_contract_sha256": "4eb7d0ddb7e5eb47740d27e1726cffa809d85a00ebec41705e582883d0b99a65",
+      "public_source_role_projection_sha256": "4eb7d0ddb7e5eb47740d27e1726cffa809d85a00ebec41705e582883d0b99a65",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "assumption_nonsurge_derivative_source_bounds": {
+      "accepted_source_role_contract_sha256": "4eb7d0ddb7e5eb47740d27e1726cffa809d85a00ebec41705e582883d0b99a65",
+      "public_source_role_projection_sha256": "4eb7d0ddb7e5eb47740d27e1726cffa809d85a00ebec41705e582883d0b99a65",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "assumption_single_state_defined_reward_domain": {
+      "accepted_source_role_contract_sha256": "4eb7d0ddb7e5eb47740d27e1726cffa809d85a00ebec41705e582883d0b99a65",
+      "public_source_role_projection_sha256": "4eb7d0ddb7e5eb47740d27e1726cffa809d85a00ebec41705e582883d0b99a65",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "assumption_surge_derivative_source_bounds": {
+      "accepted_source_role_contract_sha256": "4eb7d0ddb7e5eb47740d27e1726cffa809d85a00ebec41705e582883d0b99a65",
+      "public_source_role_projection_sha256": "4eb7d0ddb7e5eb47740d27e1726cffa809d85a00ebec41705e582883d0b99a65",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "assumption_switch_rate_domain": {
+      "accepted_source_role_contract_sha256": "4eb7d0ddb7e5eb47740d27e1726cffa809d85a00ebec41705e582883d0b99a65",
+      "public_source_role_projection_sha256": "4eb7d0ddb7e5eb47740d27e1726cffa809d85a00ebec41705e582883d0b99a65",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "assumption_theorem3_source_data_domain": {
+      "accepted_source_role_contract_sha256": "4eb7d0ddb7e5eb47740d27e1726cffa809d85a00ebec41705e582883d0b99a65",
+      "public_source_role_projection_sha256": "4eb7d0ddb7e5eb47740d27e1726cffa809d85a00ebec41705e582883d0b99a65",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "assumption_upper_endpoint_derivative_domain": {
+      "accepted_source_role_contract_sha256": "4eb7d0ddb7e5eb47740d27e1726cffa809d85a00ebec41705e582883d0b99a65",
+      "public_source_role_projection_sha256": "4eb7d0ddb7e5eb47740d27e1726cffa809d85a00ebec41705e582883d0b99a65",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "condition_lemma5_component_variation": {
+      "accepted_source_role_contract_sha256": "2d6df3df23dfc6bde6da0073116e6b4bb3a841d86daed6f8b12513f1ec5cfccd",
+      "public_source_role_projection_sha256": "2d6df3df23dfc6bde6da0073116e6b4bb3a841d86daed6f8b12513f1ec5cfccd",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "condition_lemma6_endpoint_derivative_data": {
+      "accepted_source_role_contract_sha256": "2d6df3df23dfc6bde6da0073116e6b4bb3a841d86daed6f8b12513f1ec5cfccd",
+      "public_source_role_projection_sha256": "2d6df3df23dfc6bde6da0073116e6b4bb3a841d86daed6f8b12513f1ec5cfccd",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "gn21_lemma10_appendix_presentation": {
+      "accepted_source_role_contract_sha256": "f712a128a06b4e15ff2d16311dbbb7cbc3920b95aeae2da76ba5083d135d267f",
+      "public_source_role_projection_sha256": "f712a128a06b4e15ff2d16311dbbb7cbc3920b95aeae2da76ba5083d135d267f",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "gn21_lemma1_appendix_presentation": {
+      "accepted_source_role_contract_sha256": "f712a128a06b4e15ff2d16311dbbb7cbc3920b95aeae2da76ba5083d135d267f",
+      "public_source_role_projection_sha256": "f712a128a06b4e15ff2d16311dbbb7cbc3920b95aeae2da76ba5083d135d267f",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "gn21_lemma2_appendix_presentation": {
+      "accepted_source_role_contract_sha256": "f712a128a06b4e15ff2d16311dbbb7cbc3920b95aeae2da76ba5083d135d267f",
+      "public_source_role_projection_sha256": "f712a128a06b4e15ff2d16311dbbb7cbc3920b95aeae2da76ba5083d135d267f",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "gn21_lemma3_appendix_presentation": {
+      "accepted_source_role_contract_sha256": "f712a128a06b4e15ff2d16311dbbb7cbc3920b95aeae2da76ba5083d135d267f",
+      "public_source_role_projection_sha256": "f712a128a06b4e15ff2d16311dbbb7cbc3920b95aeae2da76ba5083d135d267f",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "gn21_lemma6_appendix_presentation": {
+      "accepted_source_role_contract_sha256": "f712a128a06b4e15ff2d16311dbbb7cbc3920b95aeae2da76ba5083d135d267f",
+      "public_source_role_projection_sha256": "f712a128a06b4e15ff2d16311dbbb7cbc3920b95aeae2da76ba5083d135d267f",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "gn21_lemma7_appendix_presentation": {
+      "accepted_source_role_contract_sha256": "f712a128a06b4e15ff2d16311dbbb7cbc3920b95aeae2da76ba5083d135d267f",
+      "public_source_role_projection_sha256": "f712a128a06b4e15ff2d16311dbbb7cbc3920b95aeae2da76ba5083d135d267f",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "gn21_lemma8_appendix_presentation": {
+      "accepted_source_role_contract_sha256": "f712a128a06b4e15ff2d16311dbbb7cbc3920b95aeae2da76ba5083d135d267f",
+      "public_source_role_projection_sha256": "f712a128a06b4e15ff2d16311dbbb7cbc3920b95aeae2da76ba5083d135d267f",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "gn21_lemma9_appendix_presentation": {
+      "accepted_source_role_contract_sha256": "f712a128a06b4e15ff2d16311dbbb7cbc3920b95aeae2da76ba5083d135d267f",
+      "public_source_role_projection_sha256": "f712a128a06b4e15ff2d16311dbbb7cbc3920b95aeae2da76ba5083d135d267f",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "gn21_theorem3_appendix_presentation": {
+      "accepted_source_role_contract_sha256": "18678200494b5733d8d94d1998063f9d55ccb348125ea070c4daab4102dab5e7",
+      "public_source_role_projection_sha256": "18678200494b5733d8d94d1998063f9d55ccb348125ea070c4daab4102dab5e7",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "model_dynamic_iid_renewal_cycle_bridge": {
+      "accepted_source_role_contract_sha256": "cb4c52d7162057fe79d176483b8606eae69ef415544ac40e16cd2b0dd1287867",
+      "public_source_role_projection_sha256": "cb4c52d7162057fe79d176483b8606eae69ef415544ac40e16cd2b0dd1287867",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "model_policy_equalities_modulo_null_sets": {
+      "accepted_source_role_contract_sha256": "cb4c52d7162057fe79d176483b8606eae69ef415544ac40e16cd2b0dd1287867",
+      "public_source_role_projection_sha256": "cb4c52d7162057fe79d176483b8606eae69ef415544ac40e16cd2b0dd1287867",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "model_theorem3_nonnegative_target_rate_convention": {
+      "accepted_source_role_contract_sha256": "25ae0445cbad5700740ca0d901cdb22fa81678daaa2adcfa53e3e0db581adee2",
+      "public_source_role_projection_sha256": "25ae0445cbad5700740ca0d901cdb22fa81678daaa2adcfa53e3e0db581adee2",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "review_definition_dynamic_defined_reward": {
+      "accepted_source_role_contract_sha256": "25ae0445cbad5700740ca0d901cdb22fa81678daaa2adcfa53e3e0db581adee2",
+      "public_source_role_projection_sha256": "25ae0445cbad5700740ca0d901cdb22fa81678daaa2adcfa53e3e0db581adee2",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "review_definition_dynamic_ic": {
+      "accepted_source_role_contract_sha256": "b03be44aee1045ec135ecba63850242d11979b5638f12ae1892adcb8d8ca3c46",
+      "public_source_role_projection_sha256": "b03be44aee1045ec135ecba63850242d11979b5638f12ae1892adcb8d8ca3c46",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "review_definition_single_state_ic": {
+      "accepted_source_role_contract_sha256": "b03be44aee1045ec135ecba63850242d11979b5638f12ae1892adcb8d8ca3c46",
+      "public_source_role_projection_sha256": "b03be44aee1045ec135ecba63850242d11979b5638f12ae1892adcb8d8ca3c46",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "review_definition_threshold_policy": {
+      "accepted_source_role_contract_sha256": "b03be44aee1045ec135ecba63850242d11979b5638f12ae1892adcb8d8ca3c46",
+      "public_source_role_projection_sha256": "b03be44aee1045ec135ecba63850242d11979b5638f12ae1892adcb8d8ca3c46",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "review_lemma10_nonsurge_derivative_positive_of_acceptAll_bounds": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "review_lemma1_measured_dynamic_reward_decomposition": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "review_lemma2_switch_probability_formula": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "review_lemma3_measured_time_fraction_formula": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "review_lemma4_single_state_threshold_uniqueness": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "review_lemma6_upper_endpoint_derivative_formula": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "review_lemma7_affine_positive_additive_response_quasi_convex": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "review_lemma8_affine_negative_additive_response_quasi_concave": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "review_lemma9_surge_derivative_positive_of_acceptAll_bounds": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "review_proposition3_1_affine_single_state_ic": {
+      "accepted_source_role_contract_sha256": "64a83a0ae6edbdb2d3cfb6cb84e3bf045734ef9303f62643ff780eff69b02885",
+      "public_source_role_projection_sha256": "64a83a0ae6edbdb2d3cfb6cb84e3bf045734ef9303f62643ff780eff69b02885",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "review_remark1_switch_probability_per_time_strictAntiOn": {
+      "accepted_source_role_contract_sha256": "e8d9ea626c6796bf5c210b65cb2804170df6e599af23ff246323c14b850e4133",
+      "public_source_role_projection_sha256": "e8d9ea626c6796bf5c210b65cb2804170df6e599af23ff246323c14b850e4133",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "review_remark3_switch_probability_per_time_tendsto_at_zero": {
+      "accepted_source_role_contract_sha256": "e8d9ea626c6796bf5c210b65cb2804170df6e599af23ff246323c14b850e4133",
+      "public_source_role_projection_sha256": "e8d9ea626c6796bf5c210b65cb2804170df6e599af23ff246323c14b850e4133",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "review_remark4_switch_time_minus_switch_probability_nonneg": {
+      "accepted_source_role_contract_sha256": "e8d9ea626c6796bf5c210b65cb2804170df6e599af23ff246323c14b850e4133",
+      "public_source_role_projection_sha256": "e8d9ea626c6796bf5c210b65cb2804170df6e599af23ff246323c14b850e4133",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "review_section2_single_state_renewal_reward_iid_bridge": {
+      "accepted_source_role_contract_sha256": "0c2028098511fdaf97110b8f57eb8ed7c4664a4964e7f2a3f72923d022b21220",
+      "public_source_role_projection_sha256": "0c2028098511fdaf97110b8f57eb8ed7c4664a4964e7f2a3f72923d022b21220",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "review_theorem1_single_state_threshold_best_response": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "review_theorem2_multiplicative_policy_shape_source_claim": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "review_theorem2_multiplicative_positive_finite_cutoff_not_ic_both_states": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "review_theorem3_structured_pricing": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_definition_incentive_compatible": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_definition_surge_state": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_lemma5_full_variational_policy_forms": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_remark2_structured_derivative_kernel_algebra": {
+      "accepted_source_role_contract_sha256": "e8d9ea626c6796bf5c210b65cb2804170df6e599af23ff246323c14b850e4133",
+      "public_source_role_projection_sha256": "e8d9ea626c6796bf5c210b65cb2804170df6e599af23ff246323c14b850e4133",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_remark2_structured_scaled_earning_algebra": {
+      "accepted_source_role_contract_sha256": "e8d9ea626c6796bf5c210b65cb2804170df6e599af23ff246323c14b850e4133",
+      "public_source_role_projection_sha256": "e8d9ea626c6796bf5c210b65cb2804170df6e599af23ff246323c14b850e4133",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_theorem4_full_structural_policy_forms": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    }
+  },
+  "paper": "GN21DriverSurgePricing",
+  "private_role_material_included": false,
+  "private_source_map_material_sha256": "b88f60a5061b91fdfd851d50ac34793d9f812ee532636e423459090a09ff3250",
+  "private_source_map_sha256": "a9d3c6228db98112a39c95482beee91e91b803e5a91c6750836f007470dc0d7b",
+  "projection_contract_sha256": "ed0964edc9c70f5ce087ce9bf134712ca40c7964ecaefd403309ac9a1b47d34d",
+  "public_display_manifest_material_sha256": "f6553dcb9f77ac4643977c91f76cf5470d576ac2d42c7b4e2df77c39ff66fb4c",
+  "public_display_manifest_sha256": "adb618d3a8e85e7e9bec0ec120564230ebea2e7f612fb07ca275f8d79d19cfe3",
+  "public_source_map_material_sha256": "8862e3005495fa95cf7d552a60aea880602ab18ebc45bd9ac50bf4fdf64fde51",
+  "public_source_map_sha256": "e1c9f52e5f9db748e5f5096155a7b5679a601daf60ea29fa4d0c1f1c34e29e4e",
+  "raw_private_approval_material_included": false,
+  "schema": 1
+}

--- a/papers/GS62CollegeAdmissions/audit/paper_statement_map.json
+++ b/papers/GS62CollegeAdmissions/audit/paper_statement_map.json
@@ -501,6 +501,11 @@
     "GS62CollegeAdmissions.ExactCollegeBatchedProcedure.sourceWaitingListFinalAssignment": "section4_waiting_list_procedure_model",
     "GS62CollegeAdmissions.ExactCollegeBatchedProcedure.sourceWaitingListFinalState": "section4_waiting_list_procedure_model"
   },
+  "publication_source_display_projection": {
+    "manifest": "audit/public_source_display_projection.json",
+    "raw_source_bytes_included": false,
+    "schema": 1
+  },
   "schema": 1,
   "semantic_contract_schema": 1,
   "semantic_route_schema": 2,

--- a/papers/GS62CollegeAdmissions/audit/public_source_role_projection.json
+++ b/papers/GS62CollegeAdmissions/audit/public_source_role_projection.json
@@ -1,0 +1,59 @@
+{
+  "acceptance_credential": false,
+  "accepted_graph_sha256": "984111887de81d66476413c0f385d7f3088b511673ae0ac07c221f719b1a1fd3",
+  "bindings_by_source_item": {
+    "displayed_optimal_assignment_definition": {
+      "accepted_source_role_contract_sha256": "4a5d5e0481f12028d09716bdc408f7660f44a95750daceeff5b45886ab5c7091",
+      "public_source_role_projection_sha256": "4a5d5e0481f12028d09716bdc408f7660f44a95750daceeff5b45886ab5c7091",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "displayed_unstable_college_assignment_definition": {
+      "accepted_source_role_contract_sha256": "4a5d5e0481f12028d09716bdc408f7660f44a95750daceeff5b45886ab5c7091",
+      "public_source_role_projection_sha256": "4a5d5e0481f12028d09716bdc408f7660f44a95750daceeff5b45886ab5c7091",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "section3_marriage_instability_definition": {
+      "accepted_source_role_contract_sha256": "4a5d5e0481f12028d09716bdc408f7660f44a95750daceeff5b45886ab5c7091",
+      "public_source_role_projection_sha256": "4a5d5e0481f12028d09716bdc408f7660f44a95750daceeff5b45886ab5c7091",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "section4_waiting_list_procedure_model": {
+      "accepted_source_role_contract_sha256": "e8bd731c387f27f23e485836c19e8cd56ab3be13060fd6b4343e29952fe8b856",
+      "public_source_role_projection_sha256": "e8bd731c387f27f23e485836c19e8cd56ab3be13060fd6b4343e29952fe8b856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "section4_waiting_list_terminal_stability": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem1_stable_marriage_exists": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem2_applicant_optimality": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    }
+  },
+  "paper": "GS62CollegeAdmissions",
+  "private_role_material_included": false,
+  "private_source_map_material_sha256": "33b53c99e6af102233444fd089fd0488abbd0def06938525640f64bdf61df290",
+  "private_source_map_sha256": "60e662193001f2021ead099c251c4960b9be228a132a0b256eed1f98f5fcced7",
+  "projection_contract_sha256": "ed0964edc9c70f5ce087ce9bf134712ca40c7964ecaefd403309ac9a1b47d34d",
+  "public_display_manifest_material_sha256": "1af13de47fd8dd6b40097ef27c010165458d728931489616ed89d98063113187",
+  "public_display_manifest_sha256": "324e9a94aba2f36ca2e341ff8bd926e966a2cf8e158e01b02fd47675fbf71706",
+  "public_source_map_material_sha256": "802b343430aa19716174854bfebe23b57be76de21068a8429536e80c8bc2da8c",
+  "public_source_map_sha256": "cde327469dd4eedcd8e6ea623f755630af8598558428126eb553797e8508a5d7",
+  "raw_private_approval_material_included": false,
+  "schema": 1
+}

--- a/papers/GeEtAl2024AlignmentAxioms/audit/paper_statement_map.json
+++ b/papers/GeEtAl2024AlignmentAxioms/audit/paper_statement_map.json
@@ -1836,6 +1836,11 @@
     "approval_material_included": false,
     "schema": 1
   },
+  "publication_source_display_projection": {
+    "manifest": "audit/public_source_display_projection.json",
+    "raw_source_bytes_included": false,
+    "schema": 1
+  },
   "schema": 1,
   "semantic_contract_schema": 1,
   "semantic_route_schema": 2,

--- a/papers/GeEtAl2024AlignmentAxioms/audit/public_source_role_projection.json
+++ b/papers/GeEtAl2024AlignmentAxioms/audit/public_source_role_projection.json
@@ -1,0 +1,194 @@
+{
+  "acceptance_credential": false,
+  "accepted_graph_sha256": "4a71c52687abc0c5b125060d3814b1adbd527dc25ffb952287d0f4f5ddb069db",
+  "bindings_by_source_item": {
+    "appendix_b_unique_pmc_infeasible_example": {
+      "accepted_source_role_contract_sha256": "ff5a0e099e16c780ec0c807bad8030a1474e5e84b20ee9670ac2ec27355bdb21",
+      "public_source_role_projection_sha256": "ff5a0e099e16c780ec0c807bad8030a1474e5e84b20ee9670ac2ec27355bdb21",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "c1_rule_model": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition2_1_pareto_optimality": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition2_2_and_attached_consequences": {
+      "accepted_source_role_contract_sha256": "4a5d5e0481f12028d09716bdc408f7660f44a95750daceeff5b45886ab5c7091",
+      "public_source_role_projection_sha256": "4a5d5e0481f12028d09716bdc408f7660f44a95750daceeff5b45886ab5c7091",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition4_1_majority_consistency": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition4_2_winner_monotonicity": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definitionC_1_ranking_separability": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lcpo_quadratic_linear_program_implementation": {
+      "accepted_source_role_contract_sha256": "664bc2e7c33653721c670aa590886fd348e412e6e105731f1e47855858badea3",
+      "public_source_role_projection_sha256": "664bc2e7c33653721c670aa590886fd348e412e6e105731f1e47855858badea3",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lcpo_rule_model": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lemma3_2": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lemma3_3": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lemma3_4": {
+      "accepted_source_role_contract_sha256": "d33780436cd79f540d10ddaec63560d945e0f994fa966ae94e2cb1745cd114a4",
+      "public_source_role_projection_sha256": "5565faa8673f02b593016215642bb52d6a7acbd2d4e3986f7d2a65389d05b4bc",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "lemma3_5": {
+      "accepted_source_role_contract_sha256": "09f28da27de68e66404ec9d70e5abfe12c3209c46d053272dbebee2ac2a485c1",
+      "public_source_role_projection_sha256": "fec637d0f1560d304295fff17febacbcf34d189b00668066b8eeddf78f1db677",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "leximax_plurality_rule_model": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "linear_kemeny_rule_model": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "linear_social_choice_model": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "majority_loss_rule_model": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "pareto_kemeny_rule_model": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "standard_loss_rule_model": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem3_1": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem3_6": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem3_7_and_attached_consequences": {
+      "accepted_source_role_contract_sha256": "47823599efc5eefed1d1a37c1cf77309651f7b5f949fc0b013d9d0fa68ace840",
+      "public_source_role_projection_sha256": "34c3898f30b970a987558b7ba3258ddf5e389f6e6eff2ab91b53710bf9c44b16",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "theorem4_3": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theoremC_2": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theoremC_3": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theoremC_4": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theoremC_5": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theoremC_6": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    }
+  },
+  "paper": "GeEtAl2024AlignmentAxioms",
+  "private_role_material_included": false,
+  "private_source_map_material_sha256": "fb60077cb416e7be219580c9afb717e576c46de51d0594e165f8d06ce500d8fd",
+  "private_source_map_sha256": "7ea8859629abb71b790aae880dc95240d67cbde8d29c906e8190378fae46a25f",
+  "projection_contract_sha256": "ed0964edc9c70f5ce087ce9bf134712ca40c7964ecaefd403309ac9a1b47d34d",
+  "public_display_manifest_material_sha256": "b21b8f85da6900622bd9427a6e56896ce9d217ef255c371e1411424aeebbbb36",
+  "public_display_manifest_sha256": "1711dfe8f751613116cae68fcf6aa9aa4c43e034cdb693fdf740ca3b89cfae42",
+  "public_source_map_material_sha256": "940e8f830bb24ea24f38c63e4d9b809cde0319eae60712909652d42fff109156",
+  "public_source_map_sha256": "a8aabca10411710b499321ed1e4411b85821863bfb42fdecedcad6973661f3bb",
+  "raw_private_approval_material_included": false,
+  "schema": 1
+}

--- a/papers/HT26EFXChores/audit/paper_statement_map.json
+++ b/papers/HT26EFXChores/audit/paper_statement_map.json
@@ -1634,6 +1634,11 @@
     "HT26EFXChores.canonicalSmallChoreAllocationSourceDefinition": "canonical_allocation_definition",
     "HT26EFXChores.superCanonicalSmallChoreAllocationSourceDefinition": "supercanonical_allocation_definition"
   },
+  "publication_source_display_projection": {
+    "manifest": "audit/public_source_display_projection.json",
+    "raw_source_bytes_included": false,
+    "schema": 1
+  },
   "schema": 1,
   "seed_scaffold": false,
   "semantic_contract_policy": {

--- a/papers/HT26EFXChores/audit/public_source_role_projection.json
+++ b/papers/HT26EFXChores/audit/public_source_role_projection.json
@@ -1,0 +1,161 @@
+{
+  "acceptance_credential": false,
+  "accepted_graph_sha256": "a752d7961c3ca6e6daae53e942da65d47fa21898a4e9b715133f7be44df1cf87",
+  "bindings_by_source_item": {
+    "appendix_no_two_a_items": {
+      "accepted_source_role_contract_sha256": "64a83a0ae6edbdb2d3cfb6cb84e3bf045734ef9303f62643ff780eff69b02885",
+      "public_source_role_projection_sha256": "64a83a0ae6edbdb2d3cfb6cb84e3bf045734ef9303f62643ff780eff69b02885",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "appendix_p1_p2_lower_bounds": {
+      "accepted_source_role_contract_sha256": "64a83a0ae6edbdb2d3cfb6cb84e3bf045734ef9303f62643ff780eff69b02885",
+      "public_source_role_projection_sha256": "64a83a0ae6edbdb2d3cfb6cb84e3bf045734ef9303f62643ff780eff69b02885",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "balanced_orientation": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "canonical_allocation_definition": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "canonical_allocation_properties": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "canonical_short_long_labels_definition": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "composition": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "efx_for_chores_definition": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "efx_pareto_construction_has_efx": {
+      "accepted_source_role_contract_sha256": "ff5a0e099e16c780ec0c807bad8030a1474e5e84b20ee9670ac2ec27355bdb21",
+      "public_source_role_projection_sha256": "ff5a0e099e16c780ec0c807bad8030a1474e5e84b20ee9670ac2ec27355bdb21",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "efx_pareto_incompatibility": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "efx_po_cost_lower_bounds": {
+      "accepted_source_role_contract_sha256": "64a83a0ae6edbdb2d3cfb6cb84e3bf045734ef9303f62643ff780eff69b02885",
+      "public_source_role_projection_sha256": "64a83a0ae6edbdb2d3cfb6cb84e3bf045734ef9303f62643ff780eff69b02885",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "efx_po_every_agent_large": {
+      "accepted_source_role_contract_sha256": "64a83a0ae6edbdb2d3cfb6cb84e3bf045734ef9303f62643ff780eff69b02885",
+      "public_source_role_projection_sha256": "64a83a0ae6edbdb2d3cfb6cb84e3bf045734ef9303f62643ff780eff69b02885",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "envy_free_for_chores_definition": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "exceptional_residue_combination": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "four_agent_bi_valued_efx_exists": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "m2_efx_allocation": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "m2_efx_allocation_properties": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "m34_insertion": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "m34_insertion_general_agents": {
+      "accepted_source_role_contract_sha256": "ff5a0e099e16c780ec0c807bad8030a1474e5e84b20ee9670ac2ec27355bdb21",
+      "public_source_role_projection_sha256": "ff5a0e099e16c780ec0c807bad8030a1474e5e84b20ee9670ac2ec27355bdb21",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "pareto_optimality_definition": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "supercanonical_allocation_definition": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "tri_four_no_a_bundle_expensive": {
+      "accepted_source_role_contract_sha256": "64a83a0ae6edbdb2d3cfb6cb84e3bf045734ef9303f62643ff780eff69b02885",
+      "public_source_role_projection_sha256": "64a83a0ae6edbdb2d3cfb6cb84e3bf045734ef9303f62643ff780eff69b02885",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "tri_four_no_two_large": {
+      "accepted_source_role_contract_sha256": "64a83a0ae6edbdb2d3cfb6cb84e3bf045734ef9303f62643ff780eff69b02885",
+      "public_source_role_projection_sha256": "64a83a0ae6edbdb2d3cfb6cb84e3bf045734ef9303f62643ff780eff69b02885",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "tri_valued_nonexistence": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    }
+  },
+  "paper": "HT26EFXChores",
+  "private_role_material_included": false,
+  "private_source_map_material_sha256": "484132f84cf4501fcfc5d41e0180c8886da795d89bad3e6fcf37bd0a73dfcc4a",
+  "private_source_map_sha256": "c306918407fb20bebcf36bfe387134dbecf2958d40bc45c0559f7d2c243a6920",
+  "projection_contract_sha256": "ed0964edc9c70f5ce087ce9bf134712ca40c7964ecaefd403309ac9a1b47d34d",
+  "public_display_manifest_material_sha256": "db4bf83e2ad1b4347c9481e1291cd87dfd167c5537bb6b91e650fcbd17ff33e2",
+  "public_display_manifest_sha256": "3bdffff3ece784cb9d88826168478f62ba639fcd23a77416cea6e557548aa561",
+  "public_source_map_material_sha256": "9b41db0cdf37f01549a089bdcf63934141da03c426009a2de3981311975208f3",
+  "public_source_map_sha256": "03223c911f7b702d0f456c41ab11b2d94fe05aac0bdf44c2432d172e08426fc2",
+  "raw_private_approval_material_included": false,
+  "schema": 1
+}

--- a/papers/JGS23SupplySideRecommenderSystems/audit/paper_statement_map.json
+++ b/papers/JGS23SupplySideRecommenderSystems/audit/paper_statement_map.json
@@ -2555,6 +2555,11 @@
     "approval_material_included": false,
     "schema": 1
   },
+  "publication_source_display_projection": {
+    "manifest": "audit/public_source_display_projection.json",
+    "raw_source_bytes_included": false,
+    "schema": 1
+  },
   "schema": 1,
   "semantic_contract_schema": 1,
   "semantic_route_schema": 2,

--- a/papers/JGS23SupplySideRecommenderSystems/audit/public_source_role_projection.json
+++ b/papers/JGS23SupplySideRecommenderSystems/audit/public_source_role_projection.json
@@ -1,0 +1,398 @@
+{
+  "acceptance_credential": false,
+  "accepted_graph_sha256": "02245477c9532d8dd0d25d6b5924b88fd7fe09d798e3c565d9bd48cb13596d17",
+  "bindings_by_source_item": {
+    "beta_star_definition": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "claim_equivalence": {
+      "accepted_source_role_contract_sha256": "ff5a0e099e16c780ec0c807bad8030a1474e5e84b20ee9670ac2ec27355bdb21",
+      "public_source_role_projection_sha256": "ff5a0e099e16c780ec0c807bad8030a1474e5e84b20ee9670ac2ec27355bdb21",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "claim_necessarysuff": {
+      "accepted_source_role_contract_sha256": "f88f000083a0188d5269422e204c873a9973eb934141969d0deda3fd02904afb",
+      "public_source_role_projection_sha256": "bb7a93b6160d4ab55aa97cbfa9e623df303d7a21a47224b8713477d0f93ad249",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "corollary_beta": {
+      "accepted_source_role_contract_sha256": "e0dd450d32e4d9ac7be722951025d5cd05b4aed9e6ff4d60f0bddc298ebf9e1c",
+      "public_source_role_projection_sha256": "b1b789fb8c25bf139548e84d932db2f02757824da475a1b778474e31b50a5021",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "corollary_betaone": {
+      "accepted_source_role_contract_sha256": "3ff5f1739cede2ba8e143d09be8a0daaffed0a4e1b15b7fefcbe840fd64849a8",
+      "public_source_role_projection_sha256": "7eef650bc7ec78f67fe8f2f58f2c9c663606df85c336e98311149739abaa05ba",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "corollary_betap": {
+      "accepted_source_role_contract_sha256": "b67286be313cd4dd8484b24039365d4549798091d5fd0aaa59b568bdd9ae3eea",
+      "public_source_role_projection_sha256": "c0cf9baf4a9ac603f746e5ca5b04252440b3b5cda6e7188d7a2643e66b246fe9",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "corollary_onepopulation": {
+      "accepted_source_role_contract_sha256": "c9d98bef01bc9a0fa91458a93b8c336ea41af53d692da5ba80cd5ffe70d57848",
+      "public_source_role_projection_sha256": "78baf32a3c8bc4fcd0e2f19283a264361b2adca98cbb064a50b917aad8f3b11a",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "corollary_singlegenrestructure": {
+      "accepted_source_role_contract_sha256": "ac1609ef3b01bbbd118ce5aed7ed6f20576afb92a17509986ceb80a5c5658419",
+      "public_source_role_projection_sha256": "2fb81a42ffd3362527cdb3672d26aca9056f8eda1b3827267c58111f7a33f4b3",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "corollary_twousers": {
+      "accepted_source_role_contract_sha256": "3cbf9c04a9173ab4b0bd3ebcd988abc86a0eaffe0c2080b8e6c1921a845ddc22",
+      "public_source_role_projection_sha256": "a1d84d207d5976c874356563a7461566ddaba119d73e63dbce30fe107a4ef1d6",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "corollary_twousersprofit": {
+      "accepted_source_role_contract_sha256": "f4254796949514af697b1a57a525740c36a37b17d9eafef0da4f0bb27d637328",
+      "public_source_role_projection_sha256": "f4254796949514af697b1a57a525740c36a37b17d9eafef0da4f0bb27d637328",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition_infinitegenre": {
+      "accepted_source_role_contract_sha256": "50f4a29c780b7301fe004ed48efc92511abf04b6ce085330b0dc9033d59a9bfa",
+      "public_source_role_projection_sha256": "d80fdf4dc8005d80ccfd28d1cd17a50f0d04ae0f6f5d2ffbcef6b46ba7b95245",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "equilibrium_profit_model": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "example_one_dimensional_setup": {
+      "accepted_source_role_contract_sha256": "dd22d7273389b231f1d5763353015512570e8c0e3fb85df26f3796ef1da2434b",
+      "public_source_role_projection_sha256": "6e4e52c47f273ea37df8174e779a49190efa288799b4c0daa879296356a1d5bd",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "global_market_model": {
+      "accepted_source_role_contract_sha256": "e8bd731c387f27f23e485836c19e8cd56ab3be13060fd6b4343e29952fe8b856",
+      "public_source_role_projection_sha256": "e8bd731c387f27f23e485836c19e8cd56ab3be13060fd6b4343e29952fe8b856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "infinite_producer_model": {
+      "accepted_source_role_contract_sha256": "caa735a97f42cc9c36cacf31f87f6dc310a49c3e05e9cf71c055bae19953a9d2",
+      "public_source_role_projection_sha256": "91059d91f23646ebe32354c9f47dba37244c364efa75a639fbb1d15ab4c950df",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "lemma_cdf": {
+      "accepted_source_role_contract_sha256": "09ed7eb64fb5f4e968379a3ee922c7d8a96117b9ea82fd7afa817ab721e39850",
+      "public_source_role_projection_sha256": "c771bb60d2cd3acc6881ce63e4acfe90a1f4adab8477962ea8f42a6f740d136f",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "lemma_conditiongen": {
+      "accepted_source_role_contract_sha256": "f8663553d71f36948d0d3b0b44dcda1572ea3ad60e650a5c8a572f4ecfd21161",
+      "public_source_role_projection_sha256": "0ca466731e745d1593b69ea0c5cc613d5bbd6473586621fb8242b9d65f6912dc",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "lemma_foc": {
+      "accepted_source_role_contract_sha256": "974621f4c9b450f34c107c91b8e9f87f23c6b831f8ff1afc8f602f6cf8d0cf8e",
+      "public_source_role_projection_sha256": "b85f05a95c84a179aa745b50cf7f3a4ba1622ca1585b47e4cb85cac65bf340b8",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "lemma_inducedcost": {
+      "accepted_source_role_contract_sha256": "fce24415dc2398bbfec5d8cecd6faf7059d94a5d779758d8f817bd9faa74d4e9",
+      "public_source_role_projection_sha256": "8eecd613f7f73d1af2f207df40db18dc265204afb10a9094c8d5055b149b2dc0",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "lemma_nonzero": {
+      "accepted_source_role_contract_sha256": "fa75bd3616ec2ba38fd92cf55ff3a7ffe9daa1d3cd6063e76c77cef0e6ebdd1e",
+      "public_source_role_projection_sha256": "6369360f346d5cb5b82e72f33de8dbe0f353bdb0506c7f3e85d3e8b61e4051a0",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "lemma_optimizationprogram": {
+      "accepted_source_role_contract_sha256": "597d877e2e0150e7dc5ffeea14cc4a6237f1d6038c7988d6ebbf8010cde282c7",
+      "public_source_role_projection_sha256": "24d0296e07fc002c2fb6b42b441bf08f41d94384b3f1be10f1b755122134c204",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "lemma_optimizationprogramrestated": {
+      "accepted_source_role_contract_sha256": "79599b1aedd62e4d19746fcab827a4d305d3c67bd736de1c4be7130296ec249b",
+      "public_source_role_projection_sha256": "dd96271ceddce0dab2b4823318391d72f7ef0e12d6df5754693f0f6277caf0e2",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "lemma_optsingledirection": {
+      "accepted_source_role_contract_sha256": "348c304036dd52f02178bd07f6665143a293ee8a503ad4e66998c03bc30f230d",
+      "public_source_role_projection_sha256": "2495dc7063c7fc3ada46dc63c822a45f728348fd72adaf907a41ac1a00b1a4db",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "lemma_regionscolor": {
+      "accepted_source_role_contract_sha256": "56fdcadcc41f61e0927ac5eb653ed0285f5d227d2eb7d67abbfcdcfd03d49097",
+      "public_source_role_projection_sha256": "9b5214ddf13413251ca2f87a02beb8b0028ef26515a6a7c8cc93266354ec6b50",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "lemma_secondderiv": {
+      "accepted_source_role_contract_sha256": "f35789a423b90737f6c86711b66bd2bdadadc0862b050d5c32025b57d26d665e",
+      "public_source_role_projection_sha256": "8e642fff8e0d31b9b7bd39db4d6b7673085bc717b339b9b90b7502c28ddc89d0",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "lemma_standardbasismax": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lemma_supinf": {
+      "accepted_source_role_contract_sha256": "decb12455aa9325bad0aa8002789706de090fca6292c9c1f38e4094a30e1c8b9",
+      "public_source_role_projection_sha256": "9b039bd17216c272137e7e60adab6ce697ce53d8259988f41818347df250a0a9",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "powered_score_geometry": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "proposition_atom": {
+      "accepted_source_role_contract_sha256": "64a83a0ae6edbdb2d3cfb6cb84e3bf045734ef9303f62643ff780eff69b02885",
+      "public_source_role_projection_sha256": "64a83a0ae6edbdb2d3cfb6cb84e3bf045734ef9303f62643ff780eff69b02885",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "proposition_existence": {
+      "accepted_source_role_contract_sha256": "64a83a0ae6edbdb2d3cfb6cb84e3bf045734ef9303f62643ff780eff69b02885",
+      "public_source_role_projection_sha256": "64a83a0ae6edbdb2d3cfb6cb84e3bf045734ef9303f62643ff780eff69b02885",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "proposition_finitegenre": {
+      "accepted_source_role_contract_sha256": "b9f5441757f507d17d8cfdc764412fe9ca4ebcf95e53eb9f7c6bdd335b6b0355",
+      "public_source_role_projection_sha256": "bb8963fa261f5157a970ebf04f88888f97b2e6857eff36cddbea6566053949d1",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "proposition_finitep": {
+      "accepted_source_role_contract_sha256": "64a83a0ae6edbdb2d3cfb6cb84e3bf045734ef9303f62643ff780eff69b02885",
+      "public_source_role_projection_sha256": "64a83a0ae6edbdb2d3cfb6cb84e3bf045734ef9303f62643ff780eff69b02885",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "proposition_ptwo": {
+      "accepted_source_role_contract_sha256": "64a83a0ae6edbdb2d3cfb6cb84e3bf045734ef9303f62643ff780eff69b02885",
+      "public_source_role_projection_sha256": "64a83a0ae6edbdb2d3cfb6cb84e3bf045734ef9303f62643ff780eff69b02885",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "proposition_pure": {
+      "accepted_source_role_contract_sha256": "64a83a0ae6edbdb2d3cfb6cb84e3bf045734ef9303f62643ff780eff69b02885",
+      "public_source_role_projection_sha256": "64a83a0ae6edbdb2d3cfb6cb84e3bf045734ef9303f62643ff780eff69b02885",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "proposition_supportrestriction": {
+      "accepted_source_role_contract_sha256": "16c415f752125d41c6e95e3acab75c05f3e68cf2d0a6682e627df870df4f1bfe",
+      "public_source_role_projection_sha256": "983c83ceea6d1deed2c55a70a0a26b9709574088e3085ce91baeec2731a21a4e",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "proposition_uniqueness": {
+      "accepted_source_role_contract_sha256": "e2f9611515cd587f4536dcbab5e25f0065fca88473a97c2608c5f74e16ec4dee",
+      "public_source_role_projection_sha256": "fe0d654fcda1b75af20714f5947eb87b1721d5e1b71d64b42b2098eeda2b1453",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "proposition_utility": {
+      "accepted_source_role_contract_sha256": "4a119858914bea898d4427561113c202c7603e47f567e9d5f80da3d73981a261",
+      "public_source_role_projection_sha256": "44ca5461802a1a54efcebe74a790ca45720824191d6a0c6f8519741071f2bfbb",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "proposition_zeroutilitysinglegenre": {
+      "accepted_source_role_contract_sha256": "e2a92e80932ccf223b83479e68eb87ae3fd8a7c79184e3d06d67a9e1fdfa298d",
+      "public_source_role_projection_sha256": "7c10b1d9d77c134209a74d78fb2ec967891a92ebaa41535c134ba6068b933e51",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "quality_and_genre_model": {
+      "accepted_source_role_contract_sha256": "f1d85b1daeed829160485eecfdc9901788c75a294e3e3ce305aab294c73880e7",
+      "public_source_role_projection_sha256": "2dd96f55203dc35c77546fa7c5a1030e854176a09a4500522db724b092180e56",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "reparameterized_equilibrium_model": {
+      "accepted_source_role_contract_sha256": "d63535bff514df929741bacebaf72667128db0ba01daad1475748a0956696e61",
+      "public_source_role_projection_sha256": "13267af270fa6f0c1e27ee648f0c60733054ed44f4e321ff3c1b4a23fc4ec7b1",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "single_and_multi_genre_regimes": {
+      "accepted_source_role_contract_sha256": "f6cd58247703a7c7bd3364f1f4ba85c80a37e5ebd02a500d945e26daff242272",
+      "public_source_role_projection_sha256": "892e3941028e6e16271ffa1e365eb3bacc1700b5b41b0acd76943e63edddf329",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "symmetric_mixed_nash_model": {
+      "accepted_source_role_contract_sha256": "e8bd731c387f27f23e485836c19e8cd56ab3be13060fd6b4343e29952fe8b856",
+      "public_source_role_projection_sha256": "e8bd731c387f27f23e485836c19e8cd56ab3be13060fd6b4343e29952fe8b856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem_infinitegenre": {
+      "accepted_source_role_contract_sha256": "d87b190cecd687e62671fb8b8dd0c8af41d71b5686d520b7d7b6df005a25dbfe",
+      "public_source_role_projection_sha256": "0dc94eb8e0396a76bc8861bfcc66daed250d6206fda81a6cc9531838d1dfc9c8",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "theorem_infinitegenreformal": {
+      "accepted_source_role_contract_sha256": "96e7912e1a9f043f3efcdb99c6262e9e316fe12f1c993819413fa710888d2818",
+      "public_source_role_projection_sha256": "6372a4f60740643a75af0f3bba892d414622cad0e15614cdf07f0fd3f5eda913",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "theorem_phasetransition": {
+      "accepted_source_role_contract_sha256": "9bbd10e9565bb24492c9d45e0db93085d9ad2dff0786fb30d37fc2e419e5943e",
+      "public_source_role_projection_sha256": "f35c5539805c438c8c929bdcf2f6fce52ef183b67fbf5341c0f77db3affda855",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "theorem_singlegenre": {
+      "accepted_source_role_contract_sha256": "ea60442ddfeec7ea5cf99ba2a482ddd9c6295e14e3bf1a43a5bc9a9d265398b3",
+      "public_source_role_projection_sha256": "28c50d553120eee5119b26103da48c686c7a1526c22edb04f58e904c6e7deca8",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "two_population_model": {
+      "accepted_source_role_contract_sha256": "e8bd731c387f27f23e485836c19e8cd56ab3be13060fd6b4343e29952fe8b856",
+      "public_source_role_projection_sha256": "e8bd731c387f27f23e485836c19e8cd56ab3be13060fd6b4343e29952fe8b856",
+      "schema": 1,
+      "withheld_field_paths": []
+    }
+  },
+  "paper": "JGS23SupplySideRecommenderSystems",
+  "private_role_material_included": false,
+  "private_source_map_material_sha256": "5b904c386bef16f34c76598ce407e0967534ed1e65df79264a01552cdbe6ea54",
+  "private_source_map_sha256": "e58cd31b4212f08a9ff21f1e0b2efd2ea5de6441bf4d69e21a204dbe63efbe08",
+  "projection_contract_sha256": "ed0964edc9c70f5ce087ce9bf134712ca40c7964ecaefd403309ac9a1b47d34d",
+  "public_display_manifest_material_sha256": "cb27dfb8afc2ef886bf5e77031c5bd64028ea2df9ca3d9ed527d457c85bc103f",
+  "public_display_manifest_sha256": "bf14271cb43da52456f8096ff94c523c740df97f297e678fda1fdf96da027aeb",
+  "public_source_map_material_sha256": "fab77a3ca372cc7db6032c19454a8630d82ffc4662243c45f9be6b77647333b2",
+  "public_source_map_sha256": "48751038f5ec0469ab6028d95a444c210a75990b46510fd769aadc142db3fb3d",
+  "raw_private_approval_material_included": false,
+  "schema": 1
+}

--- a/papers/KR21Monoculture/audit/paper_statement_map.json
+++ b/papers/KR21Monoculture/audit/paper_statement_map.json
@@ -5814,6 +5814,11 @@
     "approval_material_included": false,
     "schema": 1
   },
+  "publication_source_display_projection": {
+    "manifest": "audit/public_source_display_projection.json",
+    "raw_source_bytes_included": false,
+    "schema": 1
+  },
   "schema": 1,
   "semantic_contract_schema": 1,
   "semantic_route_schema": 2,

--- a/papers/KR21Monoculture/audit/public_source_role_projection.json
+++ b/papers/KR21Monoculture/audit/public_source_role_projection.json
@@ -1,0 +1,464 @@
+{
+  "acceptance_credential": false,
+  "accepted_graph_sha256": "9e2f6d345ca39f7d36a0880d2fbe87b25b7902262d1ec62099f902ac71a746fb",
+  "bindings_by_source_item": {
+    "kr21_appendix_b_definition2_counterexample": {
+      "accepted_source_role_contract_sha256": "c79f4a621d9108cf8c646237b8b10db85641ea9b8e5ea0bdfb5bfce2fa42cf43",
+      "public_source_role_projection_sha256": "c79f4a621d9108cf8c646237b8b10db85641ea9b8e5ea0bdfb5bfce2fa42cf43",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "kr21_appendix_b_definition3_counterexample": {
+      "accepted_source_role_contract_sha256": "c79f4a621d9108cf8c646237b8b10db85641ea9b8e5ea0bdfb5bfce2fa42cf43",
+      "public_source_role_projection_sha256": "c79f4a621d9108cf8c646237b8b10db85641ea9b8e5ea0bdfb5bfce2fa42cf43",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "kr21_appendix_b_smoothing_approximation": {
+      "accepted_source_role_contract_sha256": "cda49d27d03d0611b210c217f18f31beddb3acae966283e8fdfcffb046b71e67",
+      "public_source_role_projection_sha256": "cda49d27d03d0611b210c217f18f31beddb3acae966283e8fdfcffb046b71e67",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "kr21_appendix_c_standard_error_function": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "kr21_definition1_noisy_permutation_family": {
+      "accepted_source_role_contract_sha256": "822eb6b726c650e8a7462f68776e0205749acc68d410f952bf00a8d8778c10d4",
+      "public_source_role_projection_sha256": "822eb6b726c650e8a7462f68776e0205749acc68d410f952bf00a8d8778c10d4",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "kr21_definition2_preference_first_position": {
+      "accepted_source_role_contract_sha256": "822eb6b726c650e8a7462f68776e0205749acc68d410f952bf00a8d8778c10d4",
+      "public_source_role_projection_sha256": "822eb6b726c650e8a7462f68776e0205749acc68d410f952bf00a8d8778c10d4",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "kr21_definition3_preference_weaker_competition": {
+      "accepted_source_role_contract_sha256": "822eb6b726c650e8a7462f68776e0205749acc68d410f952bf00a8d8778c10d4",
+      "public_source_role_projection_sha256": "822eb6b726c650e8a7462f68776e0205749acc68d410f952bf00a8d8778c10d4",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "kr21_definition4_strict_well_ordered_noise": {
+      "accepted_source_role_contract_sha256": "822eb6b726c650e8a7462f68776e0205749acc68d410f952bf00a8d8778c10d4",
+      "public_source_role_projection_sha256": "822eb6b726c650e8a7462f68776e0205749acc68d410f952bf00a8d8778c10d4",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "kr21_eq1_removal_monotonicity": {
+      "accepted_source_role_contract_sha256": "681cb01e0c6ad523a6783854abdf15672e47a475e01340c3b452f524adab3470",
+      "public_source_role_projection_sha256": "681cb01e0c6ad523a6783854abdf15672e47a475e01340c3b452f524adab3470",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "kr21_eq2_independence_payoff_equivalence": {
+      "accepted_source_role_contract_sha256": "681cb01e0c6ad523a6783854abdf15672e47a475e01340c3b452f524adab3470",
+      "public_source_role_projection_sha256": "681cb01e0c6ad523a6783854abdf15672e47a475e01340c3b452f524adab3470",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "kr21_eq3_independence_payoff_identity": {
+      "accepted_source_role_contract_sha256": "681cb01e0c6ad523a6783854abdf15672e47a475e01340c3b452f524adab3470",
+      "public_source_role_projection_sha256": "681cb01e0c6ad523a6783854abdf15672e47a475e01340c3b452f524adab3470",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "kr21_eq4_dominance_against_algorithm": {
+      "accepted_source_role_contract_sha256": "681cb01e0c6ad523a6783854abdf15672e47a475e01340c3b452f524adab3470",
+      "public_source_role_projection_sha256": "681cb01e0c6ad523a6783854abdf15672e47a475e01340c3b452f524adab3470",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "kr21_eq5_dominance_against_human": {
+      "accepted_source_role_contract_sha256": "681cb01e0c6ad523a6783854abdf15672e47a475e01340c3b452f524adab3470",
+      "public_source_role_projection_sha256": "681cb01e0c6ad523a6783854abdf15672e47a475e01340c3b452f524adab3470",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "kr21_eq6_indifference_threshold": {
+      "accepted_source_role_contract_sha256": "681cb01e0c6ad523a6783854abdf15672e47a475e01340c3b452f524adab3470",
+      "public_source_role_projection_sha256": "681cb01e0c6ad523a6783854abdf15672e47a475e01340c3b452f524adab3470",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "kr21_eq7_plackett_luce_first_choice": {
+      "accepted_source_role_contract_sha256": "681cb01e0c6ad523a6783854abdf15672e47a475e01340c3b452f524adab3470",
+      "public_source_role_projection_sha256": "681cb01e0c6ad523a6783854abdf15672e47a475e01340c3b452f524adab3470",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "kr21_eq8_mallows_law": {
+      "accepted_source_role_contract_sha256": "681cb01e0c6ad523a6783854abdf15672e47a475e01340c3b452f524adab3470",
+      "public_source_role_projection_sha256": "681cb01e0c6ad523a6783854abdf15672e47a475e01340c3b452f524adab3470",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "kr21_eq_a1_rum_monotonicity": {
+      "accepted_source_role_contract_sha256": "681cb01e0c6ad523a6783854abdf15672e47a475e01340c3b452f524adab3470",
+      "public_source_role_projection_sha256": "681cb01e0c6ad523a6783854abdf15672e47a475e01340c3b452f524adab3470",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "kr21_eq_b1_counterexample_probability": {
+      "accepted_source_role_contract_sha256": "681cb01e0c6ad523a6783854abdf15672e47a475e01340c3b452f524adab3470",
+      "public_source_role_projection_sha256": "681cb01e0c6ad523a6783854abdf15672e47a475e01340c3b452f524adab3470",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "kr21_eq_b2_counterexample_probability": {
+      "accepted_source_role_contract_sha256": "681cb01e0c6ad523a6783854abdf15672e47a475e01340c3b452f524adab3470",
+      "public_source_role_projection_sha256": "681cb01e0c6ad523a6783854abdf15672e47a475e01340c3b452f524adab3470",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "kr21_eq_c10_mills_derivative_bound": {
+      "accepted_source_role_contract_sha256": "681cb01e0c6ad523a6783854abdf15672e47a475e01340c3b452f524adab3470",
+      "public_source_role_projection_sha256": "681cb01e0c6ad523a6783854abdf15672e47a475e01340c3b452f524adab3470",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "kr21_eq_c1_definition3_payoff": {
+      "accepted_source_role_contract_sha256": "681cb01e0c6ad523a6783854abdf15672e47a475e01340c3b452f524adab3470",
+      "public_source_role_projection_sha256": "681cb01e0c6ad523a6783854abdf15672e47a475e01340c3b452f524adab3470",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "kr21_eq_c2_conditional_pairwise_monotonicity": {
+      "accepted_source_role_contract_sha256": "681cb01e0c6ad523a6783854abdf15672e47a475e01340c3b452f524adab3470",
+      "public_source_role_projection_sha256": "681cb01e0c6ad523a6783854abdf15672e47a475e01340c3b452f524adab3470",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "kr21_eq_c3_laplace_derivative_ratio": {
+      "accepted_source_role_contract_sha256": "681cb01e0c6ad523a6783854abdf15672e47a475e01340c3b452f524adab3470",
+      "public_source_role_projection_sha256": "681cb01e0c6ad523a6783854abdf15672e47a475e01340c3b452f524adab3470",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "kr21_eq_c4_laplace_positive_expression": {
+      "accepted_source_role_contract_sha256": "681cb01e0c6ad523a6783854abdf15672e47a475e01340c3b452f524adab3470",
+      "public_source_role_projection_sha256": "681cb01e0c6ad523a6783854abdf15672e47a475e01340c3b452f524adab3470",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "kr21_eq_c5_gaussian_conditional_integral": {
+      "accepted_source_role_contract_sha256": "681cb01e0c6ad523a6783854abdf15672e47a475e01340c3b452f524adab3470",
+      "public_source_role_projection_sha256": "681cb01e0c6ad523a6783854abdf15672e47a475e01340c3b452f524adab3470",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "kr21_eq_c6_gaussian_reduced_expression": {
+      "accepted_source_role_contract_sha256": "681cb01e0c6ad523a6783854abdf15672e47a475e01340c3b452f524adab3470",
+      "public_source_role_projection_sha256": "681cb01e0c6ad523a6783854abdf15672e47a475e01340c3b452f524adab3470",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "kr21_eq_c7_gaussian_left_tail_limit": {
+      "accepted_source_role_contract_sha256": "681cb01e0c6ad523a6783854abdf15672e47a475e01340c3b452f524adab3470",
+      "public_source_role_projection_sha256": "681cb01e0c6ad523a6783854abdf15672e47a475e01340c3b452f524adab3470",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "kr21_eq_c8_gaussian_derivative": {
+      "accepted_source_role_contract_sha256": "681cb01e0c6ad523a6783854abdf15672e47a475e01340c3b452f524adab3470",
+      "public_source_role_projection_sha256": "681cb01e0c6ad523a6783854abdf15672e47a475e01340c3b452f524adab3470",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "kr21_eq_c9_gaussian_bracket": {
+      "accepted_source_role_contract_sha256": "8206cc43a88b1307619c78504986d0e6eee42dd09acdb2c298d24e99629f4adc",
+      "public_source_role_projection_sha256": "e7336b4a3890953a9ff2df6aee11f3271b5eaecef5b126fe3646bdeddd5c2c9d",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "kr21_eq_d1_mallows_likelihood_ratio": {
+      "accepted_source_role_contract_sha256": "bc77c2371893f89c69afff841b330f6cc3b96aa9bec946b6c23118c850d52c2d",
+      "public_source_role_projection_sha256": "e7d7c68c94c18931fc7b765be3578dde2309f9a516ae0002523a86dcae891fee",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "kr21_eq_e1_mallows_definition2_target": {
+      "accepted_source_role_contract_sha256": "b1665af0f1fdb43a919c252871eb7567a51001740ba442d2295289c0b3a4e239",
+      "public_source_role_projection_sha256": "c838ea50670c92dd40c339cbca83c4f85b406a9b04fdf9a77b06e2a8817d33f8",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "kr21_eq_e2_mallows_top_two_comparison": {
+      "accepted_source_role_contract_sha256": "45caef30bab4e2f011ff5ac74eb02e90b26a2142996c82b7d37e726bb2e7b987",
+      "public_source_role_projection_sha256": "8f4f247e0b5551337ff98983df9f5be7309d79145d6bc550b10ba0f75b1ea23c",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "kr21_eq_e3_mallows_unconditional_product": {
+      "accepted_source_role_contract_sha256": "63eea7bffa39fa6e8fabb6ec63193e08cba0c98caeff4a95b8520458a52a6e15",
+      "public_source_role_projection_sha256": "4547a38e399b5d6a5c6c9f3e43f1b7c720dc06c5a12c1d8a223a39ddb0c0ef26",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "kr21_eq_f2_mallows_first_choice": {
+      "accepted_source_role_contract_sha256": "681cb01e0c6ad523a6783854abdf15672e47a475e01340c3b452f524adab3470",
+      "public_source_role_projection_sha256": "681cb01e0c6ad523a6783854abdf15672e47a475e01340c3b452f524adab3470",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "kr21_finite_support_weakening_remark": {
+      "accepted_source_role_contract_sha256": "10d7b2f8606025c26c3cdf934b6a3d7f7732fa05ec6e879ff7fceab1d1d8cd90",
+      "public_source_role_projection_sha256": "7ee9cc4c8d109b476c2161206c65702e628f85d8f9d3cd0789b7ca33b93d2f05",
+      "schema": 1,
+      "withheld_field_paths": [
+        "user_approved_scope_exclusion.approval_reference",
+        "user_approved_scope_exclusion.source_locator"
+      ]
+    },
+    "kr21_gaussian_signed_welfare_example": {
+      "accepted_source_role_contract_sha256": "b128b7aad097d2aa6d9c844a825c9c325b143751de7ffb3e0a975e8d09f71fe4",
+      "public_source_role_projection_sha256": "debad8f6e5381e877add776aa2a60862fb72a86dabf324b074203336dca3c0a0",
+      "schema": 1,
+      "withheld_field_paths": [
+        "user_approved_scope_exclusion.approval_reference",
+        "user_approved_scope_exclusion.source_locator"
+      ]
+    },
+    "kr21_gumbel_to_plackett_luce_identification": {
+      "accepted_source_role_contract_sha256": "4d313d58bfb4985036166cc4cc9161bb845ac22d9423b79c324524c212fc3ed3",
+      "public_source_role_projection_sha256": "d8b9efa981ab07cbae3c6f206c0f952a78f4054980ed8327d580328eb8eb6fa5",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "kr21_lemma1_gaussian_laplace_well_ordering": {
+      "accepted_source_role_contract_sha256": "ec8b45ae87a11ef8cd81dabe9e6faf163175c359c1d11553c1cf730f62de97af",
+      "public_source_role_projection_sha256": "9b397f7f6c8108fd4332136ae0c77ad81def033b21b2614e9cf3eb349bd45c50",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "kr21_lemma2_bottom_probability": {
+      "accepted_source_role_contract_sha256": "dab322d39a20a21d84bc8ea0aa762690a3758b4566eb05f235aaa4f1e2eac62e",
+      "public_source_role_projection_sha256": "dab322d39a20a21d84bc8ea0aa762690a3758b4566eb05f235aaa4f1e2eac62e",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "kr21_lemma3_middle_gain_bound": {
+      "accepted_source_role_contract_sha256": "dab322d39a20a21d84bc8ea0aa762690a3758b4566eb05f235aaa4f1e2eac62e",
+      "public_source_role_projection_sha256": "dab322d39a20a21d84bc8ea0aa762690a3758b4566eb05f235aaa4f1e2eac62e",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "kr21_lemma4_weighted_average": {
+      "accepted_source_role_contract_sha256": "d39bcb4d55baee6fd9defc9770b3567dfa3100dfdca9006339514e2c952e44cd",
+      "public_source_role_projection_sha256": "cc9e828977d8a8fbae88e71cc47c08ef613782757c90a4cf804e53ce4daa531e",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "kr21_lemma5_mallows_top_two_ratio": {
+      "accepted_source_role_contract_sha256": "dab322d39a20a21d84bc8ea0aa762690a3758b4566eb05f235aaa4f1e2eac62e",
+      "public_source_role_projection_sha256": "dab322d39a20a21d84bc8ea0aa762690a3758b4566eb05f235aaa4f1e2eac62e",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "kr21_lemma6_mallows_first_choice": {
+      "accepted_source_role_contract_sha256": "dab322d39a20a21d84bc8ea0aa762690a3758b4566eb05f235aaa4f1e2eac62e",
+      "public_source_role_projection_sha256": "dab322d39a20a21d84bc8ea0aa762690a3758b4566eb05f235aaa4f1e2eac62e",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "kr21_lemma7_first_mover_advantage": {
+      "accepted_source_role_contract_sha256": "dab322d39a20a21d84bc8ea0aa762690a3758b4566eb05f235aaa4f1e2eac62e",
+      "public_source_role_projection_sha256": "dab322d39a20a21d84bc8ea0aa762690a3758b4566eb05f235aaa4f1e2eac62e",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "kr21_lemma8_mallows_pairwise_accuracy": {
+      "accepted_source_role_contract_sha256": "dab322d39a20a21d84bc8ea0aa762690a3758b4566eb05f235aaa4f1e2eac62e",
+      "public_source_role_projection_sha256": "dab322d39a20a21d84bc8ea0aa762690a3758b4566eb05f235aaa4f1e2eac62e",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "kr21_model_candidates_values": {
+      "accepted_source_role_contract_sha256": "00ae4cb206dfc1e33f3fade96fd7087e741bc4dea5e1052bf813b368d68938f7",
+      "public_source_role_projection_sha256": "00ae4cb206dfc1e33f3fade96fd7087e741bc4dea5e1052bf813b368d68938f7",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "kr21_multifirm_binary_counter_computation": {
+      "accepted_source_role_contract_sha256": "dff3d5e19c11ccf287796d71f7259bb99dfc46a52949e94c8379ed74776f471c",
+      "public_source_role_projection_sha256": "aa084dbff5efad557e91f7a28757033d7ba5d7737af58439e6eff185974cf4f1",
+      "schema": 1,
+      "withheld_field_paths": [
+        "user_approved_scope_exclusion.approval_reference",
+        "user_approved_scope_exclusion.source_locator"
+      ]
+    },
+    "kr21_multifirm_kgt2_computational_example": {
+      "accepted_source_role_contract_sha256": "ca7f84c3f8c12c2a82048e45a09b527729a1ed5a93a5a724bcf1493b94f08dc5",
+      "public_source_role_projection_sha256": "d21fa42c790f748b0707737c44adb146731974d083c53383d0065aeb901a8167",
+      "schema": 1,
+      "withheld_field_paths": [
+        "user_approved_scope_exclusion.approval_reference",
+        "user_approved_scope_exclusion.source_locator"
+      ]
+    },
+    "kr21_multifirm_structure_open_observation": {
+      "accepted_source_role_contract_sha256": "1f0ee46c08b17d4d8a95754be9d00947e82424b5d92bc029220c87c93b81a79f",
+      "public_source_role_projection_sha256": "1f0ee46c08b17d4d8a95754be9d00947e82424b5d92bc029220c87c93b81a79f",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "kr21_outer_candidate_distribution_D": {
+      "accepted_source_role_contract_sha256": "00ae4cb206dfc1e33f3fade96fd7087e741bc4dea5e1052bf813b368d68938f7",
+      "public_source_role_projection_sha256": "00ae4cb206dfc1e33f3fade96fd7087e741bc4dea5e1052bf813b368d68938f7",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "kr21_plackett_luce_strategy_conclusion": {
+      "accepted_source_role_contract_sha256": "cda49d27d03d0611b210c217f18f31beddb3acae966283e8fdfcffb046b71e67",
+      "public_source_role_projection_sha256": "cda49d27d03d0611b210c217f18f31beddb3acae966283e8fdfcffb046b71e67",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "kr21_plackett_luce_zero_monoculture_effect": {
+      "accepted_source_role_contract_sha256": "e323e454489b1280e3bea671d0ecdd4b378ba23ce2fd20e7047866c946208b84",
+      "public_source_role_projection_sha256": "e323e454489b1280e3bea671d0ecdd4b378ba23ce2fd20e7047866c946208b84",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "kr21_rum_scaled_noise_model": {
+      "accepted_source_role_contract_sha256": "00ae4cb206dfc1e33f3fade96fd7087e741bc4dea5e1052bf813b368d68938f7",
+      "public_source_role_projection_sha256": "00ae4cb206dfc1e33f3fade96fd7087e741bc4dea5e1052bf813b368d68938f7",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "kr21_signed_welfare_translation_observation": {
+      "accepted_source_role_contract_sha256": "d615e4f2825a08ad77e21e105794daf0ed7522df656f4d81a4e0eca690e645e0",
+      "public_source_role_projection_sha256": "5f24be3dad7230762a7a9d6e2da380974ca41a756bbcb70f50f5abff64bedc81",
+      "schema": 1,
+      "withheld_field_paths": [
+        "user_approved_scope_exclusion.approval_reference",
+        "user_approved_scope_exclusion.source_locator"
+      ]
+    },
+    "kr21_simulation_efficiency_claim": {
+      "accepted_source_role_contract_sha256": "3beb20f2a17db74f0818a3a7af987dcd8d348c24715e233f75f94be413ea3d0f",
+      "public_source_role_projection_sha256": "d47b3de8a3db7da9183fad6e1723fe5b4c9c82695bbd00c4aab32769a8845af9",
+      "schema": 1,
+      "withheld_field_paths": [
+        "user_approved_scope_exclusion.approval_reference",
+        "user_approved_scope_exclusion.source_locator"
+      ]
+    },
+    "kr21_simulation_test_procedure": {
+      "accepted_source_role_contract_sha256": "d5a4bb7d79ccf1b23f5e42c0e0da67a0b1f00fa51df4820c26d72aa492f8a305",
+      "public_source_role_projection_sha256": "57e4e75b50e4a081d9916d5d8a3c4c9f3b52fce698417831cd6ce67b76e0b695",
+      "schema": 1,
+      "withheld_field_paths": [
+        "user_approved_scope_exclusion.approval_reference",
+        "user_approved_scope_exclusion.source_locator"
+      ]
+    },
+    "kr21_theorem1_monoculture_paradox": {
+      "accepted_source_role_contract_sha256": "cabd14a783c9ee8afa4cd763507c1a5f94e86e285f7063b45b81ad5554b8cb10",
+      "public_source_role_projection_sha256": "cabd14a783c9ee8afa4cd763507c1a5f94e86e285f7063b45b81ad5554b8cb10",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "kr21_theorem2_gaussian_laplace_rum": {
+      "accepted_source_role_contract_sha256": "cabd14a783c9ee8afa4cd763507c1a5f94e86e285f7063b45b81ad5554b8cb10",
+      "public_source_role_projection_sha256": "cabd14a783c9ee8afa4cd763507c1a5f94e86e285f7063b45b81ad5554b8cb10",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "kr21_theorem3_mallows_conditions": {
+      "accepted_source_role_contract_sha256": "2748f000beb9646787899de2e4fa8a3d95e93a6360d6b1aca79df6118ea969e0",
+      "public_source_role_projection_sha256": "6cc226d9aa2af212f1abc050622ff4f54d7c3d8923fb2ed24b2108af0fd2af68",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "kr21_theorem4_mallows_all_human_optimal": {
+      "accepted_source_role_contract_sha256": "cabd14a783c9ee8afa4cd763507c1a5f94e86e285f7063b45b81ad5554b8cb10",
+      "public_source_role_projection_sha256": "cabd14a783c9ee8afa4cd763507c1a5f94e86e285f7063b45b81ad5554b8cb10",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "kr21_theorem5_scaled_noise_definition1": {
+      "accepted_source_role_contract_sha256": "cd52ee0cae3a387c6de7de627a15d48f27562e76bca1cdca07424eb1f9aca1be",
+      "public_source_role_projection_sha256": "5008f7a111811f1be6d4269ef3ec44997d193fbd986c114ce817b89b8fa6553a",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "kr21_theorem6_well_ordered_rum_definition3": {
+      "accepted_source_role_contract_sha256": "cabd14a783c9ee8afa4cd763507c1a5f94e86e285f7063b45b81ad5554b8cb10",
+      "public_source_role_projection_sha256": "cabd14a783c9ee8afa4cd763507c1a5f94e86e285f7063b45b81ad5554b8cb10",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "kr21_theorem7_laplace_conditional_derivative": {
+      "accepted_source_role_contract_sha256": "cabd14a783c9ee8afa4cd763507c1a5f94e86e285f7063b45b81ad5554b8cb10",
+      "public_source_role_projection_sha256": "cabd14a783c9ee8afa4cd763507c1a5f94e86e285f7063b45b81ad5554b8cb10",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "kr21_theorem8_gaussian_conditional_derivative": {
+      "accepted_source_role_contract_sha256": "cabd14a783c9ee8afa4cd763507c1a5f94e86e285f7063b45b81ad5554b8cb10",
+      "public_source_role_projection_sha256": "cabd14a783c9ee8afa4cd763507c1a5f94e86e285f7063b45b81ad5554b8cb10",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "kr21_theorem9_mallows_definition1": {
+      "accepted_source_role_contract_sha256": "cabd14a783c9ee8afa4cd763507c1a5f94e86e285f7063b45b81ad5554b8cb10",
+      "public_source_role_projection_sha256": "cabd14a783c9ee8afa4cd763507c1a5f94e86e285f7063b45b81ad5554b8cb10",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "kr21_two_firm_selection_game": {
+      "accepted_source_role_contract_sha256": "00ae4cb206dfc1e33f3fade96fd7087e741bc4dea5e1052bf813b368d68938f7",
+      "public_source_role_projection_sha256": "00ae4cb206dfc1e33f3fade96fd7087e741bc4dea5e1052bf813b368d68938f7",
+      "schema": 1,
+      "withheld_field_paths": []
+    }
+  },
+  "paper": "KR21Monoculture",
+  "private_role_material_included": false,
+  "private_source_map_material_sha256": "f6fde591439330523954cfa0c0b2110ae1cab9215fc4fdbff212f5e959d5c821",
+  "private_source_map_sha256": "51a0707c7fed2c100a2a554e14ef6d2eede41ebb82812c1ebdc3102848e902d7",
+  "projection_contract_sha256": "ed0964edc9c70f5ce087ce9bf134712ca40c7964ecaefd403309ac9a1b47d34d",
+  "public_display_manifest_material_sha256": "a9537206e71919e325fd199fc4fffa6593dfe20e24586551b9044ab40b197146",
+  "public_display_manifest_sha256": "80807ca81cdc25bf9eaa9f5bbd5a6d2d95c38d0fb028c022da06059e8c7435b3",
+  "public_source_map_material_sha256": "d2cade3503c056c961b9d6078641174094409a247b35e2fa728c0729de1e425a",
+  "public_source_map_sha256": "42391b7a5e70c32b22ac0ef0d705e81415fec93bee2a5b809c665136bf0990a9",
+  "raw_private_approval_material_included": false,
+  "schema": 1
+}

--- a/papers/LBG24SpatialUnderreporting/audit/paper_statement_map.json
+++ b/papers/LBG24SpatialUnderreporting/audit/paper_statement_map.json
@@ -4513,6 +4513,11 @@
     "LBG24SpatialUnderreporting.poissonRegressionRate": "equation4_equation5_poisson_regression_rate_formula",
     "LBG24SpatialUnderreporting.zeroInflatedIndependentIncidentFamilyLikelihood": "source_zero_inflated_incident_model"
   },
+  "publication_source_display_projection": {
+    "manifest": "audit/public_source_display_projection.json",
+    "raw_source_bytes_included": false,
+    "schema": 1
+  },
   "schema": 1,
   "semantic_contract_schema": 1,
   "semantic_route_schema": 2,

--- a/papers/LBG24SpatialUnderreporting/audit/public_source_role_projection.json
+++ b/papers/LBG24SpatialUnderreporting/audit/public_source_role_projection.json
@@ -1,0 +1,175 @@
+{
+  "acceptance_credential": false,
+  "accepted_graph_sha256": "25a60d60a6d6593115c20140f4affe08542fefa5eef9bea35676529eba4e25e9",
+  "bindings_by_source_item": {
+    "appendix_shifted_poisson_after_first_jump": {
+      "accepted_source_role_contract_sha256": "fbd7d013fc26dae1ee512eacbe6d0a8fe53945fcbb556d797c54410e7db5387a",
+      "public_source_role_projection_sha256": "eb4f0aa3eed12d66850601dee10f018fece1fcd1613f722d860509db87ab38b7",
+      "schema": 1,
+      "withheld_field_paths": [
+        "user_approved_scope_exclusion.approval_reference",
+        "user_approved_scope_exclusion.source_evidence",
+        "user_approved_scope_exclusion.source_locator"
+      ]
+    },
+    "condition1_selected_start": {
+      "accepted_source_role_contract_sha256": "833843175a57efcc42628b0a84e8c38255ed09660fd387cb299770e41e9ed782",
+      "public_source_role_projection_sha256": "833843175a57efcc42628b0a84e8c38255ed09660fd387cb299770e41e9ed782",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "condition2_endpoint_selection": {
+      "accepted_source_role_contract_sha256": "833843175a57efcc42628b0a84e8c38255ed09660fd387cb299770e41e9ed782",
+      "public_source_role_projection_sha256": "833843175a57efcc42628b0a84e8c38255ed09660fd387cb299770e41e9ed782",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "equation2_poisson_count_pmf_formula": {
+      "accepted_source_role_contract_sha256": "7943bb0a1038c9b9ca1ec777a62b2cf0d2afdf222d3ccb832d0d97bcd18dfc6a",
+      "public_source_role_projection_sha256": "7943bb0a1038c9b9ca1ec777a62b2cf0d2afdf222d3ccb832d0d97bcd18dfc6a",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "equation33_nyc_observation_end": {
+      "accepted_source_role_contract_sha256": "1013bac0f64d961cf710c45bb3ffa3c3e7f4a01364f2c91a5854886aa5488ca1",
+      "public_source_role_projection_sha256": "1013bac0f64d961cf710c45bb3ffa3c3e7f4a01364f2c91a5854886aa5488ca1",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "equation34_chicago_observation_end": {
+      "accepted_source_role_contract_sha256": "1013bac0f64d961cf710c45bb3ffa3c3e7f4a01364f2c91a5854886aa5488ca1",
+      "public_source_role_projection_sha256": "1013bac0f64d961cf710c45bb3ffa3c3e7f4a01364f2c91a5854886aa5488ca1",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "equation3_mle_formula_and_maximum_likelihood_claim": {
+      "accepted_source_role_contract_sha256": "7943bb0a1038c9b9ca1ec777a62b2cf0d2afdf222d3ccb832d0d97bcd18dfc6a",
+      "public_source_role_projection_sha256": "7943bb0a1038c9b9ca1ec777a62b2cf0d2afdf222d3ccb832d0d97bcd18dfc6a",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "equation4_equation5_poisson_regression_rate_formula": {
+      "accepted_source_role_contract_sha256": "1013bac0f64d961cf710c45bb3ffa3c3e7f4a01364f2c91a5854886aa5488ca1",
+      "public_source_role_projection_sha256": "1013bac0f64d961cf710c45bb3ffa3c3e7f4a01364f2c91a5854886aa5488ca1",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "equation6_poisson_regression_likelihood_formula": {
+      "accepted_source_role_contract_sha256": "7943bb0a1038c9b9ca1ec777a62b2cf0d2afdf222d3ccb832d0d97bcd18dfc6a",
+      "public_source_role_projection_sha256": "7943bb0a1038c9b9ca1ec777a62b2cf0d2afdf222d3ccb832d0d97bcd18dfc6a",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "equation7_zero_inflated_extension_and_likelihood": {
+      "accepted_source_role_contract_sha256": "7943bb0a1038c9b9ca1ec777a62b2cf0d2afdf222d3ccb832d0d97bcd18dfc6a",
+      "public_source_role_projection_sha256": "7943bb0a1038c9b9ca1ec777a62b2cf0d2afdf222d3ccb832d0d97bcd18dfc6a",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "equations17_20_zero_report_proof_cluster": {
+      "accepted_source_role_contract_sha256": "94a2c2ffb4ba61c2df2bee48af1f7887ffac9a0496532fc750cf6fdceb9e6a60",
+      "public_source_role_projection_sha256": "94a2c2ffb4ba61c2df2bee48af1f7887ffac9a0496532fc750cf6fdceb9e6a60",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "equations21_26_one_report_proof_cluster": {
+      "accepted_source_role_contract_sha256": "94a2c2ffb4ba61c2df2bee48af1f7887ffac9a0496532fc750cf6fdceb9e6a60",
+      "public_source_role_projection_sha256": "94a2c2ffb4ba61c2df2bee48af1f7887ffac9a0496532fc750cf6fdceb9e6a60",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "equations27_32_multi_report_proof_cluster": {
+      "accepted_source_role_contract_sha256": "94a2c2ffb4ba61c2df2bee48af1f7887ffac9a0496532fc750cf6fdceb9e6a60",
+      "public_source_role_projection_sha256": "94a2c2ffb4ba61c2df2bee48af1f7887ffac9a0496532fc750cf6fdceb9e6a60",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "equations9_16_lemma2_proof_cluster": {
+      "accepted_source_role_contract_sha256": "88c78609f9fba48e3f6b2eaa6ca0e9ee07353161ccfcf3fea79b3ffd49a2d1bb",
+      "public_source_role_projection_sha256": "88c78609f9fba48e3f6b2eaa6ca0e9ee07353161ccfcf3fea79b3ffd49a2d1bb",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "homogeneous_reporting_delay_mean_formula": {
+      "accepted_source_role_contract_sha256": "7943bb0a1038c9b9ca1ec777a62b2cf0d2afdf222d3ccb832d0d97bcd18dfc6a",
+      "public_source_role_projection_sha256": "7943bb0a1038c9b9ca1ec777a62b2cf0d2afdf222d3ccb832d0d97bcd18dfc6a",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lemma1_process_thinning_and_detection_rate": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lemma2_exponential_waiting_tail": {
+      "accepted_source_role_contract_sha256": "1b4ca7631f977342bd0ed4254a6a5dcbfd6642d29b6a00be3214a7b7ebde0d57",
+      "public_source_role_projection_sha256": "0763d88ae4e0880db5b2a101cad7167889163e94143484425062b6c46c0f8e0a",
+      "schema": 1,
+      "withheld_field_paths": [
+        "user_approved_scope_exclusion.approval_reference",
+        "user_approved_scope_exclusion.source_evidence",
+        "user_approved_scope_exclusion.source_locator"
+      ]
+    },
+    "proposition1_nonidentifiability": {
+      "accepted_source_role_contract_sha256": "64a83a0ae6edbdb2d3cfb6cb84e3bf045734ef9303f62643ff780eff69b02885",
+      "public_source_role_projection_sha256": "64a83a0ae6edbdb2d3cfb6cb84e3bf045734ef9303f62643ff780eff69b02885",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_incident_birth_death_model": {
+      "accepted_source_role_contract_sha256": "e8bd731c387f27f23e485836c19e8cd56ab3be13060fd6b4343e29952fe8b856",
+      "public_source_role_projection_sha256": "e8bd731c387f27f23e485836c19e8cd56ab3be13060fd6b4343e29952fe8b856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_lemma1_reporting_duration_primitives": {
+      "accepted_source_role_contract_sha256": "e8bd731c387f27f23e485836c19e8cd56ab3be13060fd6b4343e29952fe8b856",
+      "public_source_role_projection_sha256": "e8bd731c387f27f23e485836c19e8cd56ab3be13060fd6b4343e29952fe8b856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_observed_data_model": {
+      "accepted_source_role_contract_sha256": "094ab4540537ce251559057bf89d273a1382a3741f3e0477329f0cb872caa128",
+      "public_source_role_projection_sha256": "094ab4540537ce251559057bf89d273a1382a3741f3e0477329f0cb872caa128",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_reporting_process_model": {
+      "accepted_source_role_contract_sha256": "e8bd731c387f27f23e485836c19e8cd56ab3be13060fd6b4343e29952fe8b856",
+      "public_source_role_projection_sha256": "e8bd731c387f27f23e485836c19e8cd56ab3be13060fd6b4343e29952fe8b856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_zero_inflated_incident_model": {
+      "accepted_source_role_contract_sha256": "e8bd731c387f27f23e485836c19e8cd56ab3be13060fd6b4343e29952fe8b856",
+      "public_source_role_projection_sha256": "e8bd731c387f27f23e485836c19e8cd56ab3be13060fd6b4343e29952fe8b856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem1_likelihood_decomposition_presentation": {
+      "accepted_source_role_contract_sha256": "1d239652a90cbe5e5a6acfbc5170f0d2356a133066e0067a00e2dbb97c464b60",
+      "public_source_role_projection_sha256": "1d239652a90cbe5e5a6acfbc5170f0d2356a133066e0067a00e2dbb97c464b60",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem1_theorem2_likelihood_decomposition": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    }
+  },
+  "paper": "LBG24SpatialUnderreporting",
+  "private_role_material_included": false,
+  "private_source_map_material_sha256": "9ffd37b09aab6bb9d535233df2f9830634f2f04740393d394fe2cd445d472038",
+  "private_source_map_sha256": "b0b4f69ef6bc83617265144a67105e734bd0d684a4f48cea5f5a5a781ee814f9",
+  "projection_contract_sha256": "ed0964edc9c70f5ce087ce9bf134712ca40c7964ecaefd403309ac9a1b47d34d",
+  "public_display_manifest_material_sha256": "a62c630ee56f52dbdfa83259fe32c6058a6a1806e3df0759b36226bea64a9501",
+  "public_display_manifest_sha256": "5e79247a572e30bee393770f63bdcf0e8403f772a0ce8351527cd8bad02e2602",
+  "public_source_map_material_sha256": "5a04d786dfa611e0826df3a36fc239787b1a1c454dd4c61396224059c542c226",
+  "public_source_map_sha256": "7d769ed629ad9832559d030f1cdbfcfcbd19e04e4fa87c0ad620810a383b915c",
+  "raw_private_approval_material_included": false,
+  "schema": 1
+}

--- a/papers/LG21TestOptionalPolicies/audit/paper_statement_map.json
+++ b/papers/LG21TestOptionalPolicies/audit/paper_statement_map.json
@@ -2838,6 +2838,11 @@
     "approval_material_included": false,
     "schema": 1
   },
+  "publication_source_display_projection": {
+    "manifest": "audit/public_source_display_projection.json",
+    "raw_source_bytes_included": false,
+    "schema": 1
+  },
   "schema": 1,
   "semantic_contract_schema": 1,
   "semantic_route_schema": 2,

--- a/papers/LG21TestOptionalPolicies/audit/public_source_role_projection.json
+++ b/papers/LG21TestOptionalPolicies/audit/public_source_role_projection.json
@@ -1,0 +1,515 @@
+{
+  "acceptance_credential": false,
+  "accepted_graph_sha256": "6c6e61cdb0d135642e433337bb2eb6e3902aaa0da97eaa4cf5f1f1c2aaea1ee6",
+  "bindings_by_source_item": {
+    "lg21_access_action_constraints": {
+      "accepted_source_role_contract_sha256": "a2ff2d71935837942c6e7cb81e488a564084c2e4a4c0b5a89f6ca8cec5c1589d",
+      "public_source_role_projection_sha256": "a2ff2d71935837942c6e7cb81e488a564084c2e4a4c0b5a89f6ca8cec5c1589d",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lg21_access_observation_regimes": {
+      "accepted_source_role_contract_sha256": "a2ff2d71935837942c6e7cb81e488a564084c2e4a4c0b5a89f6ca8cec5c1589d",
+      "public_source_role_projection_sha256": "a2ff2d71935837942c6e7cb81e488a564084c2e4a4c0b5a89f6ca8cec5c1589d",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lg21_admission_probability_objective_generalization": {
+      "accepted_source_role_contract_sha256": "a0e18c23a4be0db47d687fcfcb8ca488bb3d41ba7b896463a273d74f14c3d69e",
+      "public_source_role_projection_sha256": "a0e18c23a4be0db47d687fcfcb8ca488bb3d41ba7b896463a273d74f14c3d69e",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lg21_approximate_fairness_future_work": {
+      "accepted_source_role_contract_sha256": "f7da4c6a3a6b4924896044af51f42135eb58e7b8f045b9e0422f261cef21e892",
+      "public_source_role_projection_sha256": "f7da4c6a3a6b4924896044af51f42135eb58e7b8f045b9e0422f261cef21e892",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lg21_cross_student_noise_independence": {
+      "accepted_source_role_contract_sha256": "43d104eeb60bd11ad20669157825c9920d8d29c92451f4a88cf58c2431f84686",
+      "public_source_role_projection_sha256": "43d104eeb60bd11ad20669157825c9920d8d29c92451f4a88cf58c2431f84686",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lg21_definition1_best_response": {
+      "accepted_source_role_contract_sha256": "836e5dd7fbd4a07c400d1cb4125c280b917ca9bb5f811d1e892ce089f0a9f05e",
+      "public_source_role_projection_sha256": "836e5dd7fbd4a07c400d1cb4125c280b917ca9bb5f811d1e892ce089f0a9f05e",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lg21_definition1_estimation_consistency": {
+      "accepted_source_role_contract_sha256": "836e5dd7fbd4a07c400d1cb4125c280b917ca9bb5f811d1e892ce089f0a9f05e",
+      "public_source_role_projection_sha256": "836e5dd7fbd4a07c400d1cb4125c280b917ca9bb5f811d1e892ce089f0a9f05e",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lg21_definition1_feasibility": {
+      "accepted_source_role_contract_sha256": "836e5dd7fbd4a07c400d1cb4125c280b917ca9bb5f811d1e892ce089f0a9f05e",
+      "public_source_role_projection_sha256": "836e5dd7fbd4a07c400d1cb4125c280b917ca9bb5f811d1e892ce089f0a9f05e",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lg21_definition1_hidden_access_optional_protocol": {
+      "accepted_source_role_contract_sha256": "822eb6b726c650e8a7462f68776e0205749acc68d410f952bf00a8d8778c10d4",
+      "public_source_role_projection_sha256": "822eb6b726c650e8a7462f68776e0205749acc68d410f952bf00a8d8778c10d4",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lg21_definition2_latent_skill_fair": {
+      "accepted_source_role_contract_sha256": "822eb6b726c650e8a7462f68776e0205749acc68d410f952bf00a8d8778c10d4",
+      "public_source_role_projection_sha256": "822eb6b726c650e8a7462f68776e0205749acc68d410f952bf00a8d8778c10d4",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lg21_definition3_observable_fair": {
+      "accepted_source_role_contract_sha256": "822eb6b726c650e8a7462f68776e0205749acc68d410f952bf00a8d8778c10d4",
+      "public_source_role_projection_sha256": "822eb6b726c650e8a7462f68776e0205749acc68d410f952bf00a8d8778c10d4",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lg21_definition4_demographic_fair": {
+      "accepted_source_role_contract_sha256": "822eb6b726c650e8a7462f68776e0205749acc68d410f952bf00a8d8778c10d4",
+      "public_source_role_projection_sha256": "822eb6b726c650e8a7462f68776e0205749acc68d410f952bf00a8d8778c10d4",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lg21_definition5_test_blank": {
+      "accepted_source_role_contract_sha256": "822eb6b726c650e8a7462f68776e0205749acc68d410f952bf00a8d8778c10d4",
+      "public_source_role_projection_sha256": "822eb6b726c650e8a7462f68776e0205749acc68d410f952bf00a8d8778c10d4",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lg21_definition6_access_estimator": {
+      "accepted_source_role_contract_sha256": "822eb6b726c650e8a7462f68776e0205749acc68d410f952bf00a8d8778c10d4",
+      "public_source_role_projection_sha256": "822eb6b726c650e8a7462f68776e0205749acc68d410f952bf00a8d8778c10d4",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lg21_definition6_no_access_resampling": {
+      "accepted_source_role_contract_sha256": "9cd5b379bbd174c42f14ecd1532d788af8b0461c789ae699828e98715ff434fa",
+      "public_source_role_projection_sha256": "9cd5b379bbd174c42f14ecd1532d788af8b0461c789ae699828e98715ff434fa",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lg21_distributional_equality_notation": {
+      "accepted_source_role_contract_sha256": "50a4960d7df863d2f8473dec892d9d3052a30fa225d62278c722e978b339aa7f",
+      "public_source_role_projection_sha256": "50a4960d7df863d2f8473dec892d9d3052a30fa225d62278c722e978b339aa7f",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lg21_fairness_implication_chain": {
+      "accepted_source_role_contract_sha256": "cda49d27d03d0611b210c217f18f31beddb3acae966283e8fdfcffb046b71e67",
+      "public_source_role_projection_sha256": "cda49d27d03d0611b210c217f18f31beddb3acae966283e8fdfcffb046b71e67",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lg21_hidden_access_demographic_question": {
+      "accepted_source_role_contract_sha256": "f7da4c6a3a6b4924896044af51f42135eb58e7b8f045b9e0422f261cef21e892",
+      "public_source_role_projection_sha256": "f7da4c6a3a6b4924896044af51f42135eb58e7b8f045b9e0422f261cef21e892",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lg21_ignoring_test_scores_achieves_fairness": {
+      "accepted_source_role_contract_sha256": "ff5a0e099e16c780ec0c807bad8030a1474e5e84b20ee9670ac2ec27355bdb21",
+      "public_source_role_projection_sha256": "ff5a0e099e16c780ec0c807bad8030a1474e5e84b20ee9670ac2ec27355bdb21",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lg21_known_parameters_cutoff_model": {
+      "accepted_source_role_contract_sha256": "e742a3d968b8b236f9085e2edfcf7fb2fdb92de48db046d8fe9222b77c39ec50",
+      "public_source_role_projection_sha256": "e742a3d968b8b236f9085e2edfcf7fb2fdb92de48db046d8fe9222b77c39ec50",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lg21_lemma41_lower_tail_reporting_deviation": {
+      "accepted_source_role_contract_sha256": "917ab9132fbcec5d9b4835f27a0d85c878949dee9f78c5a22e9f44331ccd1059",
+      "public_source_role_projection_sha256": "917ab9132fbcec5d9b4835f27a0d85c878949dee9f78c5a22e9f44331ccd1059",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lg21_lemma41_no_taker_lower_tail_deviation": {
+      "accepted_source_role_contract_sha256": "917ab9132fbcec5d9b4835f27a0d85c878949dee9f78c5a22e9f44331ccd1059",
+      "public_source_role_projection_sha256": "917ab9132fbcec5d9b4835f27a0d85c878949dee9f78c5a22e9f44331ccd1059",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lg21_lemma41_observed_test_law": {
+      "accepted_source_role_contract_sha256": "836e5dd7fbd4a07c400d1cb4125c280b917ca9bb5f811d1e892ce089f0a9f05e",
+      "public_source_role_projection_sha256": "836e5dd7fbd4a07c400d1cb4125c280b917ca9bb5f811d1e892ce089f0a9f05e",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lg21_lemma41_proof_presentation": {
+      "accepted_source_role_contract_sha256": "f712a128a06b4e15ff2d16311dbbb7cbc3920b95aeae2da76ba5083d135d267f",
+      "public_source_role_projection_sha256": "f712a128a06b4e15ff2d16311dbbb7cbc3920b95aeae2da76ba5083d135d267f",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lg21_lemma41_reporting_monotonicity": {
+      "accepted_source_role_contract_sha256": "917ab9132fbcec5d9b4835f27a0d85c878949dee9f78c5a22e9f44331ccd1059",
+      "public_source_role_projection_sha256": "917ab9132fbcec5d9b4835f27a0d85c878949dee9f78c5a22e9f44331ccd1059",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lg21_lemma41_strategy_proofness": {
+      "accepted_source_role_contract_sha256": "dab322d39a20a21d84bc8ea0aa762690a3758b4566eb05f235aaa4f1e2eac62e",
+      "public_source_role_projection_sha256": "dab322d39a20a21d84bc8ea0aa762690a3758b4566eb05f235aaa4f1e2eac62e",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lg21_lemma41_taking_indifference_equation": {
+      "accepted_source_role_contract_sha256": "358b131b61ca36faf8de707fae21a25a13e8ad4aa504873b3eca45aa572f03cb",
+      "public_source_role_projection_sha256": "358b131b61ca36faf8de707fae21a25a13e8ad4aa504873b3eca45aa572f03cb",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lg21_nongaussian_generality_expectation": {
+      "accepted_source_role_contract_sha256": "f7da4c6a3a6b4924896044af51f42135eb58e7b8f045b9e0422f261cef21e892",
+      "public_source_role_projection_sha256": "f7da4c6a3a6b4924896044af51f42135eb58e7b8f045b9e0422f261cef21e892",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lg21_observed_access_gaussian_nondegeneracy_domain": {
+      "accepted_source_role_contract_sha256": "de4eaf03389fb2330f2f149a9c6bb40f10e8662748443332425cc8198d83eaab",
+      "public_source_role_projection_sha256": "de4eaf03389fb2330f2f149a9c6bb40f10e8662748443332425cc8198d83eaab",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lg21_pbo_posterior_mean_formula": {
+      "accepted_source_role_contract_sha256": "836e5dd7fbd4a07c400d1cb4125c280b917ca9bb5f811d1e892ce089f0a9f05e",
+      "public_source_role_projection_sha256": "836e5dd7fbd4a07c400d1cb4125c280b917ca9bb5f811d1e892ce089f0a9f05e",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lg21_proposition42_access_gaussian_laws": {
+      "accepted_source_role_contract_sha256": "9cd5b379bbd174c42f14ecd1532d788af8b0461c789ae699828e98715ff434fa",
+      "public_source_role_projection_sha256": "9cd5b379bbd174c42f14ecd1532d788af8b0461c789ae699828e98715ff434fa",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lg21_proposition42_four_group_argument": {
+      "accepted_source_role_contract_sha256": "917ab9132fbcec5d9b4835f27a0d85c878949dee9f78c5a22e9f44331ccd1059",
+      "public_source_role_projection_sha256": "917ab9132fbcec5d9b4835f27a0d85c878949dee9f78c5a22e9f44331ccd1059",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lg21_proposition42_gaussian_pbo_source_model": {
+      "accepted_source_role_contract_sha256": "de4eaf03389fb2330f2f149a9c6bb40f10e8662748443332425cc8198d83eaab",
+      "public_source_role_projection_sha256": "de4eaf03389fb2330f2f149a9c6bb40f10e8662748443332425cc8198d83eaab",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lg21_proposition42_not_latent_skill_fair": {
+      "accepted_source_role_contract_sha256": "6fde81007543b56d77ccd940268d0d6ca11b2fc01734f027f902c3d87d07a7ae",
+      "public_source_role_projection_sha256": "6fde81007543b56d77ccd940268d0d6ca11b2fc01734f027f902c3d87d07a7ae",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lg21_proposition42_proof_presentation": {
+      "accepted_source_role_contract_sha256": "16cfcd287e08ec46601a9221bff6cf8e13fdf5eb096f17c2d9894d3b40f27e7a",
+      "public_source_role_projection_sha256": "16cfcd287e08ec46601a9221bff6cf8e13fdf5eb096f17c2d9894d3b40f27e7a",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lg21_proposition43_access_gaussian_law": {
+      "accepted_source_role_contract_sha256": "9cd5b379bbd174c42f14ecd1532d788af8b0461c789ae699828e98715ff434fa",
+      "public_source_role_projection_sha256": "9cd5b379bbd174c42f14ecd1532d788af8b0461c789ae699828e98715ff434fa",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lg21_proposition43_demographic_marginal_step": {
+      "accepted_source_role_contract_sha256": "9a8b8f2de47fa7e003e3f43580f63100282bbcf44e75dcd00c73301c78d3f2fe",
+      "public_source_role_projection_sha256": "9a8b8f2de47fa7e003e3f43580f63100282bbcf44e75dcd00c73301c78d3f2fe",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lg21_proposition43_no_access_point_estimate": {
+      "accepted_source_role_contract_sha256": "836e5dd7fbd4a07c400d1cb4125c280b917ca9bb5f811d1e892ce089f0a9f05e",
+      "public_source_role_projection_sha256": "836e5dd7fbd4a07c400d1cb4125c280b917ca9bb5f811d1e892ce089f0a9f05e",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lg21_proposition43_not_observable_or_demographic_fair": {
+      "accepted_source_role_contract_sha256": "6fde81007543b56d77ccd940268d0d6ca11b2fc01734f027f902c3d87d07a7ae",
+      "public_source_role_projection_sha256": "6fde81007543b56d77ccd940268d0d6ca11b2fc01734f027f902c3d87d07a7ae",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lg21_proposition43_proof_presentation": {
+      "accepted_source_role_contract_sha256": "16cfcd287e08ec46601a9221bff6cf8e13fdf5eb096f17c2d9894d3b40f27e7a",
+      "public_source_role_projection_sha256": "16cfcd287e08ec46601a9221bff6cf8e13fdf5eb096f17c2d9894d3b40f27e7a",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lg21_report_decision_skill_independence": {
+      "accepted_source_role_contract_sha256": "ff5a0e099e16c780ec0c807bad8030a1474e5e84b20ee9670ac2ec27355bdb21",
+      "public_source_role_projection_sha256": "ff5a0e099e16c780ec0c807bad8030a1474e5e84b20ee9670ac2ec27355bdb21",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lg21_reporting_conditioned_generalization": {
+      "accepted_source_role_contract_sha256": "e323e454489b1280e3bea671d0ecdd4b378ba23ce2fd20e7047866c946208b84",
+      "public_source_role_projection_sha256": "e323e454489b1280e3bea671d0ecdd4b378ba23ce2fd20e7047866c946208b84",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lg21_requirement_policies": {
+      "accepted_source_role_contract_sha256": "00ae4cb206dfc1e33f3fade96fd7087e741bc4dea5e1052bf813b368d68938f7",
+      "public_source_role_projection_sha256": "00ae4cb206dfc1e33f3fade96fd7087e741bc4dea5e1052bf813b368d68938f7",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lg21_requirement_policy_scope_generalization": {
+      "accepted_source_role_contract_sha256": "228620af5f5d034f80a68f03c96d52a9ac89c60ad19a1ef47a7a526bb77c36ff",
+      "public_source_role_projection_sha256": "228620af5f5d034f80a68f03c96d52a9ac89c60ad19a1ef47a7a526bb77c36ff",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lg21_school_information_and_policy": {
+      "accepted_source_role_contract_sha256": "a2ff2d71935837942c6e7cb81e488a564084c2e4a4c0b5a89f6ca8cec5c1589d",
+      "public_source_role_projection_sha256": "a2ff2d71935837942c6e7cb81e488a564084c2e4a4c0b5a89f6ca8cec5c1589d",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lg21_student_decision_objective": {
+      "accepted_source_role_contract_sha256": "00ae4cb206dfc1e33f3fade96fd7087e741bc4dea5e1052bf813b368d68938f7",
+      "public_source_role_projection_sha256": "00ae4cb206dfc1e33f3fade96fd7087e741bc4dea5e1052bf813b368d68938f7",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lg21_student_gaussian_signal_model": {
+      "accepted_source_role_contract_sha256": "00ae4cb206dfc1e33f3fade96fd7087e741bc4dea5e1052bf813b368d68938f7",
+      "public_source_role_projection_sha256": "00ae4cb206dfc1e33f3fade96fd7087e741bc4dea5e1052bf813b368d68938f7",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lg21_test_taking_probability_preference": {
+      "accepted_source_role_contract_sha256": "2d6df3df23dfc6bde6da0073116e6b4bb3a841d86daed6f8b12513f1ec5cfccd",
+      "public_source_role_projection_sha256": "2d6df3df23dfc6bde6da0073116e6b4bb3a841d86daed6f8b12513f1ec5cfccd",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lg21_theorem31_all_fairness_fail": {
+      "accepted_source_role_contract_sha256": "cabd14a783c9ee8afa4cd763507c1a5f94e86e285f7063b45b81ad5554b8cb10",
+      "public_source_role_projection_sha256": "cabd14a783c9ee8afa4cd763507c1a5f94e86e285f7063b45b81ad5554b8cb10",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lg21_theorem31_cutoff_best_response": {
+      "accepted_source_role_contract_sha256": "2e65992c7219a67ec20e6b0ae9dabba2331a4e6601bd2d221e33cec700eae857",
+      "public_source_role_projection_sha256": "2e65992c7219a67ec20e6b0ae9dabba2331a4e6601bd2d221e33cec700eae857",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lg21_theorem31_cutoff_fixed_point": {
+      "accepted_source_role_contract_sha256": "2e65992c7219a67ec20e6b0ae9dabba2331a4e6601bd2d221e33cec700eae857",
+      "public_source_role_projection_sha256": "2e65992c7219a67ec20e6b0ae9dabba2331a4e6601bd2d221e33cec700eae857",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lg21_theorem31_extreme_reporting_profiles_unstable": {
+      "accepted_source_role_contract_sha256": "2e65992c7219a67ec20e6b0ae9dabba2331a4e6601bd2d221e33cec700eae857",
+      "public_source_role_projection_sha256": "2e65992c7219a67ec20e6b0ae9dabba2331a4e6601bd2d221e33cec700eae857",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lg21_theorem31_no_report_decomposition": {
+      "accepted_source_role_contract_sha256": "836e5dd7fbd4a07c400d1cb4125c280b917ca9bb5f811d1e892ce089f0a9f05e",
+      "public_source_role_projection_sha256": "836e5dd7fbd4a07c400d1cb4125c280b917ca9bb5f811d1e892ce089f0a9f05e",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lg21_theorem31_no_take_mixture": {
+      "accepted_source_role_contract_sha256": "836e5dd7fbd4a07c400d1cb4125c280b917ca9bb5f811d1e892ce089f0a9f05e",
+      "public_source_role_projection_sha256": "836e5dd7fbd4a07c400d1cb4125c280b917ca9bb5f811d1e892ce089f0a9f05e",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lg21_theorem31_nonreport_mixture_weights": {
+      "accepted_source_role_contract_sha256": "9e06f29730422876440127e5201ad6058e1fd5a68c7a53c5eb5cca236d2eece4",
+      "public_source_role_projection_sha256": "9e06f29730422876440127e5201ad6058e1fd5a68c7a53c5eb5cca236d2eece4",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lg21_theorem31_optional_reporting": {
+      "accepted_source_role_contract_sha256": "cabd14a783c9ee8afa4cd763507c1a5f94e86e285f7063b45b81ad5554b8cb10",
+      "public_source_role_projection_sha256": "cabd14a783c9ee8afa4cd763507c1a5f94e86e285f7063b45b81ad5554b8cb10",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lg21_theorem31_pooled_no_report_estimate": {
+      "accepted_source_role_contract_sha256": "9e06f29730422876440127e5201ad6058e1fd5a68c7a53c5eb5cca236d2eece4",
+      "public_source_role_projection_sha256": "9e06f29730422876440127e5201ad6058e1fd5a68c7a53c5eb5cca236d2eece4",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lg21_theorem31_proof_presentation": {
+      "accepted_source_role_contract_sha256": "18678200494b5733d8d94d1998063f9d55ccb348125ea070c4daab4102dab5e7",
+      "public_source_role_projection_sha256": "18678200494b5733d8d94d1998063f9d55ccb348125ea070c4daab4102dab5e7",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lg21_theorem31_report_required": {
+      "accepted_source_role_contract_sha256": "cabd14a783c9ee8afa4cd763507c1a5f94e86e285f7063b45b81ad5554b8cb10",
+      "public_source_role_projection_sha256": "cabd14a783c9ee8afa4cd763507c1a5f94e86e285f7063b45b81ad5554b8cb10",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lg21_theorem31_report_required_expected_posterior": {
+      "accepted_source_role_contract_sha256": "836e5dd7fbd4a07c400d1cb4125c280b917ca9bb5f811d1e892ce089f0a9f05e",
+      "public_source_role_projection_sha256": "836e5dd7fbd4a07c400d1cb4125c280b917ca9bb5f811d1e892ce089f0a9f05e",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lg21_theorem31_report_required_threshold_fixed_point": {
+      "accepted_source_role_contract_sha256": "2e65992c7219a67ec20e6b0ae9dabba2331a4e6601bd2d221e33cec700eae857",
+      "public_source_role_projection_sha256": "2e65992c7219a67ec20e6b0ae9dabba2331a4e6601bd2d221e33cec700eae857",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lg21_theorem31_reported_posterior_formula": {
+      "accepted_source_role_contract_sha256": "836e5dd7fbd4a07c400d1cb4125c280b917ca9bb5f811d1e892ce089f0a9f05e",
+      "public_source_role_projection_sha256": "836e5dd7fbd4a07c400d1cb4125c280b917ca9bb5f811d1e892ce089f0a9f05e",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lg21_theorem31_reporting_monotonicity_cutoff": {
+      "accepted_source_role_contract_sha256": "2e65992c7219a67ec20e6b0ae9dabba2331a4e6601bd2d221e33cec700eae857",
+      "public_source_role_projection_sha256": "2e65992c7219a67ec20e6b0ae9dabba2331a4e6601bd2d221e33cec700eae857",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lg21_theorem31_reporting_share_A": {
+      "accepted_source_role_contract_sha256": "836e5dd7fbd4a07c400d1cb4125c280b917ca9bb5f811d1e892ce089f0a9f05e",
+      "public_source_role_projection_sha256": "836e5dd7fbd4a07c400d1cb4125c280b917ca9bb5f811d1e892ce089f0a9f05e",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lg21_theorem31_strategic_dominance_unfairness": {
+      "accepted_source_role_contract_sha256": "2e65992c7219a67ec20e6b0ae9dabba2331a4e6601bd2d221e33cec700eae857",
+      "public_source_role_projection_sha256": "2e65992c7219a67ec20e6b0ae9dabba2331a4e6601bd2d221e33cec700eae857",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lg21_theorem31_truncated_no_report_integral": {
+      "accepted_source_role_contract_sha256": "836e5dd7fbd4a07c400d1cb4125c280b917ca9bb5f811d1e892ce089f0a9f05e",
+      "public_source_role_projection_sha256": "836e5dd7fbd4a07c400d1cb4125c280b917ca9bb5f811d1e892ce089f0a9f05e",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lg21_theorem32_fairness_impossibility": {
+      "accepted_source_role_contract_sha256": "9fe140c3aa6023bb903acb22b8a8939afb68e4d620b5e7f4b0f31efde078052e",
+      "public_source_role_projection_sha256": "d8e8cecbb3c5cf9642f1c8407c956f0c5d35285fa85e5e4d14468a6d50a22148",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "lg21_theorem32_observable_fairness_identity": {
+      "accepted_source_role_contract_sha256": "836e5dd7fbd4a07c400d1cb4125c280b917ca9bb5f811d1e892ce089f0a9f05e",
+      "public_source_role_projection_sha256": "836e5dd7fbd4a07c400d1cb4125c280b917ca9bb5f811d1e892ce089f0a9f05e",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lg21_theorem32_observable_summary": {
+      "accepted_source_role_contract_sha256": "2ce108069e4ebe0818e13fbdc5dd2d1603b1e55cbc203e15b5c43408eadb69df",
+      "public_source_role_projection_sha256": "42ed7578f75ca0d7ae99d9a33867f6607260a1d18310d33840d7de171676899b",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "lg21_theorem32_optional_profitable_deviation": {
+      "accepted_source_role_contract_sha256": "2e65992c7219a67ec20e6b0ae9dabba2331a4e6601bd2d221e33cec700eae857",
+      "public_source_role_projection_sha256": "2e65992c7219a67ec20e6b0ae9dabba2331a4e6601bd2d221e33cec700eae857",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lg21_theorem32_proof_presentation": {
+      "accepted_source_role_contract_sha256": "18678200494b5733d8d94d1998063f9d55ccb348125ea070c4daab4102dab5e7",
+      "public_source_role_projection_sha256": "18678200494b5733d8d94d1998063f9d55ccb348125ea070c4daab4102dab5e7",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lg21_theorem32_report_required_profitable_deviation": {
+      "accepted_source_role_contract_sha256": "2e65992c7219a67ec20e6b0ae9dabba2331a4e6601bd2d221e33cec700eae857",
+      "public_source_role_projection_sha256": "2e65992c7219a67ec20e6b0ae9dabba2331a4e6601bd2d221e33cec700eae857",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lg21_theorem32_report_required_proof_conclusion": {
+      "accepted_source_role_contract_sha256": "dd5600843e0537cfa4f4eb3e11d614c1111f37cd3e999f5c521232205c7f6048",
+      "public_source_role_projection_sha256": "160fd30d2fb138fc29605539f0f66497fe002a4dd43f3484d3a95af9670f42da",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "lg21_theorem32_report_required_source_statement": {
+      "accepted_source_role_contract_sha256": "2d2297a6055d703c8f0527c883498befce7b598a03c43687bc86f0a90571f22a",
+      "public_source_role_projection_sha256": "81944761981a528ebe83ad3edcb36c82bb7da16fd418a68eb5f178a84083c7a8",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "lg21_theorem32_reporter_nonreporter_laws": {
+      "accepted_source_role_contract_sha256": "836e5dd7fbd4a07c400d1cb4125c280b917ca9bb5f811d1e892ce089f0a9f05e",
+      "public_source_role_projection_sha256": "836e5dd7fbd4a07c400d1cb4125c280b917ca9bb5f811d1e892ce089f0a9f05e",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lg21_theorem44_common_gaussian_law_equation2": {
+      "accepted_source_role_contract_sha256": "c19ede5ed51f17490a3a344a79ad1e1ec78938fee7a42426cae0fecbf0badcea",
+      "public_source_role_projection_sha256": "c19ede5ed51f17490a3a344a79ad1e1ec78938fee7a42426cae0fecbf0badcea",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lg21_theorem44_proof_presentation": {
+      "accepted_source_role_contract_sha256": "18678200494b5733d8d94d1998063f9d55ccb348125ea070c4daab4102dab5e7",
+      "public_source_role_projection_sha256": "18678200494b5733d8d94d1998063f9d55ccb348125ea070c4daab4102dab5e7",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lg21_theorem44_resampling_fairness": {
+      "accepted_source_role_contract_sha256": "cabd14a783c9ee8afa4cd763507c1a5f94e86e285f7063b45b81ad5554b8cb10",
+      "public_source_role_projection_sha256": "cabd14a783c9ee8afa4cd763507c1a5f94e86e285f7063b45b81ad5554b8cb10",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lg21_thompson_acceptance_interpretation": {
+      "accepted_source_role_contract_sha256": "e323e454489b1280e3bea671d0ecdd4b378ba23ce2fd20e7047866c946208b84",
+      "public_source_role_projection_sha256": "e323e454489b1280e3bea671d0ecdd4b378ba23ce2fd20e7047866c946208b84",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "model_theorem31_optional_local_candidate_stability_refinement": {
+      "accepted_source_role_contract_sha256": "25ae0445cbad5700740ca0d901cdb22fa81678daaa2adcfa53e3e0db581adee2",
+      "public_source_role_projection_sha256": "25ae0445cbad5700740ca0d901cdb22fa81678daaa2adcfa53e3e0db581adee2",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "model_theorem31_report_required_local_tail_stability_refinement": {
+      "accepted_source_role_contract_sha256": "25ae0445cbad5700740ca0d901cdb22fa81678daaa2adcfa53e3e0db581adee2",
+      "public_source_role_projection_sha256": "25ae0445cbad5700740ca0d901cdb22fa81678daaa2adcfa53e3e0db581adee2",
+      "schema": 1,
+      "withheld_field_paths": []
+    }
+  },
+  "paper": "LG21TestOptionalPolicies",
+  "private_role_material_included": false,
+  "private_source_map_material_sha256": "aac9b34c337fa29baf653a75bc6597d0be3e3842048e644319906580e8eaa5c5",
+  "private_source_map_sha256": "9780e24dcb4da51c3f8015d96213f112947365ef10f16904ddf222ea6fe2b983",
+  "projection_contract_sha256": "ed0964edc9c70f5ce087ce9bf134712ca40c7964ecaefd403309ac9a1b47d34d",
+  "public_display_manifest_material_sha256": "943c3b81ba335e0a8d0798a1b456ab60f48feba5335392c07c9398c412cdf917",
+  "public_display_manifest_sha256": "981b583a010d90fe15f1987fd183a155b1634aec2012926a33f155d02c47d73b",
+  "public_source_map_material_sha256": "aea97c90919c3919ce0f68401acb0376b161969959414ae457350ecf01033da6",
+  "public_source_map_sha256": "fa02972f5708ddff672b96c9cd78bbf51c1eafab69a5c3d1bb6ef22a233fa0a1",
+  "raw_private_approval_material_included": false,
+  "schema": 1
+}

--- a/papers/LG24ServiceLevelAgreements/audit/paper_statement_map.json
+++ b/papers/LG24ServiceLevelAgreements/audit/paper_statement_map.json
@@ -1210,6 +1210,11 @@
   },
   "paper": "LG24ServiceLevelAgreements",
   "paper_interface_namespace": "LG24ServiceLevelAgreements",
+  "publication_source_display_projection": {
+    "manifest": "audit/public_source_display_projection.json",
+    "raw_source_bytes_included": false,
+    "schema": 1
+  },
   "schema": 1,
   "semantic_contract_schema": 1,
   "semantic_preflight_import_module": "LG24ServiceLevelAgreements.PaperInterface",

--- a/papers/LG24ServiceLevelAgreements/audit/public_source_role_projection.json
+++ b/papers/LG24ServiceLevelAgreements/audit/public_source_role_projection.json
@@ -1,0 +1,215 @@
+{
+  "acceptance_credential": false,
+  "accepted_graph_sha256": "58d8317cf8ef69bf4bb4461e1427ede9dfc61e605ba5082c1aff8a8cd51e788d",
+  "bindings_by_source_item": {
+    "centralization_gain_relative_identity": {
+      "accepted_source_role_contract_sha256": "e7960301914702af45e2b6b68d20aef532fe8473849db58c6eda39068f6de8d1",
+      "public_source_role_projection_sha256": "e7960301914702af45e2b6b68d20aef532fe8473849db58c6eda39068f6de8d1",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "city_extreme_efficiency_context": {
+      "accepted_source_role_contract_sha256": "7943bb0a1038c9b9ca1ec777a62b2cf0d2afdf222d3ccb832d0d97bcd18dfc6a",
+      "public_source_role_projection_sha256": "7943bb0a1038c9b9ca1ec777a62b2cf0d2afdf222d3ccb832d0d97bcd18dfc6a",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "global_steady_gps_condition_context": {
+      "accepted_source_role_contract_sha256": "25ae0445cbad5700740ca0d901cdb22fa81678daaa2adcfa53e3e0db581adee2",
+      "public_source_role_projection_sha256": "25ae0445cbad5700740ca0d901cdb22fa81678daaa2adcfa53e3e0db581adee2",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "post_thinning_admitted_poisson_normal_form_context": {
+      "accepted_source_role_contract_sha256": "25ae0445cbad5700740ca0d901cdb22fa81678daaa2adcfa53e3e0db581adee2",
+      "public_source_role_projection_sha256": "25ae0445cbad5700740ca0d901cdb22fa81678daaa2adcfa53e3e0db581adee2",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "prop_centralization_gain": {
+      "accepted_source_role_contract_sha256": "64a83a0ae6edbdb2d3cfb6cb84e3bf045734ef9303f62643ff780eff69b02885",
+      "public_source_role_projection_sha256": "64a83a0ae6edbdb2d3cfb6cb84e3bf045734ef9303f62643ff780eff69b02885",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "prop_extreme_efficiency": {
+      "accepted_source_role_contract_sha256": "64a83a0ae6edbdb2d3cfb6cb84e3bf045734ef9303f62643ff780eff69b02885",
+      "public_source_role_projection_sha256": "64a83a0ae6edbdb2d3cfb6cb84e3bf045734ef9303f62643ff780eff69b02885",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "prop_extreme_equity": {
+      "accepted_source_role_contract_sha256": "64a83a0ae6edbdb2d3cfb6cb84e3bf045734ef9303f62643ff780eff69b02885",
+      "public_source_role_projection_sha256": "64a83a0ae6edbdb2d3cfb6cb84e3bf045734ef9303f62643ff780eff69b02885",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "prop_opt_reformulation": {
+      "accepted_source_role_contract_sha256": "64a83a0ae6edbdb2d3cfb6cb84e3bf045734ef9303f62643ff780eff69b02885",
+      "public_source_role_projection_sha256": "64a83a0ae6edbdb2d3cfb6cb84e3bf045734ef9303f62643ff780eff69b02885",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "prop_price_of_equity": {
+      "accepted_source_role_contract_sha256": "64a83a0ae6edbdb2d3cfb6cb84e3bf045734ef9303f62643ff780eff69b02885",
+      "public_source_role_projection_sha256": "64a83a0ae6edbdb2d3cfb6cb84e3bf045734ef9303f62643ff780eff69b02885",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "relative_price_of_equity_nonnegative_context": {
+      "accepted_source_role_contract_sha256": "7943bb0a1038c9b9ca1ec777a62b2cf0d2afdf222d3ccb832d0d97bcd18dfc6a",
+      "public_source_role_projection_sha256": "7943bb0a1038c9b9ca1ec777a62b2cf0d2afdf222d3ccb832d0d97bcd18dfc6a",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "sla_rate_fraction_context": {
+      "accepted_source_role_contract_sha256": "7943bb0a1038c9b9ca1ec777a62b2cf0d2afdf222d3ccb832d0d97bcd18dfc6a",
+      "public_source_role_projection_sha256": "7943bb0a1038c9b9ca1ec777a62b2cf0d2afdf222d3ccb832d0d97bcd18dfc6a",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_context_all_request_cost": {
+      "accepted_source_role_contract_sha256": "1313a0bddba002f7992221c8dfa03ba9c6cdba3177ad2ee0df61034508d83a95",
+      "public_source_role_projection_sha256": "1313a0bddba002f7992221c8dfa03ba9c6cdba3177ad2ee0df61034508d83a95",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_context_all_request_response_fraction": {
+      "accepted_source_role_contract_sha256": "1313a0bddba002f7992221c8dfa03ba9c6cdba3177ad2ee0df61034508d83a95",
+      "public_source_role_projection_sha256": "1313a0bddba002f7992221c8dfa03ba9c6cdba3177ad2ee0df61034508d83a95",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_context_capacity_share": {
+      "accepted_source_role_contract_sha256": "1313a0bddba002f7992221c8dfa03ba9c6cdba3177ad2ee0df61034508d83a95",
+      "public_source_role_projection_sha256": "1313a0bddba002f7992221c8dfa03ba9c6cdba3177ad2ee0df61034508d83a95",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_context_categorywise_fixed_noninspection": {
+      "accepted_source_role_contract_sha256": "db44c18598bbc1aa2abd9cbe5cb163e3e73f9adb39b6b98a4360a91e30a2e805",
+      "public_source_role_projection_sha256": "db44c18598bbc1aa2abd9cbe5cb163e3e73f9adb39b6b98a4360a91e30a2e805",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_context_city_effective_load": {
+      "accepted_source_role_contract_sha256": "1313a0bddba002f7992221c8dfa03ba9c6cdba3177ad2ee0df61034508d83a95",
+      "public_source_role_projection_sha256": "1313a0bddba002f7992221c8dfa03ba9c6cdba3177ad2ee0df61034508d83a95",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_context_city_efficiency_loss": {
+      "accepted_source_role_contract_sha256": "1313a0bddba002f7992221c8dfa03ba9c6cdba3177ad2ee0df61034508d83a95",
+      "public_source_role_projection_sha256": "1313a0bddba002f7992221c8dfa03ba9c6cdba3177ad2ee0df61034508d83a95",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_context_city_efficient_delay": {
+      "accepted_source_role_contract_sha256": "1313a0bddba002f7992221c8dfa03ba9c6cdba3177ad2ee0df61034508d83a95",
+      "public_source_role_projection_sha256": "1313a0bddba002f7992221c8dfa03ba9c6cdba3177ad2ee0df61034508d83a95",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_context_effective_load": {
+      "accepted_source_role_contract_sha256": "1313a0bddba002f7992221c8dfa03ba9c6cdba3177ad2ee0df61034508d83a95",
+      "public_source_role_projection_sha256": "1313a0bddba002f7992221c8dfa03ba9c6cdba3177ad2ee0df61034508d83a95",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_context_efficiency_best_equitable": {
+      "accepted_source_role_contract_sha256": "db44c18598bbc1aa2abd9cbe5cb163e3e73f9adb39b6b98a4360a91e30a2e805",
+      "public_source_role_projection_sha256": "db44c18598bbc1aa2abd9cbe5cb163e3e73f9adb39b6b98a4360a91e30a2e805",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_context_efficiency_loss": {
+      "accepted_source_role_contract_sha256": "1313a0bddba002f7992221c8dfa03ba9c6cdba3177ad2ee0df61034508d83a95",
+      "public_source_role_projection_sha256": "1313a0bddba002f7992221c8dfa03ba9c6cdba3177ad2ee0df61034508d83a95",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_context_efficient_delay_endpoint": {
+      "accepted_source_role_contract_sha256": "1313a0bddba002f7992221c8dfa03ba9c6cdba3177ad2ee0df61034508d83a95",
+      "public_source_role_projection_sha256": "1313a0bddba002f7992221c8dfa03ba9c6cdba3177ad2ee0df61034508d83a95",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_context_equity_loss": {
+      "accepted_source_role_contract_sha256": "1313a0bddba002f7992221c8dfa03ba9c6cdba3177ad2ee0df61034508d83a95",
+      "public_source_role_projection_sha256": "1313a0bddba002f7992221c8dfa03ba9c6cdba3177ad2ee0df61034508d83a95",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_context_excess_capacity": {
+      "accepted_source_role_contract_sha256": "1313a0bddba002f7992221c8dfa03ba9c6cdba3177ad2ee0df61034508d83a95",
+      "public_source_role_projection_sha256": "1313a0bddba002f7992221c8dfa03ba9c6cdba3177ad2ee0df61034508d83a95",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_context_fixed_noninspection_cost": {
+      "accepted_source_role_contract_sha256": "1313a0bddba002f7992221c8dfa03ba9c6cdba3177ad2ee0df61034508d83a95",
+      "public_source_role_projection_sha256": "1313a0bddba002f7992221c8dfa03ba9c6cdba3177ad2ee0df61034508d83a95",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_context_original_fixed_load_feasibility": {
+      "accepted_source_role_contract_sha256": "db44c18598bbc1aa2abd9cbe5cb163e3e73f9adb39b6b98a4360a91e30a2e805",
+      "public_source_role_projection_sha256": "db44c18598bbc1aa2abd9cbe5cb163e3e73f9adb39b6b98a4360a91e30a2e805",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_context_pearson_chi_square": {
+      "accepted_source_role_contract_sha256": "1313a0bddba002f7992221c8dfa03ba9c6cdba3177ad2ee0df61034508d83a95",
+      "public_source_role_projection_sha256": "1313a0bddba002f7992221c8dfa03ba9c6cdba3177ad2ee0df61034508d83a95",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_context_relative_centralization_gain": {
+      "accepted_source_role_contract_sha256": "1313a0bddba002f7992221c8dfa03ba9c6cdba3177ad2ee0df61034508d83a95",
+      "public_source_role_projection_sha256": "1313a0bddba002f7992221c8dfa03ba9c6cdba3177ad2ee0df61034508d83a95",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_context_relative_price_of_equity": {
+      "accepted_source_role_contract_sha256": "1313a0bddba002f7992221c8dfa03ba9c6cdba3177ad2ee0df61034508d83a95",
+      "public_source_role_projection_sha256": "1313a0bddba002f7992221c8dfa03ba9c6cdba3177ad2ee0df61034508d83a95",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_context_tradeoff_objective": {
+      "accepted_source_role_contract_sha256": "1313a0bddba002f7992221c8dfa03ba9c6cdba3177ad2ee0df61034508d83a95",
+      "public_source_role_projection_sha256": "1313a0bddba002f7992221c8dfa03ba9c6cdba3177ad2ee0df61034508d83a95",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_domain_conditions": {
+      "accepted_source_role_contract_sha256": "25ae0445cbad5700740ca0d901cdb22fa81678daaa2adcfa53e3e0db581adee2",
+      "public_source_role_projection_sha256": "25ae0445cbad5700740ca0d901cdb22fa81678daaa2adcfa53e3e0db581adee2",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "stationary_gps_response_tail_context": {
+      "accepted_source_role_contract_sha256": "7943bb0a1038c9b9ca1ec777a62b2cf0d2afdf222d3ccb832d0d97bcd18dfc6a",
+      "public_source_role_projection_sha256": "7943bb0a1038c9b9ca1ec777a62b2cf0d2afdf222d3ccb832d0d97bcd18dfc6a",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "target_guaranteed_service_margin_context": {
+      "accepted_source_role_contract_sha256": "25ae0445cbad5700740ca0d901cdb22fa81678daaa2adcfa53e3e0db581adee2",
+      "public_source_role_projection_sha256": "25ae0445cbad5700740ca0d901cdb22fa81678daaa2adcfa53e3e0db581adee2",
+      "schema": 1,
+      "withheld_field_paths": []
+    }
+  },
+  "paper": "LG24ServiceLevelAgreements",
+  "private_role_material_included": false,
+  "private_source_map_material_sha256": "ebb085516d49dd5bc48e7c5a17eb34be34e138082100c5530541fdf72b7261f8",
+  "private_source_map_sha256": "fdbc4d5420378eeb7686b6b8ce9f7afb4f3527de8831124b833fc825dedcb621",
+  "projection_contract_sha256": "ed0964edc9c70f5ce087ce9bf134712ca40c7964ecaefd403309ac9a1b47d34d",
+  "public_display_manifest_material_sha256": "665078d0a7b5f06a3c8682b612d6e5c6b8fe282890f2c73325430d13b1539b26",
+  "public_display_manifest_sha256": "6c70846ed13d1f294345669e29baf8b778fed2164ae180a03ca2cc3ba5604e59",
+  "public_source_map_material_sha256": "841920543d1557bda3eb03e8af4dddcde2d6293e6d46543b55e9ca6671398bbb",
+  "public_source_map_sha256": "d9e6853f43302aaacf5445d4a7b964f0eddfc13a7f14298e61e05039bf47fe6c",
+  "raw_private_approval_material_included": false,
+  "schema": 1
+}

--- a/papers/LMMS04FairDivision/audit/paper_statement_map.json
+++ b/papers/LMMS04FairDivision/audit/paper_statement_map.json
@@ -551,6 +551,11 @@
   },
   "paper": "LMMS04FairDivision",
   "paper_interface_namespace": "LMMS04FairDivision",
+  "publication_source_display_projection": {
+    "manifest": "audit/public_source_display_projection.json",
+    "raw_source_bytes_included": false,
+    "schema": 1
+  },
   "schema": 1,
   "semantic_contract_schema": 1,
   "semantic_route_schema": 2,

--- a/papers/LMMS04FairDivision/audit/public_source_role_projection.json
+++ b/papers/LMMS04FairDivision/audit/public_source_role_projection.json
@@ -1,0 +1,134 @@
+{
+  "acceptance_credential": false,
+  "accepted_graph_sha256": "4875ef3733cf1f2340af3c538b3dc247d17d45a22f6521215eacd5b4773cdd81",
+  "bindings_by_source_item": {
+    "claim3_4_bounded_optimal_of_exact_allocations_with_nonempty_positive_goods": {
+      "accepted_source_role_contract_sha256": "00e1f6be2fabc7d38672f43c5503002ec7b42ef8e333c09fe21a4f3b24346abd",
+      "public_source_role_projection_sha256": "c5bf762e5fc813bb28ecaedffef6adf44a3232f12beefbac46640bc4e2a51879",
+      "schema": 1,
+      "withheld_field_paths": [
+        "user_approved_scope_exclusion.approval_reference",
+        "user_approved_scope_exclusion.source_locator"
+      ]
+    },
+    "lemma2_2_acyclic_reduction": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lemma2_4_real_interval_low_value_partition": {
+      "accepted_source_role_contract_sha256": "f1f2ce68674255f3934110992be612e207b0eb4bcfe816758f55a4021c770af8",
+      "public_source_role_projection_sha256": "d66345b7c58790410b05af5cf36b9257039222b02c64a0f1d9212b1991d406bc",
+      "schema": 1,
+      "withheld_field_paths": [
+        "user_approved_scope_exclusion.approval_reference",
+        "user_approved_scope_exclusion.source_locator"
+      ]
+    },
+    "lemma3_5_additive_transfer_epsilon_bound": {
+      "accepted_source_role_contract_sha256": "1026b4a548f59944acf0088e7187a4f57febf0ba1706115e111281023fe8d78a",
+      "public_source_role_projection_sha256": "f25817d9619d58d4a632528134201dfb351b0c1a7bd5e198b4307c2b0178e08f",
+      "schema": 1,
+      "withheld_field_paths": [
+        "user_approved_scope_exclusion.approval_reference",
+        "user_approved_scope_exclusion.source_locator"
+      ]
+    },
+    "theorem2_1_bounded_envy_allocation_exists": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem2_1_runtime_bound": {
+      "accepted_source_role_contract_sha256": "eb0b4c3ee87897559f0dd349f0bd63f9b9e62e875868db1ac8a7c79757e6fc7e",
+      "public_source_role_projection_sha256": "a61c065cd4a8dba26f2688bacd49f7246d2942e52217a624482cc4bfd72fbe10",
+      "schema": 1,
+      "withheld_field_paths": [
+        "user_approved_scope_exclusion.approval_reference",
+        "user_approved_scope_exclusion.source_locator"
+      ]
+    },
+    "theorem2_3_real_interval_supported_atom_bound": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem2_3_zero_atom_envyfree_external_boundary": {
+      "accepted_source_role_contract_sha256": "435da3defea5b4fddac10c8ae6bf83d0f8df077186392aa1fd27ff441b636a73",
+      "public_source_role_projection_sha256": "0c7052c4e128a817ef5502b764b70bd04bc78d067d9fe3e01e5649c5c2c56d4d",
+      "schema": 1,
+      "withheld_field_paths": [
+        "user_approved_scope_exclusion.approval_reference",
+        "user_approved_scope_exclusion.source_locator"
+      ]
+    },
+    "theorem3_1_eventually_minimum_envy_lower_bound_from_twoBit_adaptive_queries": {
+      "accepted_source_role_contract_sha256": "f92b95f320ba64b0234e8b7e1d502d064eb9424c68b016b12e3fd57b8eb4bfa9",
+      "public_source_role_projection_sha256": "19445bc25350154226fa2a9e37723b12cfb2f5437755c9ec65cd87f668d0191c",
+      "schema": 1,
+      "withheld_field_paths": [
+        "user_approved_scope_exclusion.approval_reference",
+        "user_approved_scope_exclusion.source_locator"
+      ]
+    },
+    "theorem3_2_graham_certificate_to_envy_ratio_bound": {
+      "accepted_source_role_contract_sha256": "9928863071dd83e86fa78781021bf607d3a27d5472bceafaddb6784b76e3051b",
+      "public_source_role_projection_sha256": "c5e27f0ef48352225cf15f53dfbdeb96825e7f9212c337051b3ac39e99c25bc7",
+      "schema": 1,
+      "withheld_field_paths": [
+        "user_approved_scope_exclusion.approval_reference",
+        "user_approved_scope_exclusion.source_locator"
+      ]
+    },
+    "theorem3_3_solver_auto_cap_full_ip_summary_with_ratio_guarantee": {
+      "accepted_source_role_contract_sha256": "3b40b623cb8babe3e0f361abd8a379943fc836bf0f41b03059e169c37b16dc2e",
+      "public_source_role_projection_sha256": "b81f445066fa3605a700163cbb55e0d8b25d17f51bc81f66b37b67f38c2f4d80",
+      "schema": 1,
+      "withheld_field_paths": [
+        "user_approved_scope_exclusion.approval_reference",
+        "user_approved_scope_exclusion.source_locator"
+      ]
+    },
+    "theorem4_1_source_minimum_envy_not_truthful": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem4_1_source_not_truthful_envy_free_whenever_exists": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem4_2_asymptotic_high_probability_rate": {
+      "accepted_source_role_contract_sha256": "d3327cc28d3936f3b59f92d50c632a6a5b800fb0242d0edb624eb6044ff8e344",
+      "public_source_role_projection_sha256": "f36ff59ac9de37343fab3bfb02de03586c477c97fde3a52de472a07ea29cfd4c",
+      "schema": 1,
+      "withheld_field_paths": [
+        "user_approved_scope_exclusion.approval_reference",
+        "user_approved_scope_exclusion.source_locator"
+      ]
+    },
+    "theorem4_2_uniform_random_mechanism_truthful": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    }
+  },
+  "paper": "LMMS04FairDivision",
+  "private_role_material_included": false,
+  "private_source_map_material_sha256": "206df2dfed5341fc7d69769b1a5867d7e913c8b54ddfdab33c105354e586ed0d",
+  "private_source_map_sha256": "b600ce818d61496619eb406d10651c5b82591828d766ef3cfab8aa43479c0a6b",
+  "projection_contract_sha256": "ed0964edc9c70f5ce087ce9bf134712ca40c7964ecaefd403309ac9a1b47d34d",
+  "public_display_manifest_material_sha256": "04d83f67fb19628c59a1db3559b1aaa742fc22bfde440d4fbf7d05b0506da569",
+  "public_display_manifest_sha256": "22b594bb56a17afd0420e6e0c96afbc1c33db979a83503dfc6f52ca97a12c4da",
+  "public_source_map_material_sha256": "f2f1f262360b3482e73de7b66554ed0dc31d637e208a555321b9ec3e4d001a0a",
+  "public_source_map_sha256": "cc1f117f46a2d31cd4859a208eacb4502f7e43fd6e2713cc23721e551271f529",
+  "raw_private_approval_material_included": false,
+  "schema": 1
+}

--- a/papers/LOS02CombinatorialAuctions/audit/paper_statement_map.json
+++ b/papers/LOS02CombinatorialAuctions/audit/paper_statement_map.json
@@ -3205,6 +3205,11 @@
     "LOS02CombinatorialAuctions.SourceGreedy.averageGreedyMechanism": "source_greedy_mechanism",
     "LOS02CombinatorialAuctions.SourceGreedy.averagePayment": "definition10_1"
   },
+  "publication_source_display_projection": {
+    "manifest": "audit/public_source_display_projection.json",
+    "raw_source_bytes_included": false,
+    "schema": 1
+  },
   "schema": 1,
   "semantic_contract_schema": 1,
   "semantic_preflight_import_module": "LOS02CombinatorialAuctions.PaperInterface",

--- a/papers/LOS02CombinatorialAuctions/audit/public_source_role_projection.json
+++ b/papers/LOS02CombinatorialAuctions/audit/public_source_role_projection.json
@@ -1,0 +1,218 @@
+{
+  "acceptance_credential": false,
+  "accepted_graph_sha256": "1879202f02b15daebe27ce7cdd39cf28988f16fcf1442d0401174064e3ce456e",
+  "bindings_by_source_item": {
+    "definition10_1": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition3_1": {
+      "accepted_source_role_contract_sha256": "996d837513c015e39b2f5229081f77cfcda7b26c0cb8599dde62b71f7d5597f4",
+      "public_source_role_projection_sha256": "996d837513c015e39b2f5229081f77cfcda7b26c0cb8599dde62b71f7d5597f4",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition3_2": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition5_1": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition7_1": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lemma9_1": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lemma9_2": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lemma9_3": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lemma9_4": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lemma9_5": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "proposition4_2": {
+      "accepted_source_role_contract_sha256": "64a83a0ae6edbdb2d3cfb6cb84e3bf045734ef9303f62643ff780eff69b02885",
+      "public_source_role_projection_sha256": "64a83a0ae6edbdb2d3cfb6cb84e3bf045734ef9303f62643ff780eff69b02885",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "section12": {
+      "accepted_source_role_contract_sha256": "ff5a0e099e16c780ec0c807bad8030a1474e5e84b20ee9670ac2ec27355bdb21",
+      "public_source_role_projection_sha256": "ff5a0e099e16c780ec0c807bad8030a1474e5e84b20ee9670ac2ec27355bdb21",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "section8": {
+      "accepted_source_role_contract_sha256": "ff5a0e099e16c780ec0c807bad8030a1474e5e84b20ee9670ac2ec27355bdb21",
+      "public_source_role_projection_sha256": "ff5a0e099e16c780ec0c807bad8030a1474e5e84b20ee9670ac2ec27355bdb21",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_allocation_domain": {
+      "accepted_source_role_contract_sha256": "cb4c52d7162057fe79d176483b8606eae69ef415544ac40e16cd2b0dd1287867",
+      "public_source_role_projection_sha256": "cb4c52d7162057fe79d176483b8606eae69ef415544ac40e16cd2b0dd1287867",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_critical": {
+      "accepted_source_role_contract_sha256": "ef40ed5e5c883ef4fd4a49df1906a6229798e891ed4591307506e737b0af3cb4",
+      "public_source_role_projection_sha256": "ef40ed5e5c883ef4fd4a49df1906a6229798e891ed4591307506e737b0af3cb4",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_exactness": {
+      "accepted_source_role_contract_sha256": "743bbba9f020eb4d0a320319a29571e6f08261c76d90cbbb87a6da0dd800d074",
+      "public_source_role_projection_sha256": "743bbba9f020eb4d0a320319a29571e6f08261c76d90cbbb87a6da0dd800d074",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_feasibility": {
+      "accepted_source_role_contract_sha256": "cb4c52d7162057fe79d176483b8606eae69ef415544ac40e16cd2b0dd1287867",
+      "public_source_role_projection_sha256": "cb4c52d7162057fe79d176483b8606eae69ef415544ac40e16cd2b0dd1287867",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_greedy_allocation": {
+      "accepted_source_role_contract_sha256": "f8e02914dc932bf6905151b7390e6cc598aea1b15b2873628a44ca9430aa3bd0",
+      "public_source_role_projection_sha256": "f8e02914dc932bf6905151b7390e6cc598aea1b15b2873628a44ca9430aa3bd0",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_greedy_mechanism": {
+      "accepted_source_role_contract_sha256": "cb4c52d7162057fe79d176483b8606eae69ef415544ac40e16cd2b0dd1287867",
+      "public_source_role_projection_sha256": "cb4c52d7162057fe79d176483b8606eae69ef415544ac40e16cd2b0dd1287867",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_greedy_order": {
+      "accepted_source_role_contract_sha256": "cb4c52d7162057fe79d176483b8606eae69ef415544ac40e16cd2b0dd1287867",
+      "public_source_role_projection_sha256": "cb4c52d7162057fe79d176483b8606eae69ef415544ac40e16cd2b0dd1287867",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_gva": {
+      "accepted_source_role_contract_sha256": "cb4c52d7162057fe79d176483b8606eae69ef415544ac40e16cd2b0dd1287867",
+      "public_source_role_projection_sha256": "cb4c52d7162057fe79d176483b8606eae69ef415544ac40e16cd2b0dd1287867",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_monotonicity": {
+      "accepted_source_role_contract_sha256": "ef40ed5e5c883ef4fd4a49df1906a6229798e891ed4591307506e737b0af3cb4",
+      "public_source_role_projection_sha256": "ef40ed5e5c883ef4fd4a49df1906a6229798e891ed4591307506e737b0af3cb4",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_next_denied": {
+      "accepted_source_role_contract_sha256": "95831d632d7e2b47e2bfcb7ea4cae4def7a40fa72e4647c49aa58796c0109982",
+      "public_source_role_projection_sha256": "95831d632d7e2b47e2bfcb7ea4cae4def7a40fa72e4647c49aa58796c0109982",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_participation": {
+      "accepted_source_role_contract_sha256": "ef40ed5e5c883ef4fd4a49df1906a6229798e891ed4591307506e737b0af3cb4",
+      "public_source_role_projection_sha256": "ef40ed5e5c883ef4fd4a49df1906a6229798e891ed4591307506e737b0af3cb4",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_quasilinear_utility": {
+      "accepted_source_role_contract_sha256": "cb4c52d7162057fe79d176483b8606eae69ef415544ac40e16cd2b0dd1287867",
+      "public_source_role_projection_sha256": "cb4c52d7162057fe79d176483b8606eae69ef415544ac40e16cd2b0dd1287867",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_section12_model": {
+      "accepted_source_role_contract_sha256": "cb4c52d7162057fe79d176483b8606eae69ef415544ac40e16cd2b0dd1287867",
+      "public_source_role_projection_sha256": "cb4c52d7162057fe79d176483b8606eae69ef415544ac40e16cd2b0dd1287867",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_section8_mechanism": {
+      "accepted_source_role_contract_sha256": "cb4c52d7162057fe79d176483b8606eae69ef415544ac40e16cd2b0dd1287867",
+      "public_source_role_projection_sha256": "cb4c52d7162057fe79d176483b8606eae69ef415544ac40e16cd2b0dd1287867",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_sqrt_objective": {
+      "accepted_source_role_contract_sha256": "cb4c52d7162057fe79d176483b8606eae69ef415544ac40e16cd2b0dd1287867",
+      "public_source_role_projection_sha256": "cb4c52d7162057fe79d176483b8606eae69ef415544ac40e16cd2b0dd1287867",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem10_2": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem4_1": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem6_1": {
+      "accepted_source_role_contract_sha256": "a8184bce3e162689fde6a18cf5fd5276b13c3211e6a458d5a9deafc0f66e16ec",
+      "public_source_role_projection_sha256": "5704ed2ef191464a1d2953548beff6fec541733a1c7928592d30b4c2c778ecec",
+      "schema": 1,
+      "withheld_field_paths": [
+        "user_approved_scope_exclusion.approval_reference",
+        "user_approved_scope_exclusion.source_locator"
+      ]
+    },
+    "theorem7_2": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem9_6": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    }
+  },
+  "paper": "LOS02CombinatorialAuctions",
+  "private_role_material_included": false,
+  "private_source_map_material_sha256": "4ce3f0a607e1c92a7cb2961b021c64f40822a0ca7ee130c5710eb1a03294ad3a",
+  "private_source_map_sha256": "49ffc21ddf2c5a7414457e62762ed6d99b35ccd874a77342601c275b962e0005",
+  "projection_contract_sha256": "ed0964edc9c70f5ce087ce9bf134712ca40c7964ecaefd403309ac9a1b47d34d",
+  "public_display_manifest_material_sha256": "aa774375ec3261c444619049bc44fefc946125f3d1c3f94d47f71851d457acd8",
+  "public_display_manifest_sha256": "b1e19fc44cd882faaf84fe22ae906b2075d80bec0c784552b5227a78afd79ac6",
+  "public_source_map_material_sha256": "fc36b3d8c7ef80407ceb6fbee950b83b4697131fd25abe7ddd49cfe6ba3f7ed1",
+  "public_source_map_sha256": "be216febfab63db1571a6eeedf6bdd5bffe2b1c1b2885da6439ff29ef5e03782",
+  "raw_private_approval_material_included": false,
+  "schema": 1
+}

--- a/papers/MBJG25ProducerFairness/audit/paper_statement_map.json
+++ b/papers/MBJG25ProducerFairness/audit/paper_statement_map.json
@@ -315,6 +315,11 @@
     "approval_material_included": false,
     "schema": 1
   },
+  "publication_source_display_projection": {
+    "manifest": "audit/public_source_display_projection.json",
+    "raw_source_bytes_included": false,
+    "schema": 1
+  },
   "schema": 1,
   "semantic_contract_schema": 1,
   "semantic_preflight_import_module": "MBJG25ProducerFairness.ProofInterface",

--- a/papers/MBJG25ProducerFairness/audit/public_source_role_projection.json
+++ b/papers/MBJG25ProducerFairness/audit/public_source_role_projection.json
@@ -1,0 +1,68 @@
+{
+  "acceptance_credential": false,
+  "accepted_graph_sha256": "668354ed4fcffffb6c3810c94fc5216547ca2ce7edc4f5b49917b04ab0bd34f0",
+  "bindings_by_source_item": {
+    "mbjg25_appendix_d_beta_shape": {
+      "accepted_source_role_contract_sha256": "234ade03269477a377b19c81d729a7250b1b60f419aec19c5b48d8e009d5de35",
+      "public_source_role_projection_sha256": "62a6e0a3a1b7900e1ff2c05a1c5e5a52c688f341fc2409207408ea58e30ca03c",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "mbjg25_appendix_e_ordinal_prior": {
+      "accepted_source_role_contract_sha256": "62ef40e0c9adfef90dfbb1859037265a3c870cd436c4be79f002b48bf0888d89",
+      "public_source_role_projection_sha256": "1bd012f6ccb05d6b8178f25fa0286eaa275af7b79cb2cddff8e9c31306aa77ea",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "mbjg25_fixed_binary_model": {
+      "accepted_source_role_contract_sha256": "cb4c52d7162057fe79d176483b8606eae69ef415544ac40e16cd2b0dd1287867",
+      "public_source_role_projection_sha256": "cb4c52d7162057fe79d176483b8606eae69ef415544ac40e16cd2b0dd1287867",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "mbjg25_theorem3_1": {
+      "accepted_source_role_contract_sha256": "55ec60861f008b21ecdfca7d59a1028f0d037e62d12a299b1cb3a9db26b53150",
+      "public_source_role_projection_sha256": "43cf501ac8a50d9db390463aef31c666536115ce80a89d558070af6adcfdcc5d",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "mbjg25_theorem3_1_appendix_presentation": {
+      "accepted_source_role_contract_sha256": "1d239652a90cbe5e5a6acfbc5170f0d2356a133066e0067a00e2dbb97c464b60",
+      "public_source_role_projection_sha256": "1d239652a90cbe5e5a6acfbc5170f0d2356a133066e0067a00e2dbb97c464b60",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "mbjg25_theorem3_2": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "mbjg25_theorem3_2_appendix_presentation": {
+      "accepted_source_role_contract_sha256": "1d239652a90cbe5e5a6acfbc5170f0d2356a133066e0067a00e2dbb97c464b60",
+      "public_source_role_projection_sha256": "1d239652a90cbe5e5a6acfbc5170f0d2356a133066e0067a00e2dbb97c464b60",
+      "schema": 1,
+      "withheld_field_paths": []
+    }
+  },
+  "paper": "MBJG25ProducerFairness",
+  "private_role_material_included": false,
+  "private_source_map_material_sha256": "05df4ef25f45b14cb20fb2bba893811e96a4d8b9598b34bc74c676d051c727b9",
+  "private_source_map_sha256": "59bdf1ddf140ad3b7c6a9708ff6e1caca0f3a696b05240b1af195d77d1a71b83",
+  "projection_contract_sha256": "ed0964edc9c70f5ce087ce9bf134712ca40c7964ecaefd403309ac9a1b47d34d",
+  "public_display_manifest_material_sha256": "8c8bb22b0a0a828a82048da09fc60be8aa233d88f761210beb9bf9f60fa46d38",
+  "public_display_manifest_sha256": "59b3a3c7f40ab1a1c1fa9250d19e45ebe65ead8b2c81239d89738549ffeed3b0",
+  "public_source_map_material_sha256": "6ea29417cfdbb5ba1236cdccabd799e59f2174b2612a7b8efb61cd131687dd8b",
+  "public_source_map_sha256": "42aff698fceb40d5163bcd6d5bb39733a3418dfb95d4f120b8296ddbf658bc8f",
+  "raw_private_approval_material_included": false,
+  "schema": 1
+}

--- a/papers/MSVV07AdWords/audit/paper_statement_map.json
+++ b/papers/MSVV07AdWords/audit/paper_statement_map.json
@@ -4367,6 +4367,11 @@
     "approval_material_included": false,
     "schema": 1
   },
+  "publication_source_display_projection": {
+    "manifest": "audit/public_source_display_projection.json",
+    "raw_source_bytes_included": false,
+    "schema": 1
+  },
   "schema": 1,
   "semantic_contract_schema": 1,
   "semantic_preflight_import_module": "MSVV07AdWords.PaperInterface",

--- a/papers/MSVV07AdWords/audit/public_source_display_projection.json
+++ b/papers/MSVV07AdWords/audit/public_source_display_projection.json
@@ -1,9 +1,9 @@
 {
   "generator": "python3 scripts/public_source_display_projection.py",
   "paper_id": "MSVV07AdWords",
-  "private_source_map_sha256": "cc59638a786d30d79b10d3a47968726f608df7544a944842200bba021275456c",
+  "private_source_map_sha256": "a3f41b7d9bf3c4f54fe6c7fd98563323b94d87c05b1455d10895cd996463282a",
   "public_manifest_path": "papers/MSVV07AdWords/audit/public_source_display_projection.json",
-  "public_source_map_sha256": "f40280afc9c512418801365dd5388804f6101d94362395d0e165afd57c96c60c",
+  "public_source_map_sha256": "f5c5d40128a7c88520c59a9b0a7a54f6aa0bdc970f8ddd1bfa9534efa429c015",
   "raw_source_artifact_included": false,
   "raw_source_display_material": "selected_byte_pinned_source_anchor_quotes",
   "schema": 1,

--- a/papers/MSVV07AdWords/audit/public_source_role_projection.json
+++ b/papers/MSVV07AdWords/audit/public_source_role_projection.json
@@ -1,0 +1,707 @@
+{
+  "acceptance_credential": false,
+  "accepted_graph_sha256": "fb2187e835102b2335fea22d3b2938fc30793ba91974a898cc5d74e43027593d",
+  "bindings_by_source_item": {
+    "appendix_kappa_counterexample_family": {
+      "accepted_source_role_contract_sha256": "49b3dfad154ee342ec3d604931300f5a34a64a8de2ac42389b56efe7ffcc78fd",
+      "public_source_role_projection_sha256": "0c15f21ae1c617b7d6086eadb5ef87a4c71c871fe65a20eec1db5a255409b575",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "appendix_kappa_ratio_limit_infinity": {
+      "accepted_source_role_contract_sha256": "ff5a0e099e16c780ec0c807bad8030a1474e5e84b20ee9670ac2ec27355bdb21",
+      "public_source_role_projection_sha256": "ff5a0e099e16c780ec0c807bad8030a1474e5e84b20ee9670ac2ec27355bdb21",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "appendix_kappa_ratio_limit_one": {
+      "accepted_source_role_contract_sha256": "ff5a0e099e16c780ec0c807bad8030a1474e5e84b20ee9670ac2ec27355bdb21",
+      "public_source_role_projection_sha256": "ff5a0e099e16c780ec0c807bad8030a1474e5e84b20ee9670ac2ec27355bdb21",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "appendix_naive_algorithm_revenue_formula": {
+      "accepted_source_role_contract_sha256": "ec6f5062c00075cb4ad6a968252cdfcb4a9c2477fc3114f58c6572251a86256e",
+      "public_source_role_projection_sha256": "58953fd4d93f15ec87bc9e129d4b55769d3a777854a409250564a794d0d43433",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "appendix_naive_highest_bid_rule": {
+      "accepted_source_role_contract_sha256": "ba7b071bb25f1da49c63d615625ddd4b620c0e0bc3bb72a047c00b26d6cb7c5b",
+      "public_source_role_projection_sha256": "ba7b071bb25f1da49c63d615625ddd4b620c0e0bc3bb72a047c00b26d6cb7c5b",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "appendix_naive_strict_ratio_conclusion": {
+      "accepted_source_role_contract_sha256": "ff5a0e099e16c780ec0c807bad8030a1474e5e84b20ee9670ac2ec27355bdb21",
+      "public_source_role_projection_sha256": "ff5a0e099e16c780ec0c807bad8030a1474e5e84b20ee9670ac2ec27355bdb21",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "appendix_naive_three_phase_construction": {
+      "accepted_source_role_contract_sha256": "97116f66256719ce62459e81a77c581c55ee3997512454a73bc3e88675a0e05d",
+      "public_source_role_projection_sha256": "aa7f60c29937a26488655dd5acc806e96778f8ddbf5b83c64c1ffb27a0f9ae87",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "appendix_optimum_revenue_formula": {
+      "accepted_source_role_contract_sha256": "7943bb0a1038c9b9ca1ec777a62b2cf0d2afdf222d3ccb832d0d97bcd18dfc6a",
+      "public_source_role_projection_sha256": "7943bb0a1038c9b9ca1ec777a62b2cf0d2afdf222d3ccb832d0d97bcd18dfc6a",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "assumption_click_through_rates_probability_bounds": {
+      "accepted_source_role_contract_sha256": "10d3b168adc54f4f65034bf4056bf824f46ba8a384f57936a80b50242dd4daa6",
+      "public_source_role_projection_sha256": "10d3b168adc54f4f65034bf4056bf824f46ba8a384f57936a80b50242dd4daa6",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "assumption_epsilon_range": {
+      "accepted_source_role_contract_sha256": "eb1fb0af798d1b2f6016eb55b4edd9a208017536e831e49389c6a4bd1a553533",
+      "public_source_role_projection_sha256": "f070d0a3eda5134918b66cd0d1e0123e2bc04c4b2b9aa12802790e90792d3c17",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "assumption_nonnegative_bids": {
+      "accepted_source_role_contract_sha256": "aaf4737b0ddea4fda62b5da8492726cd48b1dadd99e1d50c3330e4d8d5277c23",
+      "public_source_role_projection_sha256": "284fc79c51e9e13327d1f3fbc68ffaa936f508722c47136a425402ed55595790",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "paperBalanceScore_formula": {
+      "accepted_source_role_contract_sha256": "7943bb0a1038c9b9ca1ec777a62b2cf0d2afdf222d3ccb832d0d97bcd18dfc6a",
+      "public_source_role_projection_sha256": "7943bb0a1038c9b9ca1ec777a62b2cf0d2afdf222d3ccb832d0d97bcd18dfc6a",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "paperCanAssign_iff": {
+      "accepted_source_role_contract_sha256": "165abba6d8f417c52f55d56610285a4aeba2138de558d655f1b671ccf4b8d330",
+      "public_source_role_projection_sha256": "165abba6d8f417c52f55d56610285a4aeba2138de558d655f1b671ccf4b8d330",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "paperFeasible_iff": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "paperIsBalanceChoice_iff": {
+      "accepted_source_role_contract_sha256": "48e39d93ab7e5f12d6c9d8a7a617c398d392fc3c5b98eeb0320c2bb31df88e0a",
+      "public_source_role_projection_sha256": "48e39d93ab7e5f12d6c9d8a7a617c398d392fc3c5b98eeb0320c2bb31df88e0a",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "paperMsvvRatio_formula": {
+      "accepted_source_role_contract_sha256": "dfcc6b216a0d49afd3abeeeaf73c47142fa1445f358257a19b2e740044965a50",
+      "public_source_role_projection_sha256": "dfcc6b216a0d49afd3abeeeaf73c47142fa1445f358257a19b2e740044965a50",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "paperRevenue_formula": {
+      "accepted_source_role_contract_sha256": "dfcc6b216a0d49afd3abeeeaf73c47142fa1445f358257a19b2e740044965a50",
+      "public_source_role_projection_sha256": "dfcc6b216a0d49afd3abeeeaf73c47142fa1445f358257a19b2e740044965a50",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "paperSlotsPerPageDistinct_iff": {
+      "accepted_source_role_contract_sha256": "820781d72c960283c7fb2b103f2bdd408e0751d04f1df1c80d95d270bd789ccd",
+      "public_source_role_projection_sha256": "e8a6b5f3ee207ed80d39c28966ffe312bfbd5ed2ae663ec560b33cc142cfd77d",
+      "schema": 1,
+      "withheld_field_paths": [
+        "user_approved_scope_exclusion.approval_reference",
+        "user_approved_scope_exclusion.source_locator"
+      ]
+    },
+    "paperSmallBidsLimitFamily_fields": {
+      "accepted_source_role_contract_sha256": "48468b46f13e2dda808348b3d4a21e7e4eddcb06a6729976b9261cdff18ee60b",
+      "public_source_role_projection_sha256": "be604c06276fefdefb3815074c5ef7702483d82ae1d04f14416f123001f1c305",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "paperSmallBids_iff": {
+      "accepted_source_role_contract_sha256": "10d3b168adc54f4f65034bf4056bf824f46ba8a384f57936a80b50242dd4daa6",
+      "public_source_role_projection_sha256": "10d3b168adc54f4f65034bf4056bf824f46ba8a384f57936a80b50242dd4daa6",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "paperSpend_formula": {
+      "accepted_source_role_contract_sha256": "dfcc6b216a0d49afd3abeeeaf73c47142fa1445f358257a19b2e740044965a50",
+      "public_source_role_projection_sha256": "dfcc6b216a0d49afd3abeeeaf73c47142fa1445f358257a19b2e740044965a50",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "paperTradeoff_formula": {
+      "accepted_source_role_contract_sha256": "dfcc6b216a0d49afd3abeeeaf73c47142fa1445f358257a19b2e740044965a50",
+      "public_source_role_projection_sha256": "dfcc6b216a0d49afd3abeeeaf73c47142fa1445f358257a19b2e740044965a50",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "section2_competitive_ratio_definition": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "section2_equal_unit_budgets_simplifying_assumption": {
+      "accepted_source_role_contract_sha256": "10d3b168adc54f4f65034bf4056bf824f46ba8a384f57936a80b50242dd4daa6",
+      "public_source_role_projection_sha256": "10d3b168adc54f4f65034bf4056bf824f46ba8a384f57936a80b50242dd4daa6",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "section2_exhaustive_optimum_simplifying_assumption": {
+      "accepted_source_role_contract_sha256": "10d3b168adc54f4f65034bf4056bf824f46ba8a384f57936a80b50242dd4daa6",
+      "public_source_role_projection_sha256": "10d3b168adc54f4f65034bf4056bf824f46ba8a384f57936a80b50242dd4daa6",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "section3_balance_choice_exists_with_finite_max_cost": {
+      "accepted_source_role_contract_sha256": "0bb2a7c92760447144bb3a16c976108dda444317eef7c304d7f2dc140353976e",
+      "public_source_role_projection_sha256": "0bb2a7c92760447144bb3a16c976108dda444317eef7c304d7f2dc140353976e",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "section3_discrete_balance_algorithm": {
+      "accepted_source_role_contract_sha256": "48e39d93ab7e5f12d6c9d8a7a617c398d392fc3c5b98eeb0320c2bb31df88e0a",
+      "public_source_role_projection_sha256": "48e39d93ab7e5f12d6c9d8a7a617c398d392fc3c5b98eeb0320c2bb31df88e0a",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "section3_discrete_tradeoff_convergence": {
+      "accepted_source_role_contract_sha256": "ff5a0e099e16c780ec0c807bad8030a1474e5e84b20ee9670ac2ec27355bdb21",
+      "public_source_role_projection_sha256": "ff5a0e099e16c780ec0c807bad8030a1474e5e84b20ee9670ac2ec27355bdb21",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "section3_discrete_tradeoff_formula": {
+      "accepted_source_role_contract_sha256": "7943bb0a1038c9b9ca1ec777a62b2cf0d2afdf222d3ccb832d0d97bcd18dfc6a",
+      "public_source_role_projection_sha256": "7943bb0a1038c9b9ca1ec777a62b2cf0d2afdf222d3ccb832d0d97bcd18dfc6a",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "section3_discrete_tradeoff_monotonicity": {
+      "accepted_source_role_contract_sha256": "ff5a0e099e16c780ec0c807bad8030a1474e5e84b20ee9670ac2ec27355bdb21",
+      "public_source_role_projection_sha256": "ff5a0e099e16c780ec0c807bad8030a1474e5e84b20ee9670ac2ec27355bdb21",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "section3_equal_bid_discrete_msvv_is_balance": {
+      "accepted_source_role_contract_sha256": "ff5a0e099e16c780ec0c807bad8030a1474e5e84b20ee9670ac2ec27355bdb21",
+      "public_source_role_projection_sha256": "ff5a0e099e16c780ec0c807bad8030a1474e5e84b20ee9670ac2ec27355bdb21",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "section3_greedy_tight_half_example": {
+      "accepted_source_role_contract_sha256": "24af3b57d5538434b02162eaed2147ad48cd373b770e44446d79c3c9a8da45f3",
+      "public_source_role_projection_sha256": "24af3b57d5538434b02162eaed2147ad48cd373b770e44446d79c3c9a8da45f3",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "section3_slab_and_current_slab_definition": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "section4_balance_exact_tightness_instance": {
+      "accepted_source_role_contract_sha256": "c627688217777334728497f0ce3a97aac828668c0bb66a0cf64aa80f53c515fa",
+      "public_source_role_projection_sha256": "34bd10873615fc2382f8ec56b2d9a0de2bd83da5b0f9da2e4633517647002b36",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "section4_balance_revenue_factor_lp_bridge_formula": {
+      "accepted_source_role_contract_sha256": "dfcc6b216a0d49afd3abeeeaf73c47142fa1445f358257a19b2e740044965a50",
+      "public_source_role_projection_sha256": "dfcc6b216a0d49afd3abeeeaf73c47142fa1445f358257a19b2e740044965a50",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "section4_bidder_type_definition": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "section4_discretization_error_bound": {
+      "accepted_source_role_contract_sha256": "ff5a0e099e16c780ec0c807bad8030a1474e5e84b20ee9670ac2ec27355bdb21",
+      "public_source_role_projection_sha256": "ff5a0e099e16c780ec0c807bad8030a1474e5e84b20ee9670ac2ec27355bdb21",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "section4_factor_revealing_primal_dual_lp_formulas": {
+      "accepted_source_role_contract_sha256": "7943bb0a1038c9b9ca1ec777a62b2cf0d2afdf222d3ccb832d0d97bcd18dfc6a",
+      "public_source_role_projection_sha256": "7943bb0a1038c9b9ca1ec777a62b2cf0d2afdf222d3ccb832d0d97bcd18dfc6a",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "section4_lemma1_balance_pays_no_later_slab": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "section4_lemma2_factor_revealing_lp_constraint": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "section4_lemma3_displayed_primal_dual_witnesses_optimal": {
+      "accepted_source_role_contract_sha256": "0a2a1ef01e750435fec0427e898171e21c293c34f236c55bbee5e0b2e9ff6522",
+      "public_source_role_projection_sha256": "0a2a1ef01e750435fec0427e898171e21c293c34f236c55bbee5e0b2e9ff6522",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "section4_lemma3_factor_revealing_lp_optimality": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "section4_slab_spend_beta_formula": {
+      "accepted_source_role_contract_sha256": "7943bb0a1038c9b9ca1ec777a62b2cf0d2afdf222d3ccb832d0d97bcd18dfc6a",
+      "public_source_role_projection_sha256": "7943bb0a1038c9b9ca1ec777a62b2cf0d2afdf222d3ccb832d0d97bcd18dfc6a",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "section4_type_count_x_definition": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "section5_alg_query_revenue_definition": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "section5_alpha_type_count_definition": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "section5_beta_slab_spend_definition": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "section5_bidder_type_definition": {
+      "accepted_source_role_contract_sha256": "1b148fdcaa4e1f69ff1eee2766be31fdb1505e050f2c5c0f8ae9ad73f00a90a2",
+      "public_source_role_projection_sha256": "1b148fdcaa4e1f69ff1eee2766be31fdb1505e050f2c5c0f8ae9ad73f00a90a2",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "section5_delta_prefix_definition": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "section5_exact_type_spend_simplifying_assumption": {
+      "accepted_source_role_contract_sha256": "10d3b168adc54f4f65034bf4056bf824f46ba8a384f57936a80b50242dd4daa6",
+      "public_source_role_projection_sha256": "10d3b168adc54f4f65034bf4056bf824f46ba8a384f57936a80b50242dd4daa6",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "section5_lemma4_dual_optimal_from_primal_dual_match": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "section5_lemma5_tradeoff_rhs_eq_base_add_delta": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "section5_lemma6_per_query_tradeoff": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "section5_lemma7_weighted_perturbation_bound": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "section5_opt_query_revenue_definition": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "section5_query_slab_definition": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "section5_query_type_definition": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "section5_slab_fiber_beta_accounting_formula": {
+      "accepted_source_role_contract_sha256": "7943bb0a1038c9b9ca1ec777a62b2cf0d2afdf222d3ccb832d0d97bcd18dfc6a",
+      "public_source_role_projection_sha256": "7943bb0a1038c9b9ca1ec777a62b2cf0d2afdf222d3ccb832d0d97bcd18dfc6a",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "section5_tradeoff_revealing_primal_dual_lp_formulas": {
+      "accepted_source_role_contract_sha256": "7943bb0a1038c9b9ca1ec777a62b2cf0d2afdf222d3ccb832d0d97bcd18dfc6a",
+      "public_source_role_projection_sha256": "7943bb0a1038c9b9ca1ec777a62b2cf0d2afdf222d3ccb832d0d97bcd18dfc6a",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "section5_type_fiber_alpha_accounting_formula": {
+      "accepted_source_role_contract_sha256": "7943bb0a1038c9b9ca1ec777a62b2cf0d2afdf222d3ccb832d0d97bcd18dfc6a",
+      "public_source_role_projection_sha256": "7943bb0a1038c9b9ca1ec777a62b2cf0d2afdf222d3ccb832d0d97bcd18dfc6a",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "section6_alive_keep_alive_capability_assumption": {
+      "accepted_source_role_contract_sha256": "cf07264f18c43b11ec6176ce4e6b18d8afcd387de930d07c3b3d6be144276c50",
+      "public_source_role_projection_sha256": "cf07264f18c43b11ec6176ce4e6b18d8afcd387de930d07c3b3d6be144276c50",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "section6_alpha_i_definition": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "section6_alpha_total_definition": {
+      "accepted_source_role_contract_sha256": "7943bb0a1038c9b9ca1ec777a62b2cf0d2afdf222d3ccb832d0d97bcd18dfc6a",
+      "public_source_role_projection_sha256": "7943bb0a1038c9b9ca1ec777a62b2cf0d2afdf222d3ccb832d0d97bcd18dfc6a",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "section6_availability_theorem8_finite_explicit_error": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "section6_beta_i_aggregate_definition": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "section6_beta_ij_definition": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "section6_beta_lower_bound_formula": {
+      "accepted_source_role_contract_sha256": "7943bb0a1038c9b9ca1ec777a62b2cf0d2afdf222d3ccb832d0d97bcd18dfc6a",
+      "public_source_role_projection_sha256": "7943bb0a1038c9b9ca1ec777a62b2cf0d2afdf222d3ccb832d0d97bcd18dfc6a",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "section6_click_through_rates_effective_bid_formula": {
+      "accepted_source_role_contract_sha256": "7943bb0a1038c9b9ca1ec777a62b2cf0d2afdf222d3ccb832d0d97bcd18dfc6a",
+      "public_source_role_projection_sha256": "7943bb0a1038c9b9ca1ec777a62b2cf0d2afdf222d3ccb832d0d97bcd18dfc6a",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "section6_click_through_rates_theorem8_finite_explicit_error": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "section6_current_type_definition": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "section6_different_budgets_and_nonexhaustive_optimum_theorem8_finite_explicit_error": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "section6_generalized_current_type_balance_algorithm": {
+      "accepted_source_role_contract_sha256": "48e39d93ab7e5f12d6c9d8a7a617c398d392fc3c5b98eeb0320c2bb31df88e0a",
+      "public_source_role_projection_sha256": "48e39d93ab7e5f12d6c9d8a7a617c398d392fc3c5b98eeb0320c2bb31df88e0a",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "section6_multiple_slots_top_n_algorithm": {
+      "accepted_source_role_contract_sha256": "88a4a7dd263a1a8e49ab722c79adfb5acebd6bccfbaccfb517058f5fea92f752",
+      "public_source_role_projection_sha256": "9fa321d19be54f2df21f8343f975b926d68e42412df91fbdb2ef2827a0fab7af",
+      "schema": 1,
+      "withheld_field_paths": [
+        "user_approved_scope_exclusion.approval_reference",
+        "user_approved_scope_exclusion.source_locator"
+      ]
+    },
+    "section6_next_highest_alive_keep_alive_reduction": {
+      "accepted_source_role_contract_sha256": "ff5a0e099e16c780ec0c807bad8030a1474e5e84b20ee9670ac2ec27355bdb21",
+      "public_source_role_projection_sha256": "ff5a0e099e16c780ec0c807bad8030a1474e5e84b20ee9670ac2ec27355bdb21",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "section6_next_highest_bid_alive_formula": {
+      "accepted_source_role_contract_sha256": "7943bb0a1038c9b9ca1ec777a62b2cf0d2afdf222d3ccb832d0d97bcd18dfc6a",
+      "public_source_role_projection_sha256": "7943bb0a1038c9b9ca1ec777a62b2cf0d2afdf222d3ccb832d0d97bcd18dfc6a",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "section6_next_highest_bid_alive_theorem8_finite_explicit_error": {
+      "accepted_source_role_contract_sha256": "855567808bbfb9b45e289865b9adba3a7a1c8347130c3f722dc042b01989b45f",
+      "public_source_role_projection_sha256": "11765222bfeb8372bc9f744d9e317e165a1318225dce87f804467cd6ef2e5792",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "section6_next_highest_bid_all_balance_algorithm": {
+      "accepted_source_role_contract_sha256": "ba7b071bb25f1da49c63d615625ddd4b620c0e0bc3bb72a047c00b26d6cb7c5b",
+      "public_source_role_projection_sha256": "ba7b071bb25f1da49c63d615625ddd4b620c0e0bc3bb72a047c00b26d6cb7c5b",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "section6_next_highest_bid_all_formula": {
+      "accepted_source_role_contract_sha256": "7943bb0a1038c9b9ca1ec777a62b2cf0d2afdf222d3ccb832d0d97bcd18dfc6a",
+      "public_source_role_projection_sha256": "7943bb0a1038c9b9ca1ec777a62b2cf0d2afdf222d3ccb832d0d97bcd18dfc6a",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "section6_next_highest_bid_all_theorem8_finite_explicit_error": {
+      "accepted_source_role_contract_sha256": "86501ff54430b76b2bab7a50b5064c383e22ed5bc4250ce94e622cfd1b1c5380",
+      "public_source_role_projection_sha256": "da3f7ffb588b48849995da93c5b7dcf763b3acdfa50ce9f2bedb9aeeabbc34d3",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "section6_page_top_balance_theorem8_finite_explicit_error": {
+      "accepted_source_role_contract_sha256": "7a3182ec705a0436b862e66f4440a3582c48667470d9afb31280b078eac25d6e",
+      "public_source_role_projection_sha256": "b273ab2f888cad31b10ed7418c269947948bf87060df6cb2f37ad0b111a91548",
+      "schema": 1,
+      "withheld_field_paths": [
+        "user_approved_scope_exclusion.approval_reference",
+        "user_approved_scope_exclusion.source_locator"
+      ]
+    },
+    "section6_weighted_alpha_beta_inequality": {
+      "accepted_source_role_contract_sha256": "7943bb0a1038c9b9ca1ec777a62b2cf0d2afdf222d3ccb832d0d97bcd18dfc6a",
+      "public_source_role_projection_sha256": "7943bb0a1038c9b9ca1ec777a62b2cf0d2afdf222d3ccb832d0d97bcd18dfc6a",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "section8_common_generalization_heuristic": {
+      "accepted_source_role_contract_sha256": "cf07264f18c43b11ec6176ce4e6b18d8afcd387de930d07c3b3d6be144276c50",
+      "public_source_role_projection_sha256": "cf07264f18c43b11ec6176ce4e6b18d8afcd387de930d07c3b3d6be144276c50",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "section8_gaming_resilience_heuristic": {
+      "accepted_source_role_contract_sha256": "cf07264f18c43b11ec6176ce4e6b18d8afcd387de930d07c3b3d6be144276c50",
+      "public_source_role_projection_sha256": "cf07264f18c43b11ec6176ce4e6b18d8afcd387de930d07c3b3d6be144276c50",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "section8_offline_distribution_complexity_context": {
+      "accepted_source_role_contract_sha256": "cf07264f18c43b11ec6176ce4e6b18d8afcd387de930d07c3b3d6be144276c50",
+      "public_source_role_projection_sha256": "cf07264f18c43b11ec6176ce4e6b18d8afcd387de930d07c3b3d6be144276c50",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "section8_online_weight_adjustment_heuristic": {
+      "accepted_source_role_contract_sha256": "48e39d93ab7e5f12d6c9d8a7a617c398d392fc3c5b98eeb0320c2bb31df88e0a",
+      "public_source_role_projection_sha256": "48e39d93ab7e5f12d6c9d8a7a617c398d392fc3c5b98eeb0320c2bb31df88e0a",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "section8_ranking_refusal_historical_correction": {
+      "accepted_source_role_contract_sha256": "cf07264f18c43b11ec6176ce4e6b18d8afcd387de930d07c3b3d6be144276c50",
+      "public_source_role_projection_sha256": "cf07264f18c43b11ec6176ce4e6b18d8afcd387de930d07c3b3d6be144276c50",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "section8_replicated_ranking_algorithm_proposal": {
+      "accepted_source_role_contract_sha256": "48e39d93ab7e5f12d6c9d8a7a617c398d392fc3c5b98eeb0320c2bb31df88e0a",
+      "public_source_role_projection_sha256": "48e39d93ab7e5f12d6c9d8a7a617c398d392fc3c5b98eeb0320c2bb31df88e0a",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "section8_replicated_ranking_balance_simulation_heuristic": {
+      "accepted_source_role_contract_sha256": "cf07264f18c43b11ec6176ce4e6b18d8afcd387de930d07c3b3d6be144276c50",
+      "public_source_role_projection_sha256": "cf07264f18c43b11ec6176ce4e6b18d8afcd387de930d07c3b3d6be144276c50",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "section8_switching_distribution_performance_goal": {
+      "accepted_source_role_contract_sha256": "cf07264f18c43b11ec6176ce4e6b18d8afcd387de930d07c3b3d6be144276c50",
+      "public_source_role_projection_sha256": "cf07264f18c43b11ec6176ce4e6b18d8afcd387de930d07c3b3d6be144276c50",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "section8_switching_query_distribution_model": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "section8_tradeoff_method_scope_open_question": {
+      "accepted_source_role_contract_sha256": "cf07264f18c43b11ec6176ce4e6b18d8afcd387de930d07c3b3d6be144276c50",
+      "public_source_role_projection_sha256": "cf07264f18c43b11ec6176ce4e6b18d8afcd387de930d07c3b3d6be144276c50",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "section8_weighted_bid_algorithm_proposal": {
+      "accepted_source_role_contract_sha256": "b207e4e270b0239a3dc4b4c1c35be080aef683a0cad20af74b2a8d269a076756",
+      "public_source_role_projection_sha256": "b207e4e270b0239a3dc4b4c1c35be080aef683a0cad20af74b2a8d269a076756",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "section8_weighted_bid_open_question": {
+      "accepted_source_role_contract_sha256": "cf07264f18c43b11ec6176ce4e6b18d8afcd387de930d07c3b3d6be144276c50",
+      "public_source_role_projection_sha256": "cf07264f18c43b11ec6176ce4e6b18d8afcd387de930d07c3b3d6be144276c50",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "section8_weighted_effective_bid_formula": {
+      "accepted_source_role_contract_sha256": "7943bb0a1038c9b9ca1ec777a62b2cf0d2afdf222d3ccb832d0d97bcd18dfc6a",
+      "public_source_role_projection_sha256": "7943bb0a1038c9b9ca1ec777a62b2cf0d2afdf222d3ccb832d0d97bcd18dfc6a",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem8_balance_msvv_competitive_of_small_bids_limit_family": {
+      "accepted_source_role_contract_sha256": "37f6aafd50b3faa8b1a91117490fa1b1322f9aed25e1dd3704431d2bd3fe1e50",
+      "public_source_role_projection_sha256": "4132cb2b44011006e85b1817a08cc3cdfa050e1b43a251b5be82e20165adda29",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "theorem8_corrected_unspent_fraction_formula": {
+      "accepted_source_role_contract_sha256": "dfcc6b216a0d49afd3abeeeaf73c47142fa1445f358257a19b2e740044965a50",
+      "public_source_role_projection_sha256": "dfcc6b216a0d49afd3abeeeaf73c47142fa1445f358257a19b2e740044965a50",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem8_delta_dual_suffix_identity": {
+      "accepted_source_role_contract_sha256": "7943bb0a1038c9b9ca1ec777a62b2cf0d2afdf222d3ccb832d0d97bcd18dfc6a",
+      "public_source_role_projection_sha256": "7943bb0a1038c9b9ca1ec777a62b2cf0d2afdf222d3ccb832d0d97bcd18dfc6a",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem8_dual_induced_tradeoff_formula": {
+      "accepted_source_role_contract_sha256": "c33b37dd6cbaa24ff7df6b333e0cf92c2baff071704409627d0297aae68b09d1",
+      "public_source_role_projection_sha256": "4a96513c7fa86db7e4893edf707beb3f0d9796612d1ef1685f3c272ed03e9597",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "theorem8_simple_proof_beta_recurrence_formula": {
+      "accepted_source_role_contract_sha256": "7943bb0a1038c9b9ca1ec777a62b2cf0d2afdf222d3ccb832d0d97bcd18dfc6a",
+      "public_source_role_projection_sha256": "7943bb0a1038c9b9ca1ec777a62b2cf0d2afdf222d3ccb832d0d97bcd18dfc6a",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem8_simple_proof_weighted_alpha_beta_inequality": {
+      "accepted_source_role_contract_sha256": "7943bb0a1038c9b9ca1ec777a62b2cf0d2afdf222d3ccb832d0d97bcd18dfc6a",
+      "public_source_role_projection_sha256": "7943bb0a1038c9b9ca1ec777a62b2cf0d2afdf222d3ccb832d0d97bcd18dfc6a",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem8_unspent_budget_bound_formula": {
+      "accepted_source_role_contract_sha256": "ff5a0e099e16c780ec0c807bad8030a1474e5e84b20ee9670ac2ec27355bdb21",
+      "public_source_role_projection_sha256": "ff5a0e099e16c780ec0c807bad8030a1474e5e84b20ee9670ac2ec27355bdb21",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem9CappedNormalizedRevenue_formula": {
+      "accepted_source_role_contract_sha256": "43d420f61a87d798aebfeb613860e35f6c725e6a081b344097202a7d2f16e787",
+      "public_source_role_projection_sha256": "43d420f61a87d798aebfeb613860e35f6c725e6a081b344097202a7d2f16e787",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem9HardDistribution_uniform": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem9_base_instance_balance_revenue_claim": {
+      "accepted_source_role_contract_sha256": "ff5a0e099e16c780ec0c807bad8030a1474e5e84b20ee9670ac2ec27355bdb21",
+      "public_source_role_projection_sha256": "ff5a0e099e16c780ec0c807bad8030a1474e5e84b20ee9670ac2ec27355bdb21",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem9_expected_round_allocation_bound": {
+      "accepted_source_role_contract_sha256": "7943bb0a1038c9b9ca1ec777a62b2cf0d2afdf222d3ccb832d0d97bcd18dfc6a",
+      "public_source_role_projection_sha256": "7943bb0a1038c9b9ca1ec777a62b2cf0d2afdf222d3ccb832d0d97bcd18dfc6a",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem9_hard_instance_round_bids_and_optimum": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem9_harmonic_spend_and_revenue_bound": {
+      "accepted_source_role_contract_sha256": "7943bb0a1038c9b9ca1ec777a62b2cf0d2afdf222d3ccb832d0d97bcd18dfc6a",
+      "public_source_role_projection_sha256": "7943bb0a1038c9b9ca1ec777a62b2cf0d2afdf222d3ccb832d0d97bcd18dfc6a",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem9_no_randomized_online_algorithm_beats_msvv_ratio": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    }
+  },
+  "paper": "MSVV07AdWords",
+  "private_role_material_included": false,
+  "private_source_map_material_sha256": "a9b61b989da11deb410c9d878d10cc582041bd66d0b3c6509ba25fc0b48dabb0",
+  "private_source_map_sha256": "a3f41b7d9bf3c4f54fe6c7fd98563323b94d87c05b1455d10895cd996463282a",
+  "projection_contract_sha256": "ed0964edc9c70f5ce087ce9bf134712ca40c7964ecaefd403309ac9a1b47d34d",
+  "public_display_manifest_material_sha256": "3066d380d59bd5017eb650f897d7c522edb96f093164bd3c5ef9e1f1645e761e",
+  "public_display_manifest_sha256": "473e2cae972d43bfe37a8989bc96d911be2b453d83f7b72d304584b731ee0fc0",
+  "public_source_map_material_sha256": "cef788b764433e91c5e504d80c1b2e0552aeea25f147c94947ae4fb61fb1a3e8",
+  "public_source_map_sha256": "f5c5d40128a7c88520c59a9b0a7a54f6aa0bdc970f8ddd1bfa9534efa429c015",
+  "raw_private_approval_material_included": false,
+  "schema": 1
+}

--- a/papers/MendelsonWhang1990PriorityPricing/audit/paper_statement_map.json
+++ b/papers/MendelsonWhang1990PriorityPricing/audit/paper_statement_map.json
@@ -913,6 +913,11 @@
     "approval_material_included": false,
     "schema": 1
   },
+  "publication_source_display_projection": {
+    "manifest": "audit/public_source_display_projection.json",
+    "raw_source_bytes_included": false,
+    "schema": 1
+  },
   "schema": 1,
   "seed_scaffold": false,
   "semantic_contract_schema": 1,

--- a/papers/MendelsonWhang1990PriorityPricing/audit/public_source_display_projection.json
+++ b/papers/MendelsonWhang1990PriorityPricing/audit/public_source_display_projection.json
@@ -1,9 +1,9 @@
 {
   "generator": "python3 scripts/public_source_display_projection.py",
   "paper_id": "MendelsonWhang1990PriorityPricing",
-  "private_source_map_sha256": "1967991c6cd010d970e355809366300b05409a2557592116c4213f254371506d",
+  "private_source_map_sha256": "b10bc9e637acf8319d84bdc2b21853101df10ff69595568f1fe56749db2dfe06",
   "public_manifest_path": "papers/MendelsonWhang1990PriorityPricing/audit/public_source_display_projection.json",
-  "public_source_map_sha256": "5cd393d3fd632f0514e027d1b4e9d2c76b95d21576ba6cb68a70481b31cd7ced",
+  "public_source_map_sha256": "b85b8de803c6240d1aa8b82888307375c014a921748e7f5c5d332fbdc665f650",
   "raw_source_artifact_included": false,
   "raw_source_display_material": "selected_byte_pinned_source_anchor_quotes",
   "schema": 1,
@@ -202,7 +202,35 @@
       "source_kind": "definition"
     },
     "ptd_optimality_and_incentive_compatibility_definition": {
+      "semantic_context": [
+        {
+          "semantic_role": "model",
+          "source_anchors": [
+            {
+              "line_end": 666,
+              "line_start": 660,
+              "publication_locator": "cited publication",
+              "quoted_text": "                                                              Consider a system with R job classes that satisfy\nclass-i jobs. As before, all aggregate class characteristics\n                                                            assumptions A1-A5 of Section 1, where class-i jobs\nare common knowledge, whereas individual job char-\n                                                            have exponential processing requirements with mean\nacteristics are known only to the user. Thus, both the\n                                                           ci. We assume that",
+              "quoted_text_sha256": "993883d717a1a4cfdd0622c48cc1f520b4300b83efb7f3f295bc15f36288c2ff"
+            }
+          ]
+        }
+      ],
       "source_anchors": [
+        {
+          "line_end": 362,
+          "line_start": 326,
+          "publication_locator": "cited publication",
+          "quoted_text": "Hence                                                                  becomes\n\n                                                                                   r     R   R\n            a\n                                                                        maxf j Vi(Xi) - viLi(, r)t.\n    P~E\n     d oi 3ax,\n                                                                       If X * and r* are the optimal arrival-rate vector and\n      + vi *[Wi(X*)+x* Wi(X*)]-viWi(X*)                                scheduling permutation, respectively, then by the opti-\n                                                                       mality of the c-, rule for fixed X = X * we have\n           R a~~~i x\n      R                                                                             R            R\n\n   - JX,*- W (X*)                                                       max{ Vi(Xi) - viLi(X,(r)\n      j=1 J axj\n\nsince for] i d                                                                   R           R\n\n\n                                                                          = E Vi(Xi) -E viLi(2*, r*)\n                                                                               i=l       i=l\n\n\n1a-\n Ax.Li (2X) a - xa\n          axi    iW xi\n                    = -i a 'J/(X).                                               R           R\n\n\n                                                                           X Vi(X*) - E viLi(X, rO)\n  Note that when R = 1, (6) reduces to (3). Also, as\nin (3), the right-hand side of (6) represents the expected                                   R   R\n\ncost inflicted on all other users as a consequence of                      < max Vi(xi) - viLi(X, rO)}\nan infinitesimal unit increase in the job flow of a class-\ni user. Thus, similar to (3), we may call the right-hand               which demonstrates that the same scheduling rate is\nside of (6) the externality cost. The result of Theorem                also optimal in the current setting.",
+          "quoted_text_sha256": "b64b9e832e3a72a15dd6f496e703d5dedb7daefa350fc4932de19e531d58329e"
+        },
+        {
+          "line_end": 666,
+          "line_start": 660,
+          "publication_locator": "cited publication",
+          "quoted_text": "                                                              Consider a system with R job classes that satisfy\nclass-i jobs. As before, all aggregate class characteristics\n                                                            assumptions A1-A5 of Section 1, where class-i jobs\nare common knowledge, whereas individual job char-\n                                                            have exponential processing requirements with mean\nacteristics are known only to the user. Thus, both the\n                                                           ci. We assume that",
+          "quoted_text_sha256": "993883d717a1a4cfdd0622c48cc1f520b4300b83efb7f3f295bc15f36288c2ff"
+        },
         {
           "line_end": 731,
           "line_start": 692,
@@ -260,6 +288,30 @@
               "publication_locator": "cited publication",
               "quoted_text": "  Under this general framework, an equilibrium can                     geneous service requirements. The answer is negative,\nbe defined in a similar way to (12) and (13). Let WJi                  as the following example demonstrates. Consider the\ndenote the expected total waiting time in the system                   case of two job classes (R = 2) and let p(t) = (pI (t),\nfor a class-i job picking priority-class j. Then, ( X (p),            P2(t)) be given by (16). Ifp(t) is optimal and incentive-\nf(p)) is an equilibrium with respect to the PTD pricing compatible, optimality implies that for a class-i job,\nscheme p(t) if for each i = 1, 2, . . ., R              we just have E[pi(ri)] = p*, where p* are given by\n                                                                       Theorem 1. Also from (16)\nE[pr,(p)(ri)] + viWri,(p)(2(p), r(p))\n\n   = min E[pj(ri)] + viWj(X(p), r(p))}                                 E[p2(T )] =- E[pl(Tri)] =- P\n                                                                                             a   a\n\n\nand                                                                          and                          (17)\n\nVi'(Xi(p)) = E[prj(p)(Ti)] + Vi Wr,(p)(X (p), r(p))\n                                                                       E[pl(T2)] = a * E[p2(T2)] = a *2\nwhere Ti is the actual processing requirement of a\n                                                                      where a = K1/K2.\nclass-i job.\n                                                                         In order for the pricing schedule p(t) to be incentive-\n  A PTD pricing scheme p0(t) will be called optimal\n                                                                       compatible, it should satisfy\nand incentive-compatible if it satisfies the following\nconditions:\n                                                                       E[pI(TI)] + v* W < S E[p2(rl)] + V1 WY\n   1. Incentive-compatibility: For all i = 1, 2, . .. , R\n                                                                       and\n   ri(p?)                   =        i      (14)\n                                                                       E[pi(T2)] + v2 * Wl q E[p2(T2)] + V2 WY-\n      2.       Optimality:                                       The                 resulting                         arrival\n                                                                       Hence using (17), incentive-compatibility implies\n  the expected                                          net                value                 of        the            system\nis, for all i= 1, 2, .. ., R\n                                                                       pi +V* 1 S-*p* + VI * W\n  X(pO)                =     _X*                (15)                                         a\n\n\n\nwhere X * achieves the overall optimum.                                      and                          (18)",
               "quoted_text_sha256": "0c50f43265ad3a7580c1b84755d8e82dd80cffa10c6140bb1ee6592c437baf71"
+            }
+          ]
+        },
+        {
+          "semantic_role": "prior_result",
+          "source_anchors": [
+            {
+              "line_end": 362,
+              "line_start": 326,
+              "publication_locator": "cited publication",
+              "quoted_text": "Hence                                                                  becomes\n\n                                                                                   r     R   R\n            a\n                                                                        maxf j Vi(Xi) - viLi(, r)t.\n    P~E\n     d oi 3ax,\n                                                                       If X * and r* are the optimal arrival-rate vector and\n      + vi *[Wi(X*)+x* Wi(X*)]-viWi(X*)                                scheduling permutation, respectively, then by the opti-\n                                                                       mality of the c-, rule for fixed X = X * we have\n           R a~~~i x\n      R                                                                             R            R\n\n   - JX,*- W (X*)                                                       max{ Vi(Xi) - viLi(X,(r)\n      j=1 J axj\n\nsince for] i d                                                                   R           R\n\n\n                                                                          = E Vi(Xi) -E viLi(2*, r*)\n                                                                               i=l       i=l\n\n\n1a-\n Ax.Li (2X) a - xa\n          axi    iW xi\n                    = -i a 'J/(X).                                               R           R\n\n\n                                                                           X Vi(X*) - E viLi(X, rO)\n  Note that when R = 1, (6) reduces to (3). Also, as\nin (3), the right-hand side of (6) represents the expected                                   R   R\n\ncost inflicted on all other users as a consequence of                      < max Vi(xi) - viLi(X, rO)}\nan infinitesimal unit increase in the job flow of a class-\ni user. Thus, similar to (3), we may call the right-hand               which demonstrates that the same scheduling rate is\nside of (6) the externality cost. The result of Theorem                also optimal in the current setting.",
+              "quoted_text_sha256": "b64b9e832e3a72a15dd6f496e703d5dedb7daefa350fc4932de19e531d58329e"
+            }
+          ]
+        },
+        {
+          "semantic_role": "model",
+          "source_anchors": [
+            {
+              "line_end": 666,
+              "line_start": 660,
+              "publication_locator": "cited publication",
+              "quoted_text": "                                                              Consider a system with R job classes that satisfy\nclass-i jobs. As before, all aggregate class characteristics\n                                                            assumptions A1-A5 of Section 1, where class-i jobs\nare common knowledge, whereas individual job char-\n                                                            have exponential processing requirements with mean\nacteristics are known only to the user. Thus, both the\n                                                           ci. We assume that",
+              "quoted_text_sha256": "993883d717a1a4cfdd0622c48cc1f520b4300b83efb7f3f295bc15f36288c2ff"
             }
           ]
         }

--- a/papers/MendelsonWhang1990PriorityPricing/audit/public_source_role_projection.json
+++ b/papers/MendelsonWhang1990PriorityPricing/audit/public_source_role_projection.json
@@ -1,0 +1,131 @@
+{
+  "acceptance_credential": false,
+  "accepted_graph_sha256": "e9dc6e77e8632d46b8a246b832524956557a0713ba87534b9d96cb5d0fd841a7",
+  "bindings_by_source_item": {
+    "appendix_priority_queueing_time": {
+      "accepted_source_role_contract_sha256": "ff5a0e099e16c780ec0c807bad8030a1474e5e84b20ee9670ac2ec27355bdb21",
+      "public_source_role_projection_sha256": "ff5a0e099e16c780ec0c807bad8030a1474e5e84b20ee9670ac2ec27355bdb21",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "arrival_process_condition": {
+      "accepted_source_role_contract_sha256": "833843175a57efcc42628b0a84e8c38255ed09660fd387cb299770e41e9ed782",
+      "public_source_role_projection_sha256": "833843175a57efcc42628b0a84e8c38255ed09660fd387cb299770e41e9ed782",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "cheating_penalty_definition": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "delay_cost_condition": {
+      "accepted_source_role_contract_sha256": "833843175a57efcc42628b0a84e8c38255ed09660fd387cb299770e41e9ed782",
+      "public_source_role_projection_sha256": "833843175a57efcc42628b0a84e8c38255ed09660fd387cb299770e41e9ed782",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "homogeneous_price_formula": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "homogeneous_queue_formulas": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "individual_decision_condition": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "net_value_objective": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "priority_queueing_time_formula": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "priority_time_dependent_price_formula": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "ptd_optimality_and_incentive_compatibility_definition": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "service_process_condition": {
+      "accepted_source_role_contract_sha256": "833843175a57efcc42628b0a84e8c38255ed09660fd387cb299770e41e9ed782",
+      "public_source_role_projection_sha256": "833843175a57efcc42628b0a84e8c38255ed09660fd387cb299770e41e9ed782",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem_1": {
+      "accepted_source_role_contract_sha256": "134c72d24878dcabd1db1bd46e19dc2ad578a7396db953beefa8facf45524d8d",
+      "public_source_role_projection_sha256": "c82f816774232e76e5e9c18decb26a310736658f10669a4997e496f157ea6586",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "theorem_2": {
+      "accepted_source_role_contract_sha256": "33f423c544ca8892bc64e09a2ec657046694cbcf22d356eda2199a3dbbdeea44",
+      "public_source_role_projection_sha256": "c64bf620fad0c8a71b2443d96a1f431bd67473cc0d1ddd80d612f7f65094c4b1",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "theorem_3": {
+      "accepted_source_role_contract_sha256": "96614745f3d1b6683a166c8a4a1a16d2931a448223d57ba1fac011112cdcbe12",
+      "public_source_role_projection_sha256": "57915c463c091fbe1c29fc9bf202efc049c74712f4b1f1cb60cf18c6543571a6",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "theorem_4": {
+      "accepted_source_role_contract_sha256": "4f86ace77ae3dcabc714d3f48afc44fa550d75fd3a8f9d7c20ce0e5101f5070d",
+      "public_source_role_projection_sha256": "353004ee13ff973b89094017522f6485b11bf6821b32fca3dbf273a915712696",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "value_function_condition": {
+      "accepted_source_role_contract_sha256": "833843175a57efcc42628b0a84e8c38255ed09660fd387cb299770e41e9ed782",
+      "public_source_role_projection_sha256": "833843175a57efcc42628b0a84e8c38255ed09660fd387cb299770e41e9ed782",
+      "schema": 1,
+      "withheld_field_paths": []
+    }
+  },
+  "paper": "MendelsonWhang1990PriorityPricing",
+  "private_role_material_included": false,
+  "private_source_map_material_sha256": "3d33e052eb9455b40fa015dea909d80eb6fc012eb0d53adcfb13a20f0bd5eac6",
+  "private_source_map_sha256": "b10bc9e637acf8319d84bdc2b21853101df10ff69595568f1fe56749db2dfe06",
+  "projection_contract_sha256": "ed0964edc9c70f5ce087ce9bf134712ca40c7964ecaefd403309ac9a1b47d34d",
+  "public_display_manifest_material_sha256": "6fde54a06d0276c0b354ecab5a43bbe41e5b88c37825c034ec0fa33416588e7f",
+  "public_display_manifest_sha256": "9f387dbb51e5f30267f0b8bdd318a63d3b6f187dd3d4d72c6ea42c9c2bb3ed15",
+  "public_source_map_material_sha256": "ad504de4e9f69e22e00a5d87add1f6950329eddf6d4bb2e6fa7528935cf27f46",
+  "public_source_map_sha256": "b85b8de803c6240d1aa8b82888307375c014a921748e7f5c5d332fbdc665f650",
+  "raw_private_approval_material_included": false,
+  "schema": 1
+}

--- a/papers/Naor1969QueueTolls/audit/paper_statement_map.json
+++ b/papers/Naor1969QueueTolls/audit/paper_statement_map.json
@@ -668,6 +668,11 @@
   },
   "paper": "Naor1969QueueTolls",
   "paper_interface_namespace": "Naor1969QueueTolls",
+  "publication_source_display_projection": {
+    "manifest": "audit/public_source_display_projection.json",
+    "raw_source_bytes_included": false,
+    "schema": 1
+  },
   "schema": 1,
   "seed_scaffold": false,
   "semantic_contract_policy": {

--- a/papers/Naor1969QueueTolls/audit/public_source_role_projection.json
+++ b/papers/Naor1969QueueTolls/audit/public_source_role_projection.json
@@ -1,0 +1,83 @@
+{
+  "acceptance_credential": false,
+  "accepted_graph_sha256": "4f402768cf049355e602392a4fa06ce431d0aef2ed37cf40ea56b1859f1e4e2a",
+  "bindings_by_source_item": {
+    "finiteCapacityStationaryLaw": {
+      "accepted_source_role_contract_sha256": "ff5a0e099e16c780ec0c807bad8030a1474e5e84b20ee9670ac2ec27355bdb21",
+      "public_source_role_projection_sha256": "ff5a0e099e16c780ec0c807bad8030a1474e5e84b20ee9670ac2ec27355bdb21",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "revenueContinuousCrossing": {
+      "accepted_source_role_contract_sha256": "b5f4804192214264d69cde3f0680e8ffdbbff8a552d1c1351ffe3d859c5b31d6",
+      "public_source_role_projection_sha256": "b5f4804192214264d69cde3f0680e8ffdbbff8a552d1c1351ffe3d859c5b31d6",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "selfOptimizingThreshold": {
+      "accepted_source_role_contract_sha256": "ff5a0e099e16c780ec0c807bad8030a1474e5e84b20ee9670ac2ec27355bdb21",
+      "public_source_role_projection_sha256": "ff5a0e099e16c780ec0c807bad8030a1474e5e84b20ee9670ac2ec27355bdb21",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "socialAndRevenueThresholdOrder": {
+      "accepted_source_role_contract_sha256": "ff5a0e099e16c780ec0c807bad8030a1474e5e84b20ee9670ac2ec27355bdb21",
+      "public_source_role_projection_sha256": "ff5a0e099e16c780ec0c807bad8030a1474e5e84b20ee9670ac2ec27355bdb21",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "socialContinuousCrossing": {
+      "accepted_source_role_contract_sha256": "b5f4804192214264d69cde3f0680e8ffdbbff8a552d1c1351ffe3d859c5b31d6",
+      "public_source_role_projection_sha256": "b5f4804192214264d69cde3f0680e8ffdbbff8a552d1c1351ffe3d859c5b31d6",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "socialOptimalThreshold": {
+      "accepted_source_role_contract_sha256": "ff5a0e099e16c780ec0c807bad8030a1474e5e84b20ee9670ac2ec27355bdb21",
+      "public_source_role_projection_sha256": "ff5a0e099e16c780ec0c807bad8030a1474e5e84b20ee9670ac2ec27355bdb21",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "socialTollImplementsOptimalThreshold": {
+      "accepted_source_role_contract_sha256": "ff5a0e099e16c780ec0c807bad8030a1474e5e84b20ee9670ac2ec27355bdb21",
+      "public_source_role_projection_sha256": "ff5a0e099e16c780ec0c807bad8030a1474e5e84b20ee9670ac2ec27355bdb21",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_concluding_qualitative_generalizations": {
+      "accepted_source_role_contract_sha256": "29221fcaff4a9f5951c216ae67d395d55f5d4df1f6192d34d463906ccbf7b2b3",
+      "public_source_role_projection_sha256": "dcc6af3d5c1a9129cfb1347aa02fce758460f6f6bf383a3449bbe09cfcd2b3ef",
+      "schema": 1,
+      "withheld_field_paths": [
+        "user_approved_scope_exclusion.approval_reference",
+        "user_approved_scope_exclusion.source_locator"
+      ]
+    },
+    "source_social_crossing_numerical_generalizations": {
+      "accepted_source_role_contract_sha256": "6cd28a895594f265ca3aa6792834da1f4c089e4827919b06cd95eca770be7360",
+      "public_source_role_projection_sha256": "953ed3c877155903c802e71ac3f3e0b7c2cba65d1cfc0e2404af0768621755be",
+      "schema": 1,
+      "withheld_field_paths": [
+        "user_approved_scope_exclusion.approval_reference",
+        "user_approved_scope_exclusion.source_locator"
+      ]
+    },
+    "stationaryPerformance": {
+      "accepted_source_role_contract_sha256": "ff5a0e099e16c780ec0c807bad8030a1474e5e84b20ee9670ac2ec27355bdb21",
+      "public_source_role_projection_sha256": "ff5a0e099e16c780ec0c807bad8030a1474e5e84b20ee9670ac2ec27355bdb21",
+      "schema": 1,
+      "withheld_field_paths": []
+    }
+  },
+  "paper": "Naor1969QueueTolls",
+  "private_role_material_included": false,
+  "private_source_map_material_sha256": "84e7eb1bd49fefe472aeb52cdf1917e359059737a985fa15bcdc15e9597c4b6a",
+  "private_source_map_sha256": "a2472bcc7371b52090c3183ff1abc54f09647934acf0a4ab1aeae39a41017730",
+  "projection_contract_sha256": "ed0964edc9c70f5ce087ce9bf134712ca40c7964ecaefd403309ac9a1b47d34d",
+  "public_display_manifest_material_sha256": "11cc0f9986aca439fb68802ed44d5b9e905ce1672d9cc4bc2946fb5e725017d5",
+  "public_display_manifest_sha256": "3fb974c8ec7b8aca3418a4bd75f670002d434f8b126da2a711d04be7ac582fa6",
+  "public_source_map_material_sha256": "f4b8de3361f548d0dc81578d0ab7a5a536ae9c288ef4366a6f8ecd1381af29b3",
+  "public_source_map_sha256": "dbaa0331e335c0dc94c13e0d6a11a4763db5c22084f236b1d7dff244159879fa",
+  "raw_private_approval_material_included": false,
+  "schema": 1
+}

--- a/papers/NoothigattuEtAl2020PairwiseComparisons/audit/paper_statement_map.json
+++ b/papers/NoothigattuEtAl2020PairwiseComparisons/audit/paper_statement_map.json
@@ -825,6 +825,11 @@
     "NoothigattuEtAl2020PairwiseComparisons.definition5_1_pairwise_majority_consistencySpec": "definition5_1",
     "NoothigattuEtAl2020PairwiseComparisons.definition6_1_separabilitySpec": "definition6_1"
   },
+  "publication_source_display_projection": {
+    "manifest": "audit/public_source_display_projection.json",
+    "raw_source_bytes_included": false,
+    "schema": 1
+  },
   "schema": 1,
   "semantic_contract_schema": 1,
   "semantic_route_schema": 2,

--- a/papers/NoothigattuEtAl2020PairwiseComparisons/audit/public_source_role_projection.json
+++ b/papers/NoothigattuEtAl2020PairwiseComparisons/audit/public_source_role_projection.json
@@ -1,0 +1,101 @@
+{
+  "acceptance_credential": false,
+  "accepted_graph_sha256": "e36cc74a93c4956093e16303e306ca12051b3dfd439c35f2a3792235e5a3552a",
+  "bindings_by_source_item": {
+    "claimA_1": {
+      "accepted_source_role_contract_sha256": "ff5a0e099e16c780ec0c807bad8030a1474e5e84b20ee9670ac2ec27355bdb21",
+      "public_source_role_projection_sha256": "ff5a0e099e16c780ec0c807bad8030a1474e5e84b20ee9670ac2ec27355bdb21",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "claimC_1": {
+      "accepted_source_role_contract_sha256": "ff5a0e099e16c780ec0c807bad8030a1474e5e84b20ee9670ac2ec27355bdb21",
+      "public_source_role_projection_sha256": "ff5a0e099e16c780ec0c807bad8030a1474e5e84b20ee9670ac2ec27355bdb21",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition3_1": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition4_1": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition5_1": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition6_1": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lemma2_1": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lemma2_2": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lemma2_3": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lemma2_4": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem3_2": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem4_2": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem5_3": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem6_3": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    }
+  },
+  "paper": "NoothigattuEtAl2020PairwiseComparisons",
+  "private_role_material_included": false,
+  "private_source_map_material_sha256": "6d0ccecbe48bf78385a549dfeb1156fc31328614fc855c9edf4f8658f1fcbbe2",
+  "private_source_map_sha256": "e61a5977e09201b46b71e95aa32e8f1e953efdb304102595ac380fe34694e661",
+  "projection_contract_sha256": "ed0964edc9c70f5ce087ce9bf134712ca40c7964ecaefd403309ac9a1b47d34d",
+  "public_display_manifest_material_sha256": "eefa3c6452781297f1c7a85034e2e897ae55595b109ed7c63a6ef8332ae9b0fb",
+  "public_display_manifest_sha256": "fee6f0945ecf84545f60ce3fd2269665abbe0e78841d3f15bbcb46b4668ead72",
+  "public_source_map_material_sha256": "f35569ec5f52c59f01990a281ce805a8dd85a58140ea8e548975b90d6f7391c6",
+  "public_source_map_sha256": "591642ce96184762473ff7f815ee4b93504300d69a5215ce91c914485d31036f",
+  "raw_private_approval_material_included": false,
+  "schema": 1
+}

--- a/papers/PG23MonocultureMatching/audit/paper_statement_map.json
+++ b/papers/PG23MonocultureMatching/audit/paper_statement_map.json
@@ -1412,6 +1412,11 @@
     "approval_material_included": false,
     "schema": 1
   },
+  "publication_source_display_projection": {
+    "manifest": "audit/public_source_display_projection.json",
+    "raw_source_bytes_included": false,
+    "schema": 1
+  },
   "schema": 1,
   "semantic_contract_schema": 1,
   "semantic_route_schema": 2,

--- a/papers/PG23MonocultureMatching/audit/public_source_role_projection.json
+++ b/papers/PG23MonocultureMatching/audit/public_source_role_projection.json
@@ -1,0 +1,212 @@
+{
+  "acceptance_credential": false,
+  "accepted_graph_sha256": "5991735710ceb751e4ff88f098649723a876989e1a24d2ee8e13c91527968a6f",
+  "bindings_by_source_item": {
+    "cited_al16_continuum_domain": {
+      "accepted_source_role_contract_sha256": "833843175a57efcc42628b0a84e8c38255ed09660fd387cb299770e41e9ed782",
+      "public_source_role_projection_sha256": "833843175a57efcc42628b0a84e8c38255ed09660fd387cb299770e41e9ed782",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "concrete_type_laws_and_market": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition_application_strategy": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition_connected_support": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition_cutoff_demand_market": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition_differential_access_model": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition_matched_firm_rank": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition_maximum_concentrating": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition_maximum_order_statistic": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition_monoculture_differential_type_law": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition_monoculture_type_law": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition_polyculture_differential_type_law": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition_polyculture_type_law": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition_raw_cutoff_order": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition_value_threshold": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lemma_potato": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "proposition_lattice": {
+      "accepted_source_role_contract_sha256": "64a83a0ae6edbdb2d3cfb6cb84e3bf045734ef9303f62643ff780eff69b02885",
+      "public_source_role_projection_sha256": "64a83a0ae6edbdb2d3cfb6cb84e3bf045734ef9303f62643ff780eff69b02885",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "review_corollary4_monocultureCutoff_lt_polycultureCutoff": {
+      "accepted_source_role_contract_sha256": "ea783786a4d9ba017babab049dfd25c0f1bc9267237107de9c81815a69301498",
+      "public_source_role_projection_sha256": "ba0b9190713f8d610e7588870f9367ce4b64171b777e4d0c8a5fae35c170fd2d",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "review_lemma1_supplyDemand": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "review_lemma2_equalCutoffs": {
+      "accepted_source_role_contract_sha256": "879b3caa6ffaa281e667772fa5152bd4fc5b86b4e3261c93ee8b80fd04582734",
+      "public_source_role_projection_sha256": "b641f1ac6e65058ac14f794c87480484dea65ca006efcaf30b11a31ecf30c479",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "review_lemma_equalCutoffs_differentialAccess": {
+      "accepted_source_role_contract_sha256": "351e777c655d7b7483ad3a2582b5a472f4a4b22e5f46a1aae021d9767afc5321",
+      "public_source_role_projection_sha256": "9c77a5bb719940d57a969ff65bc11b33b7e2f2b0d22c15fb62b5646297e3c770",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "review_proposition_cdfIncreasing_connectedSupport": {
+      "accepted_source_role_contract_sha256": "64a83a0ae6edbdb2d3cfb6cb84e3bf045734ef9303f62643ff780eff69b02885",
+      "public_source_role_projection_sha256": "64a83a0ae6edbdb2d3cfb6cb84e3bf045734ef9303f62643ff780eff69b02885",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "review_proposition_nash_differentialApplicationAccess": {
+      "accepted_source_role_contract_sha256": "718c26624e1ae1f296f5d90bae655012c9ab76820b6820d85465eb5164851530",
+      "public_source_role_projection_sha256": "4091e8357bc48285c7c8c9ed0055dcdf90f6b97bb509649186265f9305c4b47d",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "review_proposition_nonzeroMeasure_openInterval": {
+      "accepted_source_role_contract_sha256": "bb49f64c8ebceb73b01a5cbb416aac981c1f94161a800293cbe49a31d196e29d",
+      "public_source_role_projection_sha256": "dac15ac48ee8698200f8c7d678bf528516c610c49c666e05d369cd2a31b6fee3",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "review_proposition_probabilityFormula": {
+      "accepted_source_role_contract_sha256": "ca6efc0480d69f56d819dc83c1e00a558b987560e5166929fbd2872f753d42d0",
+      "public_source_role_projection_sha256": "6220efc3d86eb275889d4c1b9985ee19f56001d1ea3987ac18a328e1cda7eb40",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "review_theorem1_wisdom": {
+      "accepted_source_role_contract_sha256": "bffbe4f8ee134fa22a3a863fa08714b31ff6f900ac119f3efa98c281869446bf",
+      "public_source_role_projection_sha256": "1fb825bf77c67d4110e8398a03193d5bf38bfec7ec40fd678035df1c58e978d4",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "review_theorem2_topChoice": {
+      "accepted_source_role_contract_sha256": "b40d253dd460e8941f810e281e4cc027f3697335b1257e064e53f68875f69f34",
+      "public_source_role_projection_sha256": "04ec82c31e0b1e771c33bc6cf657059cee30432e93042b46c6f92cd6e29cf975",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "review_theorem3_differentialApplicationAccess": {
+      "accepted_source_role_contract_sha256": "aa12e4c39651f0dad99feeaa376c5b9eb229cf662f1647b17ea1914f868e9989",
+      "public_source_role_projection_sha256": "daf93d608e78a35a235ab810eec692822b9052c5863d2296ee25702518b583b3",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    }
+  },
+  "paper": "PG23MonocultureMatching",
+  "private_role_material_included": false,
+  "private_source_map_material_sha256": "5ae9ddcf1b45308f2714fbe744533b2fc95a936ad7014f51acace9d6fa45c208",
+  "private_source_map_sha256": "af79b3a157ed16933a44eea82fa9e6e941014e47bbeb0fd03b424198ef0405a6",
+  "projection_contract_sha256": "ed0964edc9c70f5ce087ce9bf134712ca40c7964ecaefd403309ac9a1b47d34d",
+  "public_display_manifest_material_sha256": "1fea98c261648a600353dcd0d5339f0416dd77118b85a1a4d708fe612ac3967d",
+  "public_display_manifest_sha256": "0e8fa8204346cc5295d5ba8e4309dbad01185294aba8d9a87d86f5428fdf9ed9",
+  "public_source_map_material_sha256": "1d09f533289de6514343f0612904caa3cb6c5bafa99b932021f90dd8b80bf08e",
+  "public_source_map_sha256": "abe5b4eac10e85cb022610fc6c88bb2e747067f0814fe39dc3736fc32de7b3b9",
+  "raw_private_approval_material_included": false,
+  "schema": 1
+}

--- a/papers/PG24NoisyMatchingMarkets/audit/paper_statement_map.json
+++ b/papers/PG24NoisyMatchingMarkets/audit/paper_statement_map.json
@@ -1462,6 +1462,11 @@
     "PG24NoisyMatchingMarkets.PG24LiteralBasicMarket": "basic_economy_model",
     "PG24NoisyMatchingMarkets.PG24TrueValueSourceStableData": "extended_coalition_model"
   },
+  "publication_source_display_projection": {
+    "manifest": "audit/public_source_display_projection.json",
+    "raw_source_bytes_included": false,
+    "schema": 1
+  },
   "schema": 1,
   "semantic_contract_schema": 1,
   "semantic_route_schema": 2,

--- a/papers/PG24NoisyMatchingMarkets/audit/public_source_role_projection.json
+++ b/papers/PG24NoisyMatchingMarkets/audit/public_source_role_projection.json
@@ -1,0 +1,179 @@
+{
+  "acceptance_credential": false,
+  "accepted_graph_sha256": "1f58b5ff9ab429b141c029e6e47d40db1e7ad60aa3eab99df28ba18bd9d5349f",
+  "bindings_by_source_item": {
+    "basic_economy_model": {
+      "accepted_source_role_contract_sha256": "cb4c52d7162057fe79d176483b8606eae69ef415544ac40e16cd2b0dd1287867",
+      "public_source_role_projection_sha256": "cb4c52d7162057fe79d176483b8606eae69ef415544ac40e16cd2b0dd1287867",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "beta_max_concentrating": {
+      "accepted_source_role_contract_sha256": "4a5d5e0481f12028d09716bdc408f7660f44a95750daceeff5b45886ab5c7091",
+      "public_source_role_projection_sha256": "4a5d5e0481f12028d09716bdc408f7660f44a95750daceeff5b45886ab5c7091",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "capacity_regularity": {
+      "accepted_source_role_contract_sha256": "4a5d5e0481f12028d09716bdc408f7660f44a95750daceeff5b45886ab5c7091",
+      "public_source_role_projection_sha256": "4a5d5e0481f12028d09716bdc408f7660f44a95750daceeff5b45886ab5c7091",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "extended_coalition_model": {
+      "accepted_source_role_contract_sha256": "cb4c52d7162057fe79d176483b8606eae69ef415544ac40e16cd2b0dd1287867",
+      "public_source_role_projection_sha256": "cb4c52d7162057fe79d176483b8606eae69ef415544ac40e16cd2b0dd1287867",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "holder_value_law_regularity": {
+      "accepted_source_role_contract_sha256": "4a5d5e0481f12028d09716bdc408f7660f44a95750daceeff5b45886ab5c7091",
+      "public_source_role_projection_sha256": "4a5d5e0481f12028d09716bdc408f7660f44a95750daceeff5b45886ab5c7091",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "long_tailed_noise": {
+      "accepted_source_role_contract_sha256": "4a5d5e0481f12028d09716bdc408f7660f44a95750daceeff5b45886ab5c7091",
+      "public_source_role_projection_sha256": "4a5d5e0481f12028d09716bdc408f7660f44a95750daceeff5b45886ab5c7091",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "match_probability_formula": {
+      "accepted_source_role_contract_sha256": "4a5d5e0481f12028d09716bdc408f7660f44a95750daceeff5b45886ab5c7091",
+      "public_source_role_projection_sha256": "4a5d5e0481f12028d09716bdc408f7660f44a95750daceeff5b45886ab5c7091",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_apple": {
+      "accepted_source_role_contract_sha256": "65381e43976cd7fe80230dae6fa478acaabc00c26ea7674d54016908b8e336d1",
+      "public_source_role_projection_sha256": "65381e43976cd7fe80230dae6fa478acaabc00c26ea7674d54016908b8e336d1",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_beet": {
+      "accepted_source_role_contract_sha256": "1bdc7791f6342e90697936ca86ef9e1c3a9ff041eb83cb8e2027bb370ff01c08",
+      "public_source_role_projection_sha256": "1bdc7791f6342e90697936ca86ef9e1c3a9ff041eb83cb8e2027bb370ff01c08",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_duck_1": {
+      "accepted_source_role_contract_sha256": "c6a8a4310190c6b271ae06641d71faf430a0d957640598b24f33b81237e09058",
+      "public_source_role_projection_sha256": "c6a8a4310190c6b271ae06641d71faf430a0d957640598b24f33b81237e09058",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_duck_2": {
+      "accepted_source_role_contract_sha256": "c6a8a4310190c6b271ae06641d71faf430a0d957640598b24f33b81237e09058",
+      "public_source_role_projection_sha256": "c6a8a4310190c6b271ae06641d71faf430a0d957640598b24f33b81237e09058",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_goose_1": {
+      "accepted_source_role_contract_sha256": "c6a8a4310190c6b271ae06641d71faf430a0d957640598b24f33b81237e09058",
+      "public_source_role_projection_sha256": "c6a8a4310190c6b271ae06641d71faf430a0d957640598b24f33b81237e09058",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_goose_2": {
+      "accepted_source_role_contract_sha256": "1bdc7791f6342e90697936ca86ef9e1c3a9ff041eb83cb8e2027bb370ff01c08",
+      "public_source_role_projection_sha256": "1bdc7791f6342e90697936ca86ef9e1c3a9ff041eb83cb8e2027bb370ff01c08",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_large_firm_tail_bound": {
+      "accepted_source_role_contract_sha256": "65381e43976cd7fe80230dae6fa478acaabc00c26ea7674d54016908b8e336d1",
+      "public_source_role_projection_sha256": "65381e43976cd7fe80230dae6fa478acaabc00c26ea7674d54016908b8e336d1",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_log_bound": {
+      "accepted_source_role_contract_sha256": "65381e43976cd7fe80230dae6fa478acaabc00c26ea7674d54016908b8e336d1",
+      "public_source_role_projection_sha256": "65381e43976cd7fe80230dae6fa478acaabc00c26ea7674d54016908b8e336d1",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_lt_approx_f2": {
+      "accepted_source_role_contract_sha256": "c6a8a4310190c6b271ae06641d71faf430a0d957640598b24f33b81237e09058",
+      "public_source_role_projection_sha256": "c6a8a4310190c6b271ae06641d71faf430a0d957640598b24f33b81237e09058",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_lt_large_firms": {
+      "accepted_source_role_contract_sha256": "c6a8a4310190c6b271ae06641d71faf430a0d957640598b24f33b81237e09058",
+      "public_source_role_projection_sha256": "c6a8a4310190c6b271ae06641d71faf430a0d957640598b24f33b81237e09058",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_lt_small_firms": {
+      "accepted_source_role_contract_sha256": "c6a8a4310190c6b271ae06641d71faf430a0d957640598b24f33b81237e09058",
+      "public_source_role_projection_sha256": "c6a8a4310190c6b271ae06641d71faf430a0d957640598b24f33b81237e09058",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_thm1_equivalent_bound": {
+      "accepted_source_role_contract_sha256": "47b92ebe06c3b62e146923c82ebb2d75f380abc6d78754faac7170a71ca2100c",
+      "public_source_role_projection_sha256": "47b92ebe06c3b62e146923c82ebb2d75f380abc6d78754faac7170a71ca2100c",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_thm2_equivalent_bound": {
+      "accepted_source_role_contract_sha256": "c6a8a4310190c6b271ae06641d71faf430a0d957640598b24f33b81237e09058",
+      "public_source_role_projection_sha256": "c6a8a4310190c6b271ae06641d71faf430a0d957640598b24f33b81237e09058",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_tomato": {
+      "accepted_source_role_contract_sha256": "c6a8a4310190c6b271ae06641d71faf430a0d957640598b24f33b81237e09058",
+      "public_source_role_projection_sha256": "c6a8a4310190c6b271ae06641d71faf430a0d957640598b24f33b81237e09058",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_unbounded_cutoffs": {
+      "accepted_source_role_contract_sha256": "65381e43976cd7fe80230dae6fa478acaabc00c26ea7674d54016908b8e336d1",
+      "public_source_role_projection_sha256": "65381e43976cd7fe80230dae6fa478acaabc00c26ea7674d54016908b8e336d1",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "stable_matching_cutoff_definition": {
+      "accepted_source_role_contract_sha256": "4a5d5e0481f12028d09716bdc408f7660f44a95750daceeff5b45886ab5c7091",
+      "public_source_role_projection_sha256": "4a5d5e0481f12028d09716bdc408f7660f44a95750daceeff5b45886ab5c7091",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem1_attenuation": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem2_amplification": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem3_attenuation_in_coalitions": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem4_amplification_in_coalitions": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    }
+  },
+  "paper": "PG24NoisyMatchingMarkets",
+  "private_role_material_included": false,
+  "private_source_map_material_sha256": "7e9b7b1b8cd22f4814a43151f032418fc6ca501dfc2286caf1cb858410136b88",
+  "private_source_map_sha256": "75807d3e497e33db7bac393a4f462345818254525907cd111102300d1b6ed237",
+  "projection_contract_sha256": "ed0964edc9c70f5ce087ce9bf134712ca40c7964ecaefd403309ac9a1b47d34d",
+  "public_display_manifest_material_sha256": "776ee32c4e269066665159b83f19460968cf7a3d04a0ade2b0443bfe9b5533da",
+  "public_display_manifest_sha256": "5f35add2d5f28cb51684f1b972ffc6e81a16d4ab50a773b48535df734f8950b4",
+  "public_source_map_material_sha256": "82cf35b417bbef17b44de6ce9a793bbe9ed35ec633e5ff01ac03743f2343d684",
+  "public_source_map_sha256": "9be6980bf955df0acf1e42e5ba4990fb5a6f62bb9649dd77e796ec74e3fdbde3",
+  "raw_private_approval_material_included": false,
+  "schema": 1
+}

--- a/papers/PKG25NoFreeLunch/audit/paper_statement_map.json
+++ b/papers/PKG25NoFreeLunch/audit/paper_statement_map.json
@@ -1857,6 +1857,11 @@
     "PKG25NoFreeLunch.source_definition_disagree_on": "source_definition_disagree",
     "PKG25NoFreeLunch.source_definition_incorrect_on": "source_definition_incorrect"
   },
+  "publication_source_display_projection": {
+    "manifest": "audit/public_source_display_projection.json",
+    "raw_source_bytes_included": false,
+    "schema": 1
+  },
   "schema": 1,
   "semantic_contract_schema": 1,
   "semantic_route_schema": 2,

--- a/papers/PKG25NoFreeLunch/audit/public_source_role_projection.json
+++ b/papers/PKG25NoFreeLunch/audit/public_source_role_projection.json
@@ -1,0 +1,335 @@
+{
+  "acceptance_credential": false,
+  "accepted_graph_sha256": "c8ac1bc881b92dadffc313e3d90a454161ff5111908ce298a68133bfb66c6cc7",
+  "bindings_by_source_item": {
+    "source_claim_correctness_strict_dominance": {
+      "accepted_source_role_contract_sha256": "d7d70303426088c651cded2e6545beba24ea207db38742f15b22ca6ec2ec5c1d",
+      "public_source_role_projection_sha256": "d7d70303426088c651cded2e6545beba24ea207db38742f15b22ca6ec2ec5c1d",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_claim_lemma8_mass_and_accuracy_dominance": {
+      "accepted_source_role_contract_sha256": "06aaf87ea6660fc4977a9e6826d4a64b120bd00c87b17b52dacf58d5bdf90fc6",
+      "public_source_role_projection_sha256": "06aaf87ea6660fc4977a9e6826d4a64b120bd00c87b17b52dacf58d5bdf90fc6",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_claim_proposition6_sampling_index_typo": {
+      "accepted_source_role_contract_sha256": "d7d70303426088c651cded2e6545beba24ea207db38742f15b22ca6ec2ec5c1d",
+      "public_source_role_projection_sha256": "d7d70303426088c651cded2e6545beba24ea207db38742f15b22ca6ec2ec5c1d",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_claim_proposition9_s1_positive_domain": {
+      "accepted_source_role_contract_sha256": "d7d70303426088c651cded2e6545beba24ea207db38742f15b22ca6ec2ec5c1d",
+      "public_source_role_projection_sha256": "d7d70303426088c651cded2e6545beba24ea207db38742f15b22ca6ec2ec5c1d",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_definition_agree": {
+      "accepted_source_role_contract_sha256": "19f3c3198275beddf106c0578e1b854122d7060121a70a8735b5fbe5ed3acc78",
+      "public_source_role_projection_sha256": "19f3c3198275beddf106c0578e1b854122d7060121a70a8735b5fbe5ed3acc78",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_definition_collaboration_setting": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_definition_collaboration_strategy": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_definition_correct": {
+      "accepted_source_role_contract_sha256": "19f3c3198275beddf106c0578e1b854122d7060121a70a8735b5fbe5ed3acc78",
+      "public_source_role_projection_sha256": "19f3c3198275beddf106c0578e1b854122d7060121a70a8735b5fbe5ed3acc78",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_definition_disagree": {
+      "accepted_source_role_contract_sha256": "19f3c3198275beddf106c0578e1b854122d7060121a70a8735b5fbe5ed3acc78",
+      "public_source_role_projection_sha256": "19f3c3198275beddf106c0578e1b854122d7060121a70a8735b5fbe5ed3acc78",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_definition_incorrect": {
+      "accepted_source_role_contract_sha256": "19f3c3198275beddf106c0578e1b854122d7060121a70a8735b5fbe5ed3acc78",
+      "public_source_role_projection_sha256": "19f3c3198275beddf106c0578e1b854122d7060121a70a8735b5fbe5ed3acc78",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_definition_lemma8_input_and_partitions": {
+      "accepted_source_role_contract_sha256": "b751c02f2bff7cd0ea242da15fa62823f620a6050ea3d004c22351988bb31379",
+      "public_source_role_projection_sha256": "b751c02f2bff7cd0ea242da15fa62823f620a6050ea3d004c22351988bb31379",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_definition_non_collaboration": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_definition_predictor": {
+      "accepted_source_role_contract_sha256": "7f8b8b5e9e41e4c2222db89a11eda86c86e1f71d9dd1659081ecdfa13f32d3ac",
+      "public_source_role_projection_sha256": "7f8b8b5e9e41e4c2222db89a11eda86c86e1f71d9dd1659081ecdfa13f32d3ac",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_definition_proposition9_s2_input_space": {
+      "accepted_source_role_contract_sha256": "64df61b9c52465f34b4f2eef7a2913dd0006a40bc305d590befa30824d8bc90a",
+      "public_source_role_projection_sha256": "64df61b9c52465f34b4f2eef7a2913dd0006a40bc305d590befa30824d8bc90a",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_definition_proposition9_s2_witness_profiles": {
+      "accepted_source_role_contract_sha256": "64df61b9c52465f34b4f2eef7a2913dd0006a40bc305d590befa30824d8bc90a",
+      "public_source_role_projection_sha256": "64df61b9c52465f34b4f2eef7a2913dd0006a40bc305d590befa30824d8bc90a",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_definition_reliability": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_definition_rounding_classifier": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_definition_strategy_accuracy": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_formula_calibration": {
+      "accepted_source_role_contract_sha256": "ce9d6d2242e086629bc712ee3eedd154ec4ecaa172f140d7a61446eadaa28c8b",
+      "public_source_role_projection_sha256": "ce9d6d2242e086629bc712ee3eedd154ec4ecaa172f140d7a61446eadaa28c8b",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_formula_individual_accuracy": {
+      "accepted_source_role_contract_sha256": "1013bac0f64d961cf710c45bb3ffa3c3e7f4a01364f2c91a5854886aa5488ca1",
+      "public_source_role_projection_sha256": "1013bac0f64d961cf710c45bb3ffa3c3e7f4a01364f2c91a5854886aa5488ca1",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_formula_induced_collaboration_classifier": {
+      "accepted_source_role_contract_sha256": "1013bac0f64d961cf710c45bb3ffa3c3e7f4a01364f2c91a5854886aa5488ca1",
+      "public_source_role_projection_sha256": "1013bac0f64d961cf710c45bb3ffa3c3e7f4a01364f2c91a5854886aa5488ca1",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_formula_lemma8_calibration_cells": {
+      "accepted_source_role_contract_sha256": "0ba89c45f8d21c66bfc66b6f672cd9a7c3cec9bacf36dab319affee9654e7b35",
+      "public_source_role_projection_sha256": "0ba89c45f8d21c66bfc66b6f672cd9a7c3cec9bacf36dab319affee9654e7b35",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_formula_lemma8_center_profile": {
+      "accepted_source_role_contract_sha256": "0ba89c45f8d21c66bfc66b6f672cd9a7c3cec9bacf36dab319affee9654e7b35",
+      "public_source_role_projection_sha256": "0ba89c45f8d21c66bfc66b6f672cd9a7c3cec9bacf36dab319affee9654e7b35",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_formula_lemma8_label_probabilities": {
+      "accepted_source_role_contract_sha256": "51ff915c4facf246df21f1dd1bf8f8003022615a6fc7b7ff35017fd406d91d51",
+      "public_source_role_projection_sha256": "51ff915c4facf246df21f1dd1bf8f8003022615a6fc7b7ff35017fd406d91d51",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_formula_lemma8_masses_output_one": {
+      "accepted_source_role_contract_sha256": "51ff915c4facf246df21f1dd1bf8f8003022615a6fc7b7ff35017fd406d91d51",
+      "public_source_role_projection_sha256": "51ff915c4facf246df21f1dd1bf8f8003022615a6fc7b7ff35017fd406d91d51",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_formula_lemma8_masses_output_zero": {
+      "accepted_source_role_contract_sha256": "51ff915c4facf246df21f1dd1bf8f8003022615a6fc7b7ff35017fd406d91d51",
+      "public_source_role_projection_sha256": "51ff915c4facf246df21f1dd1bf8f8003022615a6fc7b7ff35017fd406d91d51",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_formula_mixture_conditional_label": {
+      "accepted_source_role_contract_sha256": "3c13be0edf167aa857321ca9b2ba0be562b03482aa184dbe485c7cbe3f14050a",
+      "public_source_role_projection_sha256": "3c13be0edf167aa857321ca9b2ba0be562b03482aa184dbe485c7cbe3f14050a",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_formula_mixture_mass": {
+      "accepted_source_role_contract_sha256": "3c13be0edf167aa857321ca9b2ba0be562b03482aa184dbe485c7cbe3f14050a",
+      "public_source_role_projection_sha256": "3c13be0edf167aa857321ca9b2ba0be562b03482aa184dbe485c7cbe3f14050a",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_formula_mixture_predictors": {
+      "accepted_source_role_contract_sha256": "3c13be0edf167aa857321ca9b2ba0be562b03482aa184dbe485c7cbe3f14050a",
+      "public_source_role_projection_sha256": "3c13be0edf167aa857321ca9b2ba0be562b03482aa184dbe485c7cbe3f14050a",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_formula_opening_zero_one_loss": {
+      "accepted_source_role_contract_sha256": "e190fa4149d82644ea35f7bdcb510e3984b0db78318bcb35188895cd815713fd",
+      "public_source_role_projection_sha256": "e190fa4149d82644ea35f7bdcb510e3984b0db78318bcb35188895cd815713fd",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_formula_partition_induced_predictor": {
+      "accepted_source_role_contract_sha256": "20cca5aa24286d85099acdf586d9cf7a17dd46cef314663d1ed9a16bfcf7e396",
+      "public_source_role_projection_sha256": "20cca5aa24286d85099acdf586d9cf7a17dd46cef314663d1ed9a16bfcf7e396",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_formula_proposition7_average_mixture": {
+      "accepted_source_role_contract_sha256": "76ec2a324cf68e5a73ac4563e64e88251607c81ef9e43e1897d8b02c3f889ab9",
+      "public_source_role_projection_sha256": "76ec2a324cf68e5a73ac4563e64e88251607c81ef9e43e1897d8b02c3f889ab9",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_formula_proposition9_final_mixture": {
+      "accepted_source_role_contract_sha256": "c7f02937c0359da7e4dacd0e105b5381e11bfcdf711c2ea3fabda0c0f878e911",
+      "public_source_role_projection_sha256": "c7f02937c0359da7e4dacd0e105b5381e11bfcdf711c2ea3fabda0c0f878e911",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_formula_proposition9_s1_accuracies": {
+      "accepted_source_role_contract_sha256": "c7f02937c0359da7e4dacd0e105b5381e11bfcdf711c2ea3fabda0c0f878e911",
+      "public_source_role_projection_sha256": "c7f02937c0359da7e4dacd0e105b5381e11bfcdf711c2ea3fabda0c0f878e911",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_formula_proposition9_s1_mass_and_labels": {
+      "accepted_source_role_contract_sha256": "36cd08941d90eaae145d104e8651aa432c7fbea8c8da35e8cea16a1a16a50ef3",
+      "public_source_role_projection_sha256": "36cd08941d90eaae145d104e8651aa432c7fbea8c8da35e8cea16a1a16a50ef3",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_formula_proposition9_s1_predictions_and_calibration": {
+      "accepted_source_role_contract_sha256": "36cd08941d90eaae145d104e8651aa432c7fbea8c8da35e8cea16a1a16a50ef3",
+      "public_source_role_projection_sha256": "36cd08941d90eaae145d104e8651aa432c7fbea8c8da35e8cea16a1a16a50ef3",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_formula_proposition9_s2_calibration_cells": {
+      "accepted_source_role_contract_sha256": "6a1579250c9d1c22c10800c470050d5ee214035cf92bb92cb3d32900fbe65761",
+      "public_source_role_projection_sha256": "6a1579250c9d1c22c10800c470050d5ee214035cf92bb92cb3d32900fbe65761",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_formula_proposition9_s2_mass_and_labels": {
+      "accepted_source_role_contract_sha256": "e190fa4149d82644ea35f7bdcb510e3984b0db78318bcb35188895cd815713fd",
+      "public_source_role_projection_sha256": "e190fa4149d82644ea35f7bdcb510e3984b0db78318bcb35188895cd815713fd",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_formula_proposition9_s2_profiles_and_gap": {
+      "accepted_source_role_contract_sha256": "93b9ae4337fc98df8984cc07e09d1dc890537c37225af780f1d6064b5f8e1d5d",
+      "public_source_role_projection_sha256": "93b9ae4337fc98df8984cc07e09d1dc890537c37225af780f1d6064b5f8e1d5d",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_formula_proposition9_s2_repaired_mass_and_labels": {
+      "accepted_source_role_contract_sha256": "5aba949cb44a66afa6a19e0b678c160815f5c2c4e4d3330696f8a8f83e9b74ed",
+      "public_source_role_projection_sha256": "5aba949cb44a66afa6a19e0b678c160815f5c2c4e4d3330696f8a8f83e9b74ed",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_lemma8_bad_tuple": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_model_event_calibration_convention": {
+      "accepted_source_role_contract_sha256": "b3f6033daec1cfb227c98bc97180175be632684b3dbef3f036bb947f06a52a77",
+      "public_source_role_projection_sha256": "b3f6033daec1cfb227c98bc97180175be632684b3dbef3f036bb947f06a52a77",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_model_nonempty_agent_domain": {
+      "accepted_source_role_contract_sha256": "73ebb10a46031f58ce7cab04b4f221c15ff08861964495961229723ee972ca7b",
+      "public_source_role_projection_sha256": "73ebb10a46031f58ce7cab04b4f221c15ff08861964495961229723ee972ca7b",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_model_predictor_measurability": {
+      "accepted_source_role_contract_sha256": "73ebb10a46031f58ce7cab04b4f221c15ff08861964495961229723ee972ca7b",
+      "public_source_role_projection_sha256": "73ebb10a46031f58ce7cab04b4f221c15ff08861964495961229723ee972ca7b",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_model_strategy_expectation_definedness": {
+      "accepted_source_role_contract_sha256": "73ebb10a46031f58ce7cab04b4f221c15ff08861964495961229723ee972ca7b",
+      "public_source_role_projection_sha256": "73ebb10a46031f58ce7cab04b4f221c15ff08861964495961229723ee972ca7b",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_observation_correctness_weak_dominance": {
+      "accepted_source_role_contract_sha256": "7865fd8502e518b1fa0bdad0a62e17ce5d78dee0bdc8e30b5de301cb52860447",
+      "public_source_role_projection_sha256": "7865fd8502e518b1fa0bdad0a62e17ce5d78dee0bdc8e30b5de301cb52860447",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_partition_finite_measurable_repair": {
+      "accepted_source_role_contract_sha256": "e8bd731c387f27f23e485836c19e8cd56ab3be13060fd6b4343e29952fe8b856",
+      "public_source_role_projection_sha256": "e8bd731c387f27f23e485836c19e8cd56ab3be13060fd6b4343e29952fe8b856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_proposition6_linear_combination": {
+      "accepted_source_role_contract_sha256": "64a83a0ae6edbdb2d3cfb6cb84e3bf045734ef9303f62643ff780eff69b02885",
+      "public_source_role_projection_sha256": "64a83a0ae6edbdb2d3cfb6cb84e3bf045734ef9303f62643ff780eff69b02885",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_proposition7_fixed_deferral": {
+      "accepted_source_role_contract_sha256": "64a83a0ae6edbdb2d3cfb6cb84e3bf045734ef9303f62643ff780eff69b02885",
+      "public_source_role_projection_sha256": "64a83a0ae6edbdb2d3cfb6cb84e3bf045734ef9303f62643ff780eff69b02885",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_proposition9_constant_tie_label": {
+      "accepted_source_role_contract_sha256": "64a83a0ae6edbdb2d3cfb6cb84e3bf045734ef9303f62643ff780eff69b02885",
+      "public_source_role_projection_sha256": "64a83a0ae6edbdb2d3cfb6cb84e3bf045734ef9303f62643ff780eff69b02885",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_remark_boundary_certain_agent": {
+      "accepted_source_role_contract_sha256": "afd43ce46cfac71973aa3680a9e5fcdfe07e07b5656074368bfaf566722474ac",
+      "public_source_role_projection_sha256": "afd43ce46cfac71973aa3680a9e5fcdfe07e07b5656074368bfaf566722474ac",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_theorem1_no_free_lunch": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "source_unnumbered_iff_restatement": {
+      "accepted_source_role_contract_sha256": "df4912474e0214a5182b9c521a4664389a82ce006f8bc3621751d78bebdab06a",
+      "public_source_role_projection_sha256": "df4912474e0214a5182b9c521a4664389a82ce006f8bc3621751d78bebdab06a",
+      "schema": 1,
+      "withheld_field_paths": []
+    }
+  },
+  "paper": "PKG25NoFreeLunch",
+  "private_role_material_included": false,
+  "private_source_map_material_sha256": "24aacc71f99bd3ee196387c81b74ed4aac718d2fe23f9a075d26acaf73c0d0ea",
+  "private_source_map_sha256": "6c35fa35bc414614ea617eacd94a5020ad25b1beb98fc1b6dbec15ea34241107",
+  "projection_contract_sha256": "ed0964edc9c70f5ce087ce9bf134712ca40c7964ecaefd403309ac9a1b47d34d",
+  "public_display_manifest_material_sha256": "0f591ed9568c0e647deecba514860852edcbda258ca5ac2e074262e8481dc7af",
+  "public_display_manifest_sha256": "2d2426415f290d8fc9bfcfcd76b2534f0655325b9694fad2aa3075fd968d858a",
+  "public_source_map_material_sha256": "3e6df8eb51a72a42e699e7b00d0861caa71155b9a7c9f08311b3d4d36aed2bf9",
+  "public_source_map_sha256": "7f15ae36ae7cea591cddadd2f17f29bbeca0199865216bccc995cca71fb00fc8",
+  "raw_private_approval_material_included": false,
+  "schema": 1
+}

--- a/papers/PRPKG24AccuracyDiversity/audit/paper_statement_map.json
+++ b/papers/PRPKG24AccuracyDiversity/audit/paper_statement_map.json
@@ -3218,6 +3218,11 @@
     "approval_material_included": false,
     "schema": 1
   },
+  "publication_source_display_projection": {
+    "manifest": "audit/public_source_display_projection.json",
+    "raw_source_bytes_included": false,
+    "schema": 1
+  },
   "schema": 1,
   "semantic_contract_schema": 1,
   "semantic_route_schema": 2,

--- a/papers/PRPKG24AccuracyDiversity/audit/public_source_display_projection.json
+++ b/papers/PRPKG24AccuracyDiversity/audit/public_source_display_projection.json
@@ -1,9 +1,9 @@
 {
   "generator": "python3 scripts/public_source_display_projection.py",
   "paper_id": "PRPKG24AccuracyDiversity",
-  "private_source_map_sha256": "f72f20a5f4188d45df50524bea68bc2ae85cf11a0d151905a99fa5b35227c3d7",
+  "private_source_map_sha256": "05a59f471e8ee6c8bf164d3542aa3d7d0eb0f4eab5e8d6c9ce52370756c5079f",
   "public_manifest_path": "papers/PRPKG24AccuracyDiversity/audit/public_source_display_projection.json",
-  "public_source_map_sha256": "bad4e351d924ec3d8d965a6a83ea1b8f6db7c2db1dd96ac0c17324a70d07cf69",
+  "public_source_map_sha256": "7f4bae9f4cba0809b40e3a78eadcc2a6612036abf5e4e942e7c4fc66c7c83665",
   "raw_source_artifact_included": false,
   "raw_source_display_material": "selected_byte_pinned_source_anchor_quotes",
   "schema": 1,

--- a/papers/PRPKG24AccuracyDiversity/audit/public_source_role_projection.json
+++ b/papers/PRPKG24AccuracyDiversity/audit/public_source_role_projection.json
@@ -1,0 +1,491 @@
+{
+  "acceptance_credential": false,
+  "accepted_graph_sha256": "72a29aa4f6c37913bd3e980b6a963ad1da6ecf640ec7b7e70ffcbbf804c81e8e",
+  "bindings_by_source_item": {
+    "prpkg_assumption_bernoulli_success_probability_range": {
+      "accepted_source_role_contract_sha256": "4eb7d0ddb7e5eb47740d27e1726cffa809d85a00ebec41705e582883d0b99a65",
+      "public_source_role_projection_sha256": "4eb7d0ddb7e5eb47740d27e1726cffa809d85a00ebec41705e582883d0b99a65",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "prpkg_assumption_bounded_density_domain": {
+      "accepted_source_role_contract_sha256": "4eb7d0ddb7e5eb47740d27e1726cffa809d85a00ebec41705e582883d0b99a65",
+      "public_source_role_projection_sha256": "4eb7d0ddb7e5eb47740d27e1726cffa809d85a00ebec41705e582883d0b99a65",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "prpkg_assumption_common_mean_argmax": {
+      "accepted_source_role_contract_sha256": "4eb7d0ddb7e5eb47740d27e1726cffa809d85a00ebec41705e582883d0b99a65",
+      "public_source_role_projection_sha256": "4eb7d0ddb7e5eb47740d27e1726cffa809d85a00ebec41705e582883d0b99a65",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "prpkg_assumption_corollary3_iid_bernoulli_domain": {
+      "accepted_source_role_contract_sha256": "4eb7d0ddb7e5eb47740d27e1726cffa809d85a00ebec41705e582883d0b99a65",
+      "public_source_role_projection_sha256": "4eb7d0ddb7e5eb47740d27e1726cffa809d85a00ebec41705e582883d0b99a65",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "prpkg_assumption_decaying_bernoulli_domain": {
+      "accepted_source_role_contract_sha256": "4eb7d0ddb7e5eb47740d27e1726cffa809d85a00ebec41705e582883d0b99a65",
+      "public_source_role_projection_sha256": "4eb7d0ddb7e5eb47740d27e1726cffa809d85a00ebec41705e582883d0b99a65",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "prpkg_assumption_example1_domain": {
+      "accepted_source_role_contract_sha256": "4eb7d0ddb7e5eb47740d27e1726cffa809d85a00ebec41705e582883d0b99a65",
+      "public_source_role_projection_sha256": "4eb7d0ddb7e5eb47740d27e1726cffa809d85a00ebec41705e582883d0b99a65",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "prpkg_assumption_exponential_domain": {
+      "accepted_source_role_contract_sha256": "4eb7d0ddb7e5eb47740d27e1726cffa809d85a00ebec41705e582883d0b99a65",
+      "public_source_role_projection_sha256": "4eb7d0ddb7e5eb47740d27e1726cffa809d85a00ebec41705e582883d0b99a65",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "prpkg_assumption_finite_discrete_domain": {
+      "accepted_source_role_contract_sha256": "4eb7d0ddb7e5eb47740d27e1726cffa809d85a00ebec41705e582883d0b99a65",
+      "public_source_role_projection_sha256": "4eb7d0ddb7e5eb47740d27e1726cffa809d85a00ebec41705e582883d0b99a65",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "prpkg_assumption_lemmaD2_domain": {
+      "accepted_source_role_contract_sha256": "4eb7d0ddb7e5eb47740d27e1726cffa809d85a00ebec41705e582883d0b99a65",
+      "public_source_role_projection_sha256": "4eb7d0ddb7e5eb47740d27e1726cffa809d85a00ebec41705e582883d0b99a65",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "prpkg_assumption_nonnegative_gamma": {
+      "accepted_source_role_contract_sha256": "4eb7d0ddb7e5eb47740d27e1726cffa809d85a00ebec41705e582883d0b99a65",
+      "public_source_role_projection_sha256": "4eb7d0ddb7e5eb47740d27e1726cffa809d85a00ebec41705e582883d0b99a65",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "prpkg_assumption_pareto_domain": {
+      "accepted_source_role_contract_sha256": "4eb7d0ddb7e5eb47740d27e1726cffa809d85a00ebec41705e582883d0b99a65",
+      "public_source_role_projection_sha256": "4eb7d0ddb7e5eb47740d27e1726cffa809d85a00ebec41705e582883d0b99a65",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "prpkg_assumption_positive_rounding_size": {
+      "accepted_source_role_contract_sha256": "4eb7d0ddb7e5eb47740d27e1726cffa809d85a00ebec41705e582883d0b99a65",
+      "public_source_role_projection_sha256": "4eb7d0ddb7e5eb47740d27e1726cffa809d85a00ebec41705e582883d0b99a65",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "prpkg_assumption_positive_source_preference_law": {
+      "accepted_source_role_contract_sha256": "4eb7d0ddb7e5eb47740d27e1726cffa809d85a00ebec41705e582883d0b99a65",
+      "public_source_role_projection_sha256": "4eb7d0ddb7e5eb47740d27e1726cffa809d85a00ebec41705e582883d0b99a65",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "prpkg_assumption_positive_type_likelihoods": {
+      "accepted_source_role_contract_sha256": "4eb7d0ddb7e5eb47740d27e1726cffa809d85a00ebec41705e582883d0b99a65",
+      "public_source_role_projection_sha256": "4eb7d0ddb7e5eb47740d27e1726cffa809d85a00ebec41705e582883d0b99a65",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "prpkg_assumption_proposition4_radial_kernel": {
+      "accepted_source_role_contract_sha256": "4eb7d0ddb7e5eb47740d27e1726cffa809d85a00ebec41705e582883d0b99a65",
+      "public_source_role_projection_sha256": "4eb7d0ddb7e5eb47740d27e1726cffa809d85a00ebec41705e582883d0b99a65",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "prpkg_assumption_theorem3_varying_bernoulli_domain": {
+      "accepted_source_role_contract_sha256": "4eb7d0ddb7e5eb47740d27e1726cffa809d85a00ebec41705e582883d0b99a65",
+      "public_source_role_projection_sha256": "4eb7d0ddb7e5eb47740d27e1726cffa809d85a00ebec41705e582883d0b99a65",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "prpkg_assumption_uniform_topk_domain": {
+      "accepted_source_role_contract_sha256": "4eb7d0ddb7e5eb47740d27e1726cffa809d85a00ebec41705e582883d0b99a65",
+      "public_source_role_projection_sha256": "4eb7d0ddb7e5eb47740d27e1726cffa809d85a00ebec41705e582883d0b99a65",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "prpkg_corollary1_any_gamma": {
+      "accepted_source_role_contract_sha256": "f4254796949514af697b1a57a525740c36a37b17d9eafef0da4f0bb27d637328",
+      "public_source_role_projection_sha256": "f4254796949514af697b1a57a525740c36a37b17d9eafef0da4f0bb27d637328",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "prpkg_corollary3_iid_bernoulli": {
+      "accepted_source_role_contract_sha256": "d07685beeed431321fce19e2e45dd7ec7ce3966d3d1ac53d9cce7289f53fc246",
+      "public_source_role_projection_sha256": "feb9fe0a5f8244766d4869bd3d9b1745644eed39488640b53864ebb7600ef17b",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "prpkg_definition1_eq5_gamma_homogeneity": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "prpkg_definition2_eq6_sequence_homogeneity": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "prpkg_definition3_order_statistic_mean": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "prpkg_definition3_topk_sum_formula": {
+      "accepted_source_role_contract_sha256": "0c2028098511fdaf97110b8f57eb8ed7c4664a4964e7f2a3f72923d022b21220",
+      "public_source_role_projection_sha256": "0c2028098511fdaf97110b8f57eb8ed7c4664a4964e7f2a3f72923d022b21220",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "prpkg_eq10_representation_limit": {
+      "accepted_source_role_contract_sha256": "0c2028098511fdaf97110b8f57eb8ed7c4664a4964e7f2a3f72923d022b21220",
+      "public_source_role_projection_sha256": "0c2028098511fdaf97110b8f57eb8ed7c4664a4964e7f2a3f72923d022b21220",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "prpkg_eq11_bounded_share_limit": {
+      "accepted_source_role_contract_sha256": "0c2028098511fdaf97110b8f57eb8ed7c4664a4964e7f2a3f72923d022b21220",
+      "public_source_role_projection_sha256": "0c2028098511fdaf97110b8f57eb8ed7c4664a4964e7f2a3f72923d022b21220",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "prpkg_eq12_computational_objective": {
+      "accepted_source_role_contract_sha256": "5d52e39bde3dcc7bb430024f7642dd44a50b945d19a2894c8fae93e97b984c00",
+      "public_source_role_projection_sha256": "5d52e39bde3dcc7bb430024f7642dd44a50b945d19a2894c8fae93e97b984c00",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "prpkg_eq13_multiple_preference_failure": {
+      "accepted_source_role_contract_sha256": "0c2028098511fdaf97110b8f57eb8ed7c4664a4964e7f2a3f72923d022b21220",
+      "public_source_role_projection_sha256": "0c2028098511fdaf97110b8f57eb8ed7c4664a4964e7f2a3f72923d022b21220",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "prpkg_eq14_reduced_multiple_preference": {
+      "accepted_source_role_contract_sha256": "0c2028098511fdaf97110b8f57eb8ed7c4664a4964e7f2a3f72923d022b21220",
+      "public_source_role_projection_sha256": "0c2028098511fdaf97110b8f57eb8ed7c4664a4964e7f2a3f72923d022b21220",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "prpkg_eq15_finite_failure_product_log": {
+      "accepted_source_role_contract_sha256": "0c2028098511fdaf97110b8f57eb8ed7c4664a4964e7f2a3f72923d022b21220",
+      "public_source_role_projection_sha256": "0c2028098511fdaf97110b8f57eb8ed7c4664a4964e7f2a3f72923d022b21220",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "prpkg_eq16_relaxed_failure_integral": {
+      "accepted_source_role_contract_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "public_source_role_projection_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "prpkg_eq17_gamma_limit": {
+      "accepted_source_role_contract_sha256": "0c2028098511fdaf97110b8f57eb8ed7c4664a4964e7f2a3f72923d022b21220",
+      "public_source_role_projection_sha256": "0c2028098511fdaf97110b8f57eb8ed7c4664a4964e7f2a3f72923d022b21220",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "prpkg_eq18_uniform_minimizes_gamma": {
+      "accepted_source_role_contract_sha256": "e054fc81f828559c03aef85eb43fe3f1313b503356c23c050f28b7491f788033",
+      "public_source_role_projection_sha256": "88de2ac752bfa4474c0c510dbbe42ea33341e816248e48c333cbd8f932073546",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "prpkg_eq19_profile_payoff": {
+      "accepted_source_role_contract_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "public_source_role_projection_sha256": "3a8e03e95c34d11d52f67b2123658030c43d7588d33e47abdf0c45821a23a83b",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "prpkg_eq1_example1_expected_best": {
+      "accepted_source_role_contract_sha256": "0c2028098511fdaf97110b8f57eb8ed7c4664a4964e7f2a3f72923d022b21220",
+      "public_source_role_projection_sha256": "0c2028098511fdaf97110b8f57eb8ed7c4664a4964e7f2a3f72923d022b21220",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "prpkg_eq20_laplace_supremum": {
+      "accepted_source_role_contract_sha256": "0c2028098511fdaf97110b8f57eb8ed7c4664a4964e7f2a3f72923d022b21220",
+      "public_source_role_projection_sha256": "0c2028098511fdaf97110b8f57eb8ed7c4664a4964e7f2a3f72923d022b21220",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "prpkg_eq21_average_rho_unfold": {
+      "accepted_source_role_contract_sha256": "0c2028098511fdaf97110b8f57eb8ed7c4664a4964e7f2a3f72923d022b21220",
+      "public_source_role_projection_sha256": "0c2028098511fdaf97110b8f57eb8ed7c4664a4964e7f2a3f72923d022b21220",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "prpkg_eq22_fubini_swap": {
+      "accepted_source_role_contract_sha256": "0c2028098511fdaf97110b8f57eb8ed7c4664a4964e7f2a3f72923d022b21220",
+      "public_source_role_projection_sha256": "0c2028098511fdaf97110b8f57eb8ed7c4664a4964e7f2a3f72923d022b21220",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "prpkg_eq23_integral_constant": {
+      "accepted_source_role_contract_sha256": "0c2028098511fdaf97110b8f57eb8ed7c4664a4964e7f2a3f72923d022b21220",
+      "public_source_role_projection_sha256": "0c2028098511fdaf97110b8f57eb8ed7c4664a4964e7f2a3f72923d022b21220",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "prpkg_eq24_probability_integrates_constant": {
+      "accepted_source_role_contract_sha256": "0c2028098511fdaf97110b8f57eb8ed7c4664a4964e7f2a3f72923d022b21220",
+      "public_source_role_projection_sha256": "0c2028098511fdaf97110b8f57eb8ed7c4664a4964e7f2a3f72923d022b21220",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "prpkg_eq25_radial_integral_constant": {
+      "accepted_source_role_contract_sha256": "0c2028098511fdaf97110b8f57eb8ed7c4664a4964e7f2a3f72923d022b21220",
+      "public_source_role_projection_sha256": "0c2028098511fdaf97110b8f57eb8ed7c4664a4964e7f2a3f72923d022b21220",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "prpkg_eq26_uniform_profile_constant_payoff": {
+      "accepted_source_role_contract_sha256": "0c2028098511fdaf97110b8f57eb8ed7c4664a4964e7f2a3f72923d022b21220",
+      "public_source_role_projection_sha256": "0c2028098511fdaf97110b8f57eb8ed7c4664a4964e7f2a3f72923d022b21220",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "prpkg_eq2_example1_log_relaxation": {
+      "accepted_source_role_contract_sha256": "0c2028098511fdaf97110b8f57eb8ed7c4664a4964e7f2a3f72923d022b21220",
+      "public_source_role_projection_sha256": "0c2028098511fdaf97110b8f57eb8ed7c4664a4964e7f2a3f72923d022b21220",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "prpkg_eq3_weighted_objective": {
+      "accepted_source_role_contract_sha256": "0c2028098511fdaf97110b8f57eb8ed7c4664a4964e7f2a3f72923d022b21220",
+      "public_source_role_projection_sha256": "0c2028098511fdaf97110b8f57eb8ed7c4664a4964e7f2a3f72923d022b21220",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "prpkg_eq4_representation": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "prpkg_eq7_theorem1_ii_density_tail": {
+      "accepted_source_role_contract_sha256": "0c2028098511fdaf97110b8f57eb8ed7c4664a4964e7f2a3f72923d022b21220",
+      "public_source_role_projection_sha256": "0c2028098511fdaf97110b8f57eb8ed7c4664a4964e7f2a3f72923d022b21220",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "prpkg_eq8_proposition2_uniform_finite": {
+      "accepted_source_role_contract_sha256": "828a8e87991e3f7b4fe4a01eb300f3587a728752a6617a3f88812e6841387ed6",
+      "public_source_role_projection_sha256": "5a51443f45aa254d3542abcd047c9fdd96c92ae56545d4f5d63d3f088d38a42c",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "prpkg_eq9_theorem3_log_share": {
+      "accepted_source_role_contract_sha256": "ce3c585041b5cc79ae5b8280e6990b14e9d43102771d24625f9602cb5081c4c3",
+      "public_source_role_projection_sha256": "af5e2c6634cbac1b7fd87f09d1a71daa9a44030b8e10b442822b50334d148c5a",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "prpkg_example1_all_consumed": {
+      "accepted_source_role_contract_sha256": "1532247469bc43bb6d6acab1e8a1e354feeda5e944b6295e846c4775cf95d74d",
+      "public_source_role_projection_sha256": "1532247469bc43bb6d6acab1e8a1e354feeda5e944b6295e846c4775cf95d74d",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "prpkg_example1_top_one_calibration": {
+      "accepted_source_role_contract_sha256": "f6687e07087b430a5d10dc39cf60f91e7c421dc8cf182c38c48dd5a81397eaa6",
+      "public_source_role_projection_sha256": "f6687e07087b430a5d10dc39cf60f91e7c421dc8cf182c38c48dd5a81397eaa6",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "prpkg_lemma1_bounded_tail": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "prpkg_lemmaD1_i_exponential_limit": {
+      "accepted_source_role_contract_sha256": "7d6eaa4c7dfe7c2d87f6733b2e0874288a8a126fc4deda0e135f8bfbb8c11564",
+      "public_source_role_projection_sha256": "b2bdf4be05abf92e3aa5beac01949bfdd2560c2b4b5d91efc092687075205063",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "prpkg_lemmaD1_ii_power_limit": {
+      "accepted_source_role_contract_sha256": "e8d901c828b24676d2d2afe00d46bc70fc4e4301afaa7902e20126ed86b7ca62",
+      "public_source_role_projection_sha256": "b75b89592a8018210414a54334d58fac249a12dcc1d3b9d491824e0a1b3d695f",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "prpkg_lemmaD1_iii_log_limit": {
+      "accepted_source_role_contract_sha256": "7e149e034728fdb508c1093a074a0ca2547e30012132d1b0ac8e2fba65d69f42",
+      "public_source_role_projection_sha256": "5a7d81010ce4cc01083fc67776e48fcf02560505c8322e3423b9848dba673188",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "prpkg_lemmaD1_iv_sublinear_power_limit": {
+      "accepted_source_role_contract_sha256": "1db4adea3508532f5e31f79f3a090dd26a7580df729fa14d410f84eead636eb0",
+      "public_source_role_projection_sha256": "db47b9380d1891ef734221bc030cc9b521d9825c415d78d827939a95e14105cf",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "prpkg_lemmaD2_bounded_integral": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "prpkg_lemmaD3_exponential_order_stats": {
+      "accepted_source_role_contract_sha256": "5d7ddbb95d1ed3b4f94c48989af2115c4e5e73fbaea34090703c2ffa21b3e7b0",
+      "public_source_role_projection_sha256": "205d2a5679f5e5f1f942c36db7baf43278cd2014d8273af08474e9651339ccbf",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "prpkg_lemmaD4_pareto_order_stats": {
+      "accepted_source_role_contract_sha256": "458eb04abdac2e9f1ff6d80380c6667ed376d95ea0b5d47d1503bda8475b803b",
+      "public_source_role_projection_sha256": "87a509671a48b9203764536ee8428fd1cf20b07cdfa7654a752b09404cf4face",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "prpkg_lemmaD5_rounding": {
+      "accepted_source_role_contract_sha256": "281e3091e1248b6c54cbb51d4ef44d470bb9b999de6a7c7e322fc2f4442be17a",
+      "public_source_role_projection_sha256": "068894b0065fe6ad3ae12b5e77581a5320cfc67ab50139777aa2f01a1a5b21e1",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "prpkg_main_text_lemmaD1_ii_bounded_tail": {
+      "accepted_source_role_contract_sha256": "a4dbade2321dd32340e18415b308575c149172186e025d45f1a9669a6dbb9f20",
+      "public_source_role_projection_sha256": "1b4ea27df24b38aa4379ca64d1ffa1b3a2dc182e7a998354eebc3f450a772034",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "prpkg_proposition5_uniform_order_statistic": {
+      "accepted_source_role_contract_sha256": "64a83a0ae6edbdb2d3cfb6cb84e3bf045734ef9303f62643ff780eff69b02885",
+      "public_source_role_projection_sha256": "64a83a0ae6edbdb2d3cfb6cb84e3bf045734ef9303f62643ff780eff69b02885",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "prpkg_theorem1_i_finite_discrete": {
+      "accepted_source_role_contract_sha256": "2461a5b694cad52a7058755f390acdc84803c30e19c7ac78507a03b93602029c",
+      "public_source_role_projection_sha256": "0e1dd0d0f861fd8821c067ff1b0923237fdbab3bcc665e8baeb36d068d8e0074",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "prpkg_theorem1_ii_bounded": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "prpkg_theorem1_iii_exponential": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "prpkg_theorem1_iv_pareto": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "prpkg_theorem1_v_all_consumed": {
+      "accepted_source_role_contract_sha256": "a5df41b98ff007cf30c376dff1638f9749222318cb06c5631f49da0202db9198",
+      "public_source_role_projection_sha256": "3d8806f2b94d4e6d267aa8cfe9811f45a15ba43e9b2672bce4ea8a2abb916fe1",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "prpkg_theorem2_i_subunit_decay": {
+      "accepted_source_role_contract_sha256": "d8487f27f264a091b37e5c5b8db5e7901bad49e22436f6a4dc01653aaac8511e",
+      "public_source_role_projection_sha256": "a1b242fdefcea1d9fd20c31e7afd7d2c4cb7bcd6504bf95b4a9531fa3bbd874c",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "prpkg_theorem2_ii_unit_decay": {
+      "accepted_source_role_contract_sha256": "bc405531c251f83890a68deddcf5c828e2c390b748748d5462e17f140924a8f8",
+      "public_source_role_projection_sha256": "5731aab031b5aab022834a89e6444491fb5c4d8f578adbc01fe50e8de979ed10",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "prpkg_theorem2_iii_superunit_decay": {
+      "accepted_source_role_contract_sha256": "9e4911601a9749bd339f0a0ccfc1ec047cb078c54037a334a410613add88dd2e",
+      "public_source_role_projection_sha256": "0bdfbe3a85eaa43a319d7ce3e3fd80edd387a0cfec4a84e03ffe920a3e819a43",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "prpkg_theorem2_iv_all_consumed_decay": {
+      "accepted_source_role_contract_sha256": "2749c53836ae60843b70bcba9e810ff3f799434bf2208e2075a6ca22cf1dd656",
+      "public_source_role_projection_sha256": "9dde363de270c57fe214bc08bd1cbbf5475cf649add87c09f05e4ff9db8d9d1b",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "prpkg_theorem3_all_consumed_argmax": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    }
+  },
+  "paper": "PRPKG24AccuracyDiversity",
+  "private_role_material_included": false,
+  "private_source_map_material_sha256": "fde539cb789f17d9f3d9280443ce1c686011be2a2fc3fb981970f43ead499db1",
+  "private_source_map_sha256": "05a59f471e8ee6c8bf164d3542aa3d7d0eb0f4eab5e8d6c9ce52370756c5079f",
+  "projection_contract_sha256": "ed0964edc9c70f5ce087ce9bf134712ca40c7964ecaefd403309ac9a1b47d34d",
+  "public_display_manifest_material_sha256": "a0dbc86652391d2271ac665ea340b94436f73ae34fc7aaf5176a70b171e04a93",
+  "public_display_manifest_sha256": "66c2fd2ef737bd9c32a0010e90f4d970e6fba41cd719f3971a1dd151f8b28604",
+  "public_source_map_material_sha256": "3d98ca8d18f6531e04eea906ffe00a2d3daa96423a0a4fa1df126605945c4456",
+  "public_source_map_sha256": "7f4bae9f4cba0809b40e3a78eadcc2a6612036abf5e4e942e7c4fc66c7c83665",
+  "raw_private_approval_material_included": false,
+  "schema": 1
+}

--- a/papers/PZMH20PerformativePrediction/audit/paper_statement_map.json
+++ b/papers/PZMH20PerformativePrediction/audit/paper_statement_map.json
@@ -1409,6 +1409,11 @@
     "approval_material_included": false,
     "schema": 1
   },
+  "publication_source_display_projection": {
+    "manifest": "audit/public_source_display_projection.json",
+    "raw_source_bytes_included": false,
+    "schema": 1
+  },
   "schema": 1,
   "semantic_contract_schema": 1,
   "semantic_route_schema": 2,

--- a/papers/PZMH20PerformativePrediction/audit/public_source_role_projection.json
+++ b/papers/PZMH20PerformativePrediction/audit/public_source_role_projection.json
@@ -1,0 +1,188 @@
+{
+  "acceptance_credential": false,
+  "accepted_graph_sha256": "dc51b908bfabd3cf71b5ce9fd95cb1d5fe666af6c35a6ea8cdb95f6820e4d811",
+  "bindings_by_source_item": {
+    "assumptions_a1_a2_joint_smoothness_and_strong_convexity": {
+      "accepted_source_role_contract_sha256": "833843175a57efcc42628b0a84e8c38255ed09660fd387cb299770e41e9ed782",
+      "public_source_role_projection_sha256": "833843175a57efcc42628b0a84e8c38255ed09660fd387cb299770e41e9ed782",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "corollary_5_1_stable_objective_gap": {
+      "accepted_source_role_contract_sha256": "eb279e2349a10df247f9f213cab536779edfc92b0daec91ed330d3975eae0312",
+      "public_source_role_projection_sha256": "24f4b2381fac9575e56cabdc0de3de1e7b6e957e6154e879a4ee52dceae942e0",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "definition_2_1_performative_optimality_and_risk": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition_2_3_performative_stability_and_decoupled_risk": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition_3_1_epsilon_sensitivity": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition_3_3_repeated_risk_minimization": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition_3_7_repeated_gradient_descent": {
+      "accepted_source_role_contract_sha256": "c1fbff08da70538ceb15a5516f967964a49d4b1f6ef1a703d776707c7545f903",
+      "public_source_role_projection_sha256": "c1fbff08da70538ceb15a5516f967964a49d4b1f6ef1a703d776707c7545f903",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "definition_3_9_repeated_empirical_updates": {
+      "accepted_source_role_contract_sha256": "c1fbff08da70538ceb15a5516f967964a49d4b1f6ef1a703d776707c7545f903",
+      "public_source_role_projection_sha256": "c1fbff08da70538ceb15a5516f967964a49d4b1f6ef1a703d776707c7545f903",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "domain_relative_performative_model": {
+      "accepted_source_role_contract_sha256": "cb4c52d7162057fe79d176483b8606eae69ef415544ac40e16cd2b0dd1287867",
+      "public_source_role_projection_sha256": "cb4c52d7162057fe79d176483b8606eae69ef415544ac40e16cd2b0dd1287867",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "proposition_3_6_counterexamples_a": {
+      "accepted_source_role_contract_sha256": "64a83a0ae6edbdb2d3cfb6cb84e3bf045734ef9303f62643ff780eff69b02885",
+      "public_source_role_projection_sha256": "64a83a0ae6edbdb2d3cfb6cb84e3bf045734ef9303f62643ff780eff69b02885",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "proposition_3_6_counterexamples_b": {
+      "accepted_source_role_contract_sha256": "64a83a0ae6edbdb2d3cfb6cb84e3bf045734ef9303f62643ff780eff69b02885",
+      "public_source_role_projection_sha256": "64a83a0ae6edbdb2d3cfb6cb84e3bf045734ef9303f62643ff780eff69b02885",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "proposition_3_6_counterexamples_c": {
+      "accepted_source_role_contract_sha256": "7a713420b31af12a5ff75494f9f4a652dc590cb9a03100eda84e01a43f300454",
+      "public_source_role_projection_sha256": "af099bbc53adb478f7e459d0f2a8a7e9655df7177d83b3e36164abfce93a40d1",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "proposition_4_1_stable_point_existence": {
+      "accepted_source_role_contract_sha256": "0c10351149313d7c130b6ec265bbca74393517e72f976c8e3265050d7a23b3d5",
+      "public_source_role_projection_sha256": "a17ce7bc2d37ae2c499fe465ce1f734fbdf74eba3458e5866095075d27808da0",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "proposition_4_2_concave_performative_risk": {
+      "accepted_source_role_contract_sha256": "64a83a0ae6edbdb2d3cfb6cb84e3bf045734ef9303f62643ff780eff69b02885",
+      "public_source_role_projection_sha256": "64a83a0ae6edbdb2d3cfb6cb84e3bf045734ef9303f62643ff780eff69b02885",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem_1_1_informal_overview": {
+      "accepted_source_role_contract_sha256": "eccee30332c79050699ba71291b1e8c5ba2c6ab01e06fd1d40df0b291f7e1aa8",
+      "public_source_role_projection_sha256": "eccee30332c79050699ba71291b1e8c5ba2c6ab01e06fd1d40df0b291f7e1aa8",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem_1_2_informal_overview": {
+      "accepted_source_role_contract_sha256": "eccee30332c79050699ba71291b1e8c5ba2c6ab01e06fd1d40df0b291f7e1aa8",
+      "public_source_role_projection_sha256": "eccee30332c79050699ba71291b1e8c5ba2c6ab01e06fd1d40df0b291f7e1aa8",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem_3_10_finite_sample_retraining_rerm": {
+      "accepted_source_role_contract_sha256": "19c0513a508924a0ba6ed08b40f2b3b1fb62e06a6c3030bf26a7d697088760da",
+      "public_source_role_projection_sha256": "11abaa98e1817620c2bab904c1d700c22fb570b2ab8959e0a74ed6814858e744",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "theorem_3_10_finite_sample_retraining_rgd": {
+      "accepted_source_role_contract_sha256": "1f6fe883034a9afcc78185870b21d528963a57a0f9a07b19e990fda25871ba49",
+      "public_source_role_projection_sha256": "9052afc080dae5811ad338d2c410f685b42179d8afae222105e5e74177b8e096",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "theorem_3_10_rerm_formalized_premises": {
+      "accepted_source_role_contract_sha256": "61ad9a5ad5b1b845313c71351a3643d8937dbc8d7b3c3538cc0c42a4130dff1c",
+      "public_source_role_projection_sha256": "d625e97cac05308062af57a188c89bae526789046d1ed8ab9fa59809b3685cb6",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "theorem_3_10_rgd_formalized_premises": {
+      "accepted_source_role_contract_sha256": "c5e1281d8ede286cd968bf1a8bb8bcbac10233148b7a7bca131198c9cc45bda8",
+      "public_source_role_projection_sha256": "da746894c7831af213d2f4f79970e9a33fd0ce8ea6636aba3911f2460f81d0d3",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "theorem_3_5_repeated_risk_minimization_convergence": {
+      "accepted_source_role_contract_sha256": "e126d7160f5718c97b981ad01e5916c780dd4f61146263d5ed7ac652ce698693",
+      "public_source_role_projection_sha256": "feaa22a043d666976740e77407faeeeb9594be25bec95f3571db9884cecad9c9",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "theorem_3_8_repeated_gradient_descent_convergence": {
+      "accepted_source_role_contract_sha256": "48997c479b80ed3a4b767c97f36ffa11580c40bba361f996c3b4fab669a49cd2",
+      "public_source_role_projection_sha256": "ee5d86257d0ce84529d040ac6eed6804470387737253eeccf3e6796b8caa1640",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "theorem_4_3_data_lipschitz_premise": {
+      "accepted_source_role_contract_sha256": "2d6df3df23dfc6bde6da0073116e6b4bb3a841d86daed6f8b12513f1ec5cfccd",
+      "public_source_role_projection_sha256": "2d6df3df23dfc6bde6da0073116e6b4bb3a841d86daed6f8b12513f1ec5cfccd",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem_4_3_optimum_stable_distance": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    }
+  },
+  "paper": "PZMH20PerformativePrediction",
+  "private_role_material_included": false,
+  "private_source_map_material_sha256": "744a4abfefa6703a15f3b0eb9837efce0e5ed9491e513ca9aafe9105132f16c7",
+  "private_source_map_sha256": "e4950a1d816aff2fcb574a66ba7bb00cbbb1dafce02bbfad09bd96e9a547e008",
+  "projection_contract_sha256": "ed0964edc9c70f5ce087ce9bf134712ca40c7964ecaefd403309ac9a1b47d34d",
+  "public_display_manifest_material_sha256": "c13c4dbec73c942c15e8bce23cb766d2b09d6e18ada77987d9e34115ba18f586",
+  "public_display_manifest_sha256": "e667f712e8ff56ed70a405abc553b62ec9929af5a17b8546fb62a9b7443bf8b5",
+  "public_source_map_material_sha256": "5a05fded19edeae2b6326740b8c4e8bea0efe49f284d3eeca7aecc15714aeaa2",
+  "public_source_map_sha256": "4132fe3a15f0bae85961945d95b5ed394903af38b23068ae452779f7e906f9f3",
+  "raw_private_approval_material_included": false,
+  "schema": 1
+}

--- a/papers/Roth82StableMatching/audit/paper_statement_map.json
+++ b/papers/Roth82StableMatching/audit/paper_statement_map.json
@@ -2970,6 +2970,11 @@
     "Roth82StableMatching.PaperInterface.sourceWomenOptimal": "side_optimal_stable_outcome_definition",
     "Roth82StableMatching.PaperInterface.truthfulForAllAgents": "dominant_truthfulness_definition"
   },
+  "publication_source_display_projection": {
+    "manifest": "audit/public_source_display_projection.json",
+    "raw_source_bytes_included": false,
+    "schema": 1
+  },
   "schema": 1,
   "semantic_contract_schema": 1,
   "semantic_route_schema": 2,

--- a/papers/Roth82StableMatching/audit/public_source_role_projection.json
+++ b/papers/Roth82StableMatching/audit/public_source_role_projection.json
@@ -1,0 +1,143 @@
+{
+  "acceptance_credential": false,
+  "accepted_graph_sha256": "2094832b9c3f8a7f6c942d7b0d68ff6f3186b97882d3d7e9d85881c0cf6b05d6",
+  "bindings_by_source_item": {
+    "complete_marriage_outcome_definition": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "corollary5_1": {
+      "accepted_source_role_contract_sha256": "f4254796949514af697b1a57a525740c36a37b17d9eafef0da4f0bb27d637328",
+      "public_source_role_projection_sha256": "f4254796949514af697b1a57a525740c36a37b17d9eafef0da4f0bb27d637328",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "dominant_truthfulness_definition": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "efficient_matching_procedure_definition": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "general_quota_outcome_definition": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lemma1": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lemma2": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "marriage_model_definition": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "matching_procedure_definition": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "preference_profile_definition": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "side_optimal_stable_outcome_definition": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "simple_misrepresentation_definition": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "stable_marriage_definition": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "stable_matching_procedure_definition": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem1": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem2": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem3": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem4": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem5": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem6": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem7": {
+      "accepted_source_role_contract_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "public_source_role_projection_sha256": "500c1615c64b9ebcf5237eb58b1273b7bf3ef43257fa5173f1e1fcc34155c286",
+      "schema": 1,
+      "withheld_field_paths": []
+    }
+  },
+  "paper": "Roth82StableMatching",
+  "private_role_material_included": false,
+  "private_source_map_material_sha256": "f453b13f5ea0bc21dbdc589181984d4575147ea0a392ce980fd5bc0f989b489c",
+  "private_source_map_sha256": "6ad732dca092d4a50d55c1ea99045fc046ee34cd2d4033daac06b231af7381a0",
+  "projection_contract_sha256": "ed0964edc9c70f5ce087ce9bf134712ca40c7964ecaefd403309ac9a1b47d34d",
+  "public_display_manifest_material_sha256": "8a64b9d83f04f1ffd82e54c55be87e8f4b919b4db0de87c41ad35a5874578c51",
+  "public_display_manifest_sha256": "b55755b66467e4156a8dcf6987738ffc50917f2a7e0acd9a82e8055b738d7cdf",
+  "public_source_map_material_sha256": "5e94080351840f3e0879c35061a601bafb1dddc03f0db0751046ee9f57652eab",
+  "public_source_map_sha256": "1bfa0c60583a6681c3411b2fa0ebfd11c79a6eefb1870e6be14e709b4837fd00",
+  "raw_private_approval_material_included": false,
+  "schema": 1
+}

--- a/papers/SeshadriUgander2020IIATesting/audit/paper_statement_map.json
+++ b/papers/SeshadriUgander2020IIATesting/audit/paper_statement_map.json
@@ -1254,6 +1254,11 @@
     "approval_material_included": false,
     "schema": 1
   },
+  "publication_source_display_projection": {
+    "manifest": "audit/public_source_display_projection.json",
+    "raw_source_bytes_included": false,
+    "schema": 1
+  },
   "schema": 1,
   "semantic_contract_schema": 1,
   "semantic_route_schema": 2,

--- a/papers/SeshadriUgander2020IIATesting/audit/public_source_role_projection.json
+++ b/papers/SeshadriUgander2020IIATesting/audit/public_source_role_projection.json
@@ -1,0 +1,140 @@
+{
+  "acceptance_credential": false,
+  "accepted_graph_sha256": "46e2a405b91ed221211c556608a88fddd5aaf99933d9a612896c94776533bd7e",
+  "bindings_by_source_item": {
+    "balanced_perturbation_model": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "choice_system_model": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "comparison_graph_eulerian_model": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "corollary1_global_lower_bound": {
+      "accepted_source_role_contract_sha256": "fd2a3ce75474cfa630621069a073618cb66de916a605f88c24de4067db775e43",
+      "public_source_role_projection_sha256": "7db041e700896e0fab853f86265640402731230b85fe02c944b98aacd359b4b9",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "corollary_all_even_subsets": {
+      "accepted_source_role_contract_sha256": "bebcf4b0a26506887dc3160d56f8c8067b4defc90f9670e61505940090f4fbae",
+      "public_source_role_projection_sha256": "1868f38851df811012f06e461c6177bb826a46918489e7425d38c41cec83f2f6",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "cycle_decomposition_model": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "fact_convex_hull_dense": {
+      "accepted_source_role_contract_sha256": "ff5a0e099e16c780ec0c807bad8030a1474e5e84b20ee9670ac2ec27355bdb21",
+      "public_source_role_projection_sha256": "ff5a0e099e16c780ec0c807bad8030a1474e5e84b20ee9670ac2ec27355bdb21",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "fact_max_entropy": {
+      "accepted_source_role_contract_sha256": "ff5a0e099e16c780ec0c807bad8030a1474e5e84b20ee9670ac2ec27355bdb21",
+      "public_source_role_projection_sha256": "ff5a0e099e16c780ec0c807bad8030a1474e5e84b20ee9670ac2ec27355bdb21",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "iia_model": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lemma2_separation": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lemma3_chi_square": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lemma4_cycle_chi_square": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lemma_bipartite_cycle_decomposition": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "lemma_comparison_incidence_decomposition": {
+      "accepted_source_role_contract_sha256": "7a58ec9465a9319bfba685a22ff75894dcec54a8f36a8bb9f06b3abc0db3bc0f",
+      "public_source_role_projection_sha256": "443374421ceb66a1dcb728e44ae7eb8d83dd9b0127fe08d2158c597152be9bf0",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    },
+    "lemma_general_cycle_decomposition": {
+      "accepted_source_role_contract_sha256": "050f6a661d7a7ee932a20c24bb17d4233dcbde0e3ad731199b2d7e21f0f61d72",
+      "public_source_role_projection_sha256": "6e6caabb52f3933366d462407dbe1db8838c6e6050c65b2785c360fe4b4552aa",
+      "schema": 1,
+      "withheld_field_paths": [
+        "user_approved_scope_exclusion.approval_reference",
+        "user_approved_scope_exclusion.source_locator"
+      ]
+    },
+    "lemma_iia_invariance": {
+      "accepted_source_role_contract_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "public_source_role_projection_sha256": "c09b92ec6ce609fc3a6f3c5dd73a42330a857021aaefb024976859ada081a856",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "separation_testing_model": {
+      "accepted_source_role_contract_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "public_source_role_projection_sha256": "7ca175ba7da33ed8ed359a60a17c7d9c9f405eaffd0c09c865b32e97af9a9952",
+      "schema": 1,
+      "withheld_field_paths": []
+    },
+    "theorem1_lower_bound": {
+      "accepted_source_role_contract_sha256": "73d50b05b283811929e203b49643b505d1645762a41686e2125d8a9598adb7ad",
+      "public_source_role_projection_sha256": "ba79e6fdfa8741359af26a796b21bf90867232b8e5f817ae0156396eaf6367da",
+      "schema": 1,
+      "withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator"
+      ]
+    }
+  },
+  "paper": "SeshadriUgander2020IIATesting",
+  "private_role_material_included": false,
+  "private_source_map_material_sha256": "24fb1dff30e3eef2f4ba05f3150c94ef4d6f80dd0accecb93d79bac404045efd",
+  "private_source_map_sha256": "323e93a255ebc1b4c1dcd663f392101979c599bbddd7f10d166fc00245cdeb4f",
+  "projection_contract_sha256": "ed0964edc9c70f5ce087ce9bf134712ca40c7964ecaefd403309ac9a1b47d34d",
+  "public_display_manifest_material_sha256": "7a553469ed49bab97f939b8c22207d3fe0e3880fbab48f9e095cc458e15059ce",
+  "public_display_manifest_sha256": "5854fca4bc5a5318fd6ca3e3bc2eed51a6fd7c6b7f0a0a346c7ec32d1a9a2b0b",
+  "public_source_map_material_sha256": "736ef85ce5830a0cf7955c0a49621307d369c377e6114f58b9474742dc74223d",
+  "public_source_map_sha256": "1491b7ec0892d5899bab467de11ae9f3316cd90a8f39d33148f62f9871518dd8",
+  "raw_private_approval_material_included": false,
+  "schema": 1
+}

--- a/scripts/public_release_artifact_policy.py
+++ b/scripts/public_release_artifact_policy.py
@@ -22,6 +22,7 @@ _CANONICAL_AUDIT_FILENAMES = frozenset(
         "paper_coverage_llm.json",
         "paper_statement_map.json",
         "public_source_display_projection.json",
+        "public_source_role_projection.json",
         "review_surface_llm.json",
         "source_proof_fidelity.json",
         "source_record_audit.json",

--- a/scripts/public_release_candidate_guard.py
+++ b/scripts/public_release_candidate_guard.py
@@ -65,6 +65,22 @@ try:
 except ModuleNotFoundError:  # pragma: no cover - module-style import.
     from scripts.public_release_artifact_policy import public_release_artifact_issues
 try:
+    from public_source_role_projection import (
+        PUBLIC_SOURCE_ROLE_PROJECTION_FILE,
+        PublicSourceRoleProjectionError,
+        accepted_source_role_sha256s_by_source_item,
+        validate_public_source_role_projection_envelope,
+        validate_runtime_public_source_role_projection,
+    )
+except ModuleNotFoundError:  # pragma: no cover - module-style import.
+    from scripts.public_source_role_projection import (
+        PUBLIC_SOURCE_ROLE_PROJECTION_FILE,
+        PublicSourceRoleProjectionError,
+        accepted_source_role_sha256s_by_source_item,
+        validate_public_source_role_projection_envelope,
+        validate_runtime_public_source_role_projection,
+    )
+try:
     from public_release_projection import (
         PUBLIC_CONTRIBUTOR_WORKFLOW_PATHS,
         PUBLIC_CORRECTED_TARGET_PROJECTION_FIELD,
@@ -1463,13 +1479,18 @@ def public_source_display_projection_issues(
         if map_payload is None or map_bytes is None:
             continue
         marker = map_payload.get(PUBLIC_SOURCE_DISPLAY_PROJECTION_FIELD)
+        paper_dir = PurePosixPath(map_path).parents[1]
+        expected_manifest = str(paper_dir / PUBLIC_SOURCE_DISPLAY_PROJECTION_MANIFEST)
         if marker is None:
+            if expected_manifest in candidate_paths:
+                issues.append(
+                    f"{map_path}: saved public display manifest requires the exact "
+                    "display-projection marker"
+                )
             continue
         if not isinstance(marker, dict):
             issues.append(f"{map_path}: public display-projection marker must be an object")
             continue
-        paper_dir = PurePosixPath(map_path).parents[1]
-        expected_manifest = str(paper_dir / PUBLIC_SOURCE_DISPLAY_PROJECTION_MANIFEST)
         if marker.get("schema") != PUBLIC_SOURCE_DISPLAY_PROJECTION_SCHEMA:
             issues.append(f"{map_path}: public display-projection marker has the wrong schema")
         if marker.get("manifest") != PUBLIC_SOURCE_DISPLAY_PROJECTION_MANIFEST:
@@ -1912,6 +1933,231 @@ def _public_artifact_string_issues(
             continue
         if pattern.search(scan_value):
             issues.append((".".join(route) or "$", label))
+    return issues
+
+
+def _accepted_source_role_material(
+    repo: Path,
+    candidate_ref: str,
+    paper: str,
+) -> tuple[str, dict[str, str], bytes, bytes, str]:
+    """Load exact selected graph bytes and their validated source-role index."""
+
+    try:
+        from scripts.obligation_evidence_graph import build_obligation_graph
+        from scripts.obligation_evidence_store import (
+            load_recorded_current_accepted_obligation_graph,
+        )
+        from scripts.obligation_paper_index import validate_paper_obligation_index
+    except ModuleNotFoundError:  # pragma: no cover - direct-script support.
+        from obligation_evidence_graph import build_obligation_graph
+        from obligation_evidence_store import (
+            load_recorded_current_accepted_obligation_graph,
+        )
+        from obligation_paper_index import validate_paper_obligation_index
+
+    base = f"papers/{paper}/audit/obligation_evidence"
+    pointer_path = f"{base}/current_accepted_graph.json"
+    pointer_bytes = _git_bytes(repo, ["show", f"{candidate_ref}:{pointer_path}"])
+    try:
+        pointer = json.loads(pointer_bytes)
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError("selected accepted-graph pointer is not valid JSON") from exc
+    graph_sha256 = pointer.get("graph_sha256") if isinstance(pointer, dict) else None
+    if (
+        not isinstance(pointer, dict)
+        or set(pointer) != {"schema", "graph_sha256"}
+        or pointer.get("schema") != 2
+        or not isinstance(graph_sha256, str)
+        or not SHA256_RE.fullmatch(graph_sha256)
+    ):
+        raise ValueError("selected accepted-graph pointer is malformed")
+    pack_path = (
+        f"{base}/accepted_graphs/sha256/{graph_sha256[:2]}/{graph_sha256}.json"
+    )
+    pack_bytes = _git_bytes(repo, ["show", f"{candidate_ref}:{pack_path}"])
+    try:
+        packed = json.loads(pack_bytes)
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError("selected packed accepted graph is not valid JSON") from exc
+    if not isinstance(packed, dict):
+        raise ValueError("selected packed accepted graph is malformed")
+
+    # Reuse the store owner for canonical pointer, graph, leaf, and pack
+    # validation. The temporary tree contains only the exact candidate blobs.
+    with tempfile.TemporaryDirectory(prefix="public-role-accepted-graph-") as temporary:
+        snapshot = Path(temporary)
+        for path, raw in ((pointer_path, pointer_bytes), (pack_path, pack_bytes)):
+            destination = snapshot / path
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            destination.write_bytes(raw)
+        accepted = load_recorded_current_accepted_obligation_graph(
+            snapshot, paper, graph_sha256
+        )
+
+    if accepted.graph_sha256 != graph_sha256 or len(accepted.root_leaf_sha256s) != 1:
+        raise ValueError("selected accepted graph identity or root is malformed")
+    closure = accepted.leaves[accepted.root_leaf_sha256s[0]]
+    semantic = build_obligation_graph(
+        (
+            leaf
+            for digest, leaf in accepted.leaves.items()
+            if digest != closure.leaf_sha256
+        ),
+        root_leaf_sha256s=closure.depends_on,
+    )
+    if closure.semantic_payload.get("semantic_graph_sha256") != semantic.graph_sha256:
+        raise ValueError("selected closure binds a different semantic graph")
+    paper_index = validate_paper_obligation_index(
+        packed.get("paper_index"),
+        graph=semantic,
+        require_complete=True,
+        preflight=None,
+        require_current_aggregate_identity=False,
+    )
+    if closure.semantic_payload.get("paper_index_sha256") != paper_index.index_sha256:
+        raise ValueError("selected closure binds a different paper index")
+    roles = accepted_source_role_sha256s_by_source_item(accepted, paper_index)
+    return graph_sha256, roles, pointer_bytes, pack_bytes, pack_path
+
+
+def public_source_role_projection_issues(
+    candidate_repo: Path,
+    candidate_ref: str,
+    entries: list[AllowlistEntry],
+    *,
+    private_repo: Path,
+    public_base_ref: str | None = PUBLIC_BASE_REF,
+) -> list[str]:
+    """Validate guard-issued role bridges or exact trusted-base carryforward."""
+
+    candidate_paths = set(
+        _git(candidate_repo, ["ls-tree", "-r", "--name-only", candidate_ref]).splitlines()
+    )
+    manifest_paths = sorted(
+        path
+        for path in candidate_paths
+        if len(PurePosixPath(path).parts) == 4
+        and PurePosixPath(path).parts[0] == "papers"
+        and PurePosixPath(path).parts[2:] == (
+            "audit",
+            "public_source_display_projection.json",
+        )
+    )
+    issues: list[str] = []
+    for manifest_path in manifest_paths:
+        paper = PurePosixPath(manifest_path).parts[1]
+        prefix = f"papers/{paper}/audit"
+        map_path = f"{prefix}/paper_statement_map.json"
+        envelope_path = f"{prefix}/{PurePosixPath(PUBLIC_SOURCE_ROLE_PROJECTION_FILE).name}"
+        missing = [
+            path for path in (map_path, envelope_path) if path not in candidate_paths
+        ]
+        if missing:
+            issues.append(
+                f"{manifest_path}: public source-role projection is incomplete; missing "
+                + ", ".join(missing)
+            )
+            continue
+        try:
+            map_bytes = _git_bytes(
+                candidate_repo, ["show", f"{candidate_ref}:{map_path}"]
+            )
+            manifest_bytes = _git_bytes(
+                candidate_repo, ["show", f"{candidate_ref}:{manifest_path}"]
+            )
+            envelope_bytes = _git_bytes(
+                candidate_repo, ["show", f"{candidate_ref}:{envelope_path}"]
+            )
+            (
+                graph_sha256,
+                accepted_roles,
+                pointer_bytes,
+                pack_bytes,
+                pack_path,
+            ) = _accepted_source_role_material(candidate_repo, candidate_ref, paper)
+        except (RuntimeError, ValueError, PublicSourceRoleProjectionError) as exc:
+            issues.append(
+                f"{envelope_path}: cannot load accepted public source-role inputs: {exc}"
+            )
+            continue
+
+        unchanged_from_base = False
+        if public_base_ref is not None:
+            try:
+                unchanged_from_base = all(
+                    _git_bytes(candidate_repo, ["show", f"{public_base_ref}:{path}"])
+                    == raw
+                    for path, raw in (
+                        (map_path, map_bytes),
+                        (manifest_path, manifest_bytes),
+                        (envelope_path, envelope_bytes),
+                    )
+                )
+            except RuntimeError:
+                unchanged_from_base = False
+
+        try:
+            if unchanged_from_base:
+                validate_runtime_public_source_role_projection(
+                    trusted_envelope_bytes=envelope_bytes,
+                    paper=paper,
+                    public_source_map_bytes=map_bytes,
+                    public_display_manifest_bytes=manifest_bytes,
+                    accepted_graph_sha256=graph_sha256,
+                    accepted_role_sha256s_by_source_item=accepted_roles,
+                )
+                continue
+
+            entry = matching_allowlist_entry(map_path, entries)
+            if (
+                entry is None
+                or entry.provenance != "private_projection"
+                or entry.source_commit is None
+            ):
+                raise PublicSourceRoleProjectionError(
+                    "new or changed role projection requires the source map's exact "
+                    "private_projection allowlist provenance"
+                )
+            private_map_bytes = _git_bytes(
+                private_repo, ["show", f"{entry.source_commit}:{map_path}"]
+            )
+            if (
+                _sha256_bytes(private_map_bytes) != entry.private_source_blob_sha256
+                or _sha256_bytes(map_bytes) != entry.candidate_blob_sha256
+            ):
+                raise PublicSourceRoleProjectionError(
+                    "source map bytes do not match private_projection allowlist digests"
+                )
+            private_pointer_bytes = _git_bytes(
+                private_repo,
+                [
+                    "show",
+                    f"{entry.source_commit}:papers/{paper}/audit/obligation_evidence/"
+                    "current_accepted_graph.json",
+                ],
+            )
+            private_pack_bytes = _git_bytes(
+                private_repo, ["show", f"{entry.source_commit}:{pack_path}"]
+            )
+            if (
+                private_pointer_bytes != pointer_bytes
+                or private_pack_bytes != pack_bytes
+            ):
+                raise PublicSourceRoleProjectionError(
+                    "selected accepted graph differs from the pinned private source commit"
+                )
+            validate_public_source_role_projection_envelope(
+                envelope_bytes,
+                paper=paper,
+                private_source_map_bytes=private_map_bytes,
+                public_source_map_bytes=map_bytes,
+                public_display_manifest_bytes=manifest_bytes,
+                accepted_graph_sha256=graph_sha256,
+                accepted_role_sha256s_by_source_item=accepted_roles,
+            )
+        except (RuntimeError, ValueError, PublicSourceRoleProjectionError) as exc:
+            issues.append(f"{envelope_path}: {exc}")
     return issues
 
 
@@ -2649,6 +2895,19 @@ def candidate_public_artifact_policy_issues(
         repo,
         candidate_ref,
         candidate_paths,
+    )
+    # This exact non-accepting envelope is validated independently against the
+    # selected accepted graph, display manifest, public map, and pinned private
+    # projection. It is the only new audit filename admitted by this guard.
+    current_audit_artifacts.update(
+        path
+        for path in candidate_paths
+        if len(PurePosixPath(path).parts) == 4
+        and PurePosixPath(path).parts[0] == "papers"
+        and PurePosixPath(path).parts[2:] == (
+            "audit",
+            PurePosixPath(PUBLIC_SOURCE_ROLE_PROJECTION_FILE).name,
+        )
     )
     receipt_ledgers, receipt_issues = _candidate_receipt_review_ledgers(
         repo,
@@ -3581,6 +3840,15 @@ def run_guard(
             candidate_commit,
             entries,
             private_repo=private_repo,
+        )
+    )
+    issues.extend(
+        public_source_role_projection_issues(
+            repo,
+            candidate_commit,
+            entries,
+            private_repo=private_repo,
+            public_base_ref=public_base_commit,
         )
     )
     issues.extend(forbidden_candidate_path_issues(repo, candidate_commit))

--- a/scripts/public_source_role_projection.py
+++ b/scripts/public_source_role_projection.py
@@ -1,0 +1,681 @@
+#!/usr/bin/env python3
+"""Authenticate deterministic public projections of accepted source roles.
+
+The accepted obligation graph binds the private source-role digest.  A public
+source map may deliberately withhold the approval reference and local source
+locator for a user-approved scope exclusion, or the approval object for a
+corrected target.  Those bounded transformations change the role digest even
+though the reviewed role did not change.
+
+This module builds a non-accepting bridge from an exact private map, its exact
+public projection, the selected accepted graph identity, and the accepted role
+digests.  It never treats an envelope's own content hash as authority.  The
+private release guard must authenticate issuance, and a public caller must
+supply envelope bytes obtained from its independently authenticated canonical
+Git tree.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Iterable, Mapping, Sequence
+from typing import Any
+
+try:
+    from scripts.corrected_target_identity import (
+        CORRECTED_TARGET_RECORD_SHA256_FIELD,
+        CORRECTED_TARGET_REVIEW_SHA256_FIELD,
+    )
+    from scripts.obligation_evidence_projection import _source_role_contract
+    from scripts.portable_evidence_identity import portable_evidence_sha256
+except ModuleNotFoundError:  # pragma: no cover - direct-script import support.
+    from corrected_target_identity import (
+        CORRECTED_TARGET_RECORD_SHA256_FIELD,
+        CORRECTED_TARGET_REVIEW_SHA256_FIELD,
+    )
+    from obligation_evidence_projection import _source_role_contract
+    from portable_evidence_identity import portable_evidence_sha256
+
+
+PUBLIC_SOURCE_ROLE_PROJECTION_FILE = "audit/public_source_role_projection.json"
+PUBLIC_SOURCE_ROLE_PROJECTION_SCHEMA = 1
+PUBLIC_SOURCE_ROLE_PROJECTION_BINDING_SCHEMA = 1
+# Keep these wire-format values local so the terminal reader does not import a
+# release CLI or display renderer. Focused parity tests pin them to the owner
+# modules used by the private release guard.
+PUBLIC_SOURCE_DISPLAY_PROJECTION_FIELD = "publication_source_display_projection"
+PUBLIC_SOURCE_DISPLAY_PROJECTION_SCHEMA = 1
+PUBLIC_SOURCE_DISPLAY_PROJECTION_MANIFEST = "audit/public_source_display_projection.json"
+PUBLIC_SOURCE_DISPLAY_PROJECTION_GENERATOR = (
+    "python3 scripts/public_source_display_projection.py"
+)
+PUBLIC_CORRECTED_TARGET_PROJECTION_FIELD = "publication_corrected_target_projection"
+PUBLIC_SOURCE_ROLE_PROJECTION_CONTRACT = {
+    "schema": 1,
+    "private_role_identity": "accepted_source_role_contract_sha256",
+    "public_role_identity": "all_public_visible_source_role_fields_v1",
+    "public_map_projection": "scripts.public_release_projection.project_bytes",
+    "allowed_withheld_field_paths": [
+        "corrected_target.approval",
+        "corrected_target.archival_source_locator",
+        "user_approved_scope_exclusion.approval_reference",
+        "user_approved_scope_exclusion.source_evidence",
+        "user_approved_scope_exclusion.source_locator",
+    ],
+    "rule": (
+        "The exact public map is the deterministic marker-bearing projection of "
+        "the exact private map. Every accepted private role digest must match the "
+        "private item. The public digest covers every retained public role field."
+    ),
+}
+PUBLIC_SOURCE_ROLE_PROJECTION_CONTRACT_SHA256 = portable_evidence_sha256(
+    PUBLIC_SOURCE_ROLE_PROJECTION_CONTRACT
+)
+
+_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+_PAPER_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]*$")
+_ROLE_FIELDS = (
+    "source_kind",
+    "claim_bearing",
+    "coverage_status",
+    "inventory_role",
+    "protocol_role",
+    "source_scope_classification",
+    "user_approved_scope_exclusion",
+    "scope_disposition",
+)
+_SCOPE_REDACTION_FIELDS = frozenset(
+    {"approval_reference", "source_evidence", "source_locator"}
+)
+
+
+class PublicSourceRoleProjectionError(ValueError):
+    """A source-role bridge is malformed, stale, or unauthenticated."""
+
+
+def accepted_source_role_sha256s_by_source_item(
+    accepted_graph: object,
+    paper_index: object,
+) -> dict[str, str]:
+    """Project unique accepted role digests from validated graph/index objects."""
+
+    leaves = getattr(accepted_graph, "leaves", None)
+    routes = getattr(paper_index, "route_leaf_sha256s_by_source_item", None)
+    if not isinstance(leaves, Mapping) or not isinstance(routes, Mapping):
+        raise PublicSourceRoleProjectionError(
+            "accepted graph and paper index do not expose source-route material"
+        )
+    result: dict[str, str] = {}
+    for raw_item_id, raw_roles in routes.items():
+        item_id = str(raw_item_id or "").strip()
+        if not item_id or not isinstance(raw_roles, Mapping):
+            raise PublicSourceRoleProjectionError("accepted source route is malformed")
+        atom_digests = raw_roles.get("source_atom")
+        if not isinstance(atom_digests, Sequence) or isinstance(
+            atom_digests, (str, bytes)
+        ) or not atom_digests:
+            raise PublicSourceRoleProjectionError(
+                f"accepted source item {item_id!r} has no source atoms"
+            )
+        role_digests: set[str] = set()
+        for leaf_digest in atom_digests:
+            leaf = leaves.get(str(leaf_digest))
+            payload = getattr(leaf, "semantic_payload", None)
+            if not isinstance(payload, Mapping):
+                raise PublicSourceRoleProjectionError(
+                    f"accepted source item {item_id!r} names a missing source atom"
+                )
+            role_digests.add(
+                _sha256(
+                    payload.get("source_role_contract_sha256"),
+                    f"accepted source item {item_id!r} role",
+                )
+            )
+        if len(role_digests) != 1:
+            raise PublicSourceRoleProjectionError(
+                f"accepted source item {item_id!r} has inconsistent role digests"
+            )
+        result[item_id] = next(iter(role_digests))
+    if not result:
+        raise PublicSourceRoleProjectionError("accepted graph has no source routes")
+    return result
+
+
+def _sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def _sha256(value: object, label: str) -> str:
+    digest = str(value or "").strip().lower()
+    if not _SHA256_RE.fullmatch(digest):
+        raise PublicSourceRoleProjectionError(f"{label} must be a lowercase SHA-256")
+    return digest
+
+
+def _paper(value: object) -> str:
+    paper = str(value or "").strip()
+    if not _PAPER_RE.fullmatch(paper):
+        raise PublicSourceRoleProjectionError("paper must be one canonical paper ID")
+    return paper
+
+
+def _json_object(raw: bytes, label: str) -> dict[str, Any]:
+    if not isinstance(raw, bytes):
+        raise PublicSourceRoleProjectionError(f"{label} bytes are required")
+    try:
+        value = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise PublicSourceRoleProjectionError(f"{label} is not valid UTF-8 JSON: {exc}") from exc
+    if not isinstance(value, dict):
+        raise PublicSourceRoleProjectionError(f"{label} must be a JSON object")
+    return value
+
+
+def _material_sha256(label: str, value: Mapping[str, Any]) -> str:
+    return portable_evidence_sha256({"schema": 1, label: value})
+
+
+def _items(source_map: Mapping[str, Any], *, label: str) -> Mapping[str, Any]:
+    items = source_map.get("items")
+    if not isinstance(items, Mapping):
+        raise PublicSourceRoleProjectionError(f"{label} items must be an object")
+    if any(not isinstance(key, str) or not key for key in items):
+        raise PublicSourceRoleProjectionError(f"{label} has an invalid source-item ID")
+    return items
+
+
+def _accepted_roles(
+    values: Mapping[str, str | Iterable[str]],
+) -> dict[str, str]:
+    result: dict[str, str] = {}
+    for raw_item_id, raw_value in values.items():
+        if not isinstance(raw_item_id, str) or not raw_item_id:
+            raise PublicSourceRoleProjectionError(
+                "accepted source-role map has an invalid source-item ID"
+            )
+        candidates: list[object]
+        if isinstance(raw_value, str):
+            candidates = [raw_value]
+        elif isinstance(raw_value, Iterable):
+            candidates = list(raw_value)
+        else:
+            raise PublicSourceRoleProjectionError(
+                f"accepted source item {raw_item_id!r} has no role digest"
+            )
+        digests = {
+            _sha256(value, f"accepted source item {raw_item_id!r} role")
+            for value in candidates
+        }
+        if len(digests) != 1:
+            raise PublicSourceRoleProjectionError(
+                f"accepted source item {raw_item_id!r} does not have one role digest"
+            )
+        result[raw_item_id] = next(iter(digests))
+    if not result:
+        raise PublicSourceRoleProjectionError("accepted source-role map is empty")
+    return result
+
+
+def _role_projection(item: Mapping[str, Any], *, public: bool) -> dict[str, Any]:
+    projection = {field: item[field] for field in _ROLE_FIELDS if field in item}
+    target = item.get("corrected_target")
+    if target is None:
+        return projection
+    if not isinstance(target, Mapping):
+        raise PublicSourceRoleProjectionError("corrected_target must be an object")
+    if not public:
+        # The canonical private projector performs the complete private schema
+        # validation. This branch exists only for typed difference inspection.
+        projection["corrected_target"] = dict(target)
+        return projection
+    if "approval" in target:
+        raise PublicSourceRoleProjectionError(
+            "public corrected_target retains private approval material"
+        )
+    _sha256(
+        target.get(CORRECTED_TARGET_RECORD_SHA256_FIELD),
+        f"public corrected_target {CORRECTED_TARGET_RECORD_SHA256_FIELD}",
+    )
+    _sha256(
+        target.get(CORRECTED_TARGET_REVIEW_SHA256_FIELD),
+        f"public corrected_target {CORRECTED_TARGET_REVIEW_SHA256_FIELD}",
+    )
+    # Cover the complete retained corrected-target object, not merely the
+    # mathematical statement, so status/basis/defect metadata cannot drift.
+    projection["corrected_target_public_projection"] = dict(target)
+    return projection
+
+
+def public_source_role_projection_sha256(item: Mapping[str, Any]) -> str:
+    """Hash every role field retained in one public source-map item."""
+
+    if not isinstance(item, Mapping):
+        raise PublicSourceRoleProjectionError("public source item must be an object")
+    if item.get("corrected_target") is None:
+        try:
+            return _source_role_contract(item)
+        except Exception as exc:
+            raise PublicSourceRoleProjectionError(str(exc)) from exc
+    return portable_evidence_sha256(
+        {"schema": 1, "public_source_role": _role_projection(item, public=True)}
+    )
+
+
+def _changed_scope_paths(
+    private_item: Mapping[str, Any], public_item: Mapping[str, Any]
+) -> list[str]:
+    private_scope = private_item.get("user_approved_scope_exclusion")
+    public_scope = public_item.get("user_approved_scope_exclusion")
+    if private_scope == public_scope:
+        return []
+    if not isinstance(private_scope, Mapping) or not isinstance(public_scope, Mapping):
+        raise PublicSourceRoleProjectionError(
+            "projected user_approved_scope_exclusion is not an object"
+        )
+    if set(private_scope) != set(public_scope):
+        raise PublicSourceRoleProjectionError(
+            "public projection changed scope-exclusion fields"
+        )
+    changed = {
+        key for key in private_scope if private_scope.get(key) != public_scope.get(key)
+    }
+    if not changed or not changed.issubset(_SCOPE_REDACTION_FIELDS):
+        raise PublicSourceRoleProjectionError(
+            "public projection changed a non-withheld scope-exclusion field"
+        )
+    return [f"user_approved_scope_exclusion.{key}" for key in sorted(changed)]
+
+
+def _withheld_field_paths(
+    private_item: Mapping[str, Any], public_item: Mapping[str, Any]
+) -> tuple[str, ...]:
+    paths = _changed_scope_paths(private_item, public_item)
+    private_target = private_item.get("corrected_target")
+    public_target = public_item.get("corrected_target")
+    if private_target is None and public_target is None:
+        return tuple(paths)
+    if not isinstance(private_target, Mapping) or not isinstance(public_target, Mapping):
+        raise PublicSourceRoleProjectionError(
+            "private and public corrected_target records must both be objects"
+        )
+    if "approval" not in private_target or "approval" in public_target:
+        raise PublicSourceRoleProjectionError(
+            "corrected-target projection has the wrong approval boundary"
+        )
+    expected_public_target = {
+        key: value for key, value in private_target.items() if key != "approval"
+    }
+    if set(public_target) != set(expected_public_target):
+        raise PublicSourceRoleProjectionError(
+            "public corrected_target changed retained fields"
+        )
+    changed_target_fields = {
+        key
+        for key in expected_public_target
+        if public_target.get(key) != expected_public_target.get(key)
+    }
+    if not changed_target_fields.issubset({"archival_source_locator"}):
+        raise PublicSourceRoleProjectionError(
+            "public corrected_target changed a non-withheld retained field"
+        )
+    if "archival_source_locator" in changed_target_fields:
+        paths.append("corrected_target.archival_source_locator")
+    paths.append("corrected_target.approval")
+    return tuple(sorted(paths))
+
+
+def _validate_public_map_and_display(
+    *,
+    paper: str,
+    public_source_map: Mapping[str, Any],
+    public_source_map_bytes: bytes,
+    public_display_manifest: Mapping[str, Any],
+    public_display_manifest_bytes: bytes,
+    private_source_map_bytes: bytes | None,
+) -> None:
+    if public_source_map.get("paper") != paper:
+        raise PublicSourceRoleProjectionError("public source map belongs to another paper")
+    marker = public_source_map.get(PUBLIC_SOURCE_DISPLAY_PROJECTION_FIELD)
+    expected_marker = {
+        "schema": PUBLIC_SOURCE_DISPLAY_PROJECTION_SCHEMA,
+        "manifest": PUBLIC_SOURCE_DISPLAY_PROJECTION_MANIFEST,
+        "raw_source_bytes_included": False,
+    }
+    if marker != expected_marker:
+        raise PublicSourceRoleProjectionError(
+            "public source map lacks the exact display-projection marker"
+        )
+    if public_source_map.get(PUBLIC_CORRECTED_TARGET_PROJECTION_FIELD) not in (
+        None,
+        {"schema": 1, "approval_material_included": False},
+    ):
+        raise PublicSourceRoleProjectionError(
+            "public corrected-target projection marker is malformed"
+        )
+    expected_path = f"papers/{paper}/{PUBLIC_SOURCE_DISPLAY_PROJECTION_MANIFEST}"
+    checks = {
+        "schema": PUBLIC_SOURCE_DISPLAY_PROJECTION_SCHEMA,
+        "generator": PUBLIC_SOURCE_DISPLAY_PROJECTION_GENERATOR,
+        "paper_id": paper,
+        "public_manifest_path": expected_path,
+        "public_source_map_sha256": _sha256_bytes(public_source_map_bytes),
+    }
+    for field, expected in checks.items():
+        if public_display_manifest.get(field) != expected:
+            raise PublicSourceRoleProjectionError(
+                f"public display manifest {field} does not match current public material"
+            )
+    if private_source_map_bytes is not None and public_display_manifest.get(
+        "private_source_map_sha256"
+    ) != _sha256_bytes(private_source_map_bytes):
+        raise PublicSourceRoleProjectionError(
+            "public display manifest private_source_map_sha256 does not match private map"
+        )
+    if public_display_manifest.get("raw_source_artifact_included") is not False:
+        raise PublicSourceRoleProjectionError(
+            "public display manifest does not declare raw_source_artifact_included=false"
+        )
+    # The bytes argument is intentional: callers authenticate and pin the exact
+    # committed manifest blob, while the material digest below also makes the
+    # parsed-object convention explicit.
+    if not public_display_manifest_bytes:
+        raise PublicSourceRoleProjectionError("public display manifest bytes are empty")
+
+
+def build_public_source_role_projection_envelope(
+    *,
+    paper: str,
+    private_source_map_bytes: bytes,
+    public_source_map_bytes: bytes,
+    public_display_manifest_bytes: bytes,
+    accepted_graph_sha256: str,
+    accepted_role_sha256s_by_source_item: Mapping[str, str | Iterable[str]],
+) -> dict[str, Any]:
+    """Build one guard-issued bridge from exact private and public material."""
+
+    paper = _paper(paper)
+    graph_sha256 = _sha256(accepted_graph_sha256, "accepted graph")
+    private_map = _json_object(private_source_map_bytes, "private source map")
+    public_map = _json_object(public_source_map_bytes, "public source map")
+    display = _json_object(public_display_manifest_bytes, "public display manifest")
+    if private_map.get("paper") != paper:
+        raise PublicSourceRoleProjectionError("private source map belongs to another paper")
+    expected_path = f"papers/{paper}/audit/paper_statement_map.json"
+    try:
+        try:
+            from scripts.public_release_projection import project_bytes
+        except ModuleNotFoundError:  # pragma: no cover - direct-script support.
+            from public_release_projection import project_bytes
+        expected_public_bytes = project_bytes(
+            expected_path,
+            private_source_map_bytes,
+            include_source_display_marker=True,
+        )
+    except Exception as exc:
+        raise PublicSourceRoleProjectionError(
+            f"cannot construct canonical public source-map projection: {exc}"
+        ) from exc
+    if public_source_map_bytes != expected_public_bytes:
+        raise PublicSourceRoleProjectionError(
+            "public source map is not the exact canonical marker-bearing private projection"
+        )
+    _validate_public_map_and_display(
+        paper=paper,
+        public_source_map=public_map,
+        public_source_map_bytes=public_source_map_bytes,
+        public_display_manifest=display,
+        public_display_manifest_bytes=public_display_manifest_bytes,
+        private_source_map_bytes=private_source_map_bytes,
+    )
+    accepted_roles = _accepted_roles(accepted_role_sha256s_by_source_item)
+    private_items = _items(private_map, label="private source map")
+    public_items = _items(public_map, label="public source map")
+    bindings: dict[str, dict[str, Any]] = {}
+    for item_id, accepted_role in sorted(accepted_roles.items()):
+        private_item = private_items.get(item_id)
+        public_item = public_items.get(item_id)
+        if not isinstance(private_item, Mapping) or not isinstance(public_item, Mapping):
+            raise PublicSourceRoleProjectionError(
+                f"accepted source item {item_id!r} is absent from a source map"
+            )
+        try:
+            private_role = _source_role_contract(private_item)
+        except Exception as exc:
+            raise PublicSourceRoleProjectionError(str(exc)) from exc
+        if private_role != accepted_role:
+            raise PublicSourceRoleProjectionError(
+                f"private source item {item_id!r} does not match its accepted role digest"
+            )
+        public_role = public_source_role_projection_sha256(public_item)
+        paths = _withheld_field_paths(private_item, public_item)
+        if public_role != accepted_role and not paths:
+            raise PublicSourceRoleProjectionError(
+                f"public source item {item_id!r} changed role without an allowed withholding"
+            )
+        bindings[item_id] = {
+            "accepted_source_role_contract_sha256": accepted_role,
+            "public_source_role_projection_sha256": public_role,
+            "schema": PUBLIC_SOURCE_ROLE_PROJECTION_BINDING_SCHEMA,
+            "withheld_field_paths": list(paths),
+        }
+    return {
+        "acceptance_credential": False,
+        "accepted_graph_sha256": graph_sha256,
+        "bindings_by_source_item": bindings,
+        "paper": paper,
+        "private_role_material_included": False,
+        "private_source_map_material_sha256": _material_sha256(
+            "private_source_map", private_map
+        ),
+        "private_source_map_sha256": _sha256_bytes(private_source_map_bytes),
+        "projection_contract_sha256": PUBLIC_SOURCE_ROLE_PROJECTION_CONTRACT_SHA256,
+        "public_display_manifest_material_sha256": _material_sha256(
+            "public_display_manifest", display
+        ),
+        "public_display_manifest_sha256": _sha256_bytes(public_display_manifest_bytes),
+        "public_source_map_material_sha256": _material_sha256(
+            "public_source_map", public_map
+        ),
+        "public_source_map_sha256": _sha256_bytes(public_source_map_bytes),
+        "raw_private_approval_material_included": False,
+        "schema": PUBLIC_SOURCE_ROLE_PROJECTION_SCHEMA,
+    }
+
+
+def canonical_public_source_role_projection_bytes(envelope: Mapping[str, Any]) -> bytes:
+    """Serialize one envelope canonically; its bytes are not self-authority."""
+
+    try:
+        return (
+            json.dumps(
+                envelope,
+                ensure_ascii=False,
+                indent=2,
+                sort_keys=True,
+                allow_nan=False,
+            )
+            + "\n"
+        ).encode("utf-8")
+    except (TypeError, ValueError) as exc:
+        raise PublicSourceRoleProjectionError(
+            "public source-role projection is not canonical JSON"
+        ) from exc
+
+
+def validate_public_source_role_projection_envelope(
+    envelope_bytes: bytes,
+    *,
+    paper: str,
+    private_source_map_bytes: bytes,
+    public_source_map_bytes: bytes,
+    public_display_manifest_bytes: bytes,
+    accepted_graph_sha256: str,
+    accepted_role_sha256s_by_source_item: Mapping[str, str | Iterable[str]],
+) -> dict[str, Any]:
+    """Require canonical bytes for a freshly guard-derived envelope."""
+
+    expected = build_public_source_role_projection_envelope(
+        paper=paper,
+        private_source_map_bytes=private_source_map_bytes,
+        public_source_map_bytes=public_source_map_bytes,
+        public_display_manifest_bytes=public_display_manifest_bytes,
+        accepted_graph_sha256=accepted_graph_sha256,
+        accepted_role_sha256s_by_source_item=accepted_role_sha256s_by_source_item,
+    )
+    actual = _json_object(envelope_bytes, "public source-role projection")
+    if actual != expected or envelope_bytes != canonical_public_source_role_projection_bytes(
+        expected
+    ):
+        raise PublicSourceRoleProjectionError(
+            "public source-role projection does not match authenticated private inputs"
+        )
+    return expected
+
+
+def validate_runtime_public_source_role_projection(
+    *,
+    trusted_envelope_bytes: bytes,
+    paper: str,
+    public_source_map_bytes: bytes,
+    public_display_manifest_bytes: bytes,
+    accepted_graph_sha256: str,
+    accepted_role_sha256s_by_source_item: Mapping[str, str | Iterable[str]],
+) -> dict[str, str]:
+    """Validate a bridge already authenticated by canonical public Git.
+
+    This function does not decide whether bytes are trusted. A caller must read
+    ``trusted_envelope_bytes`` from the authenticated canonical Git object, and
+    separately require the working-tree envelope to be byte-identical to it.
+    """
+
+    paper = _paper(paper)
+    graph_sha256 = _sha256(accepted_graph_sha256, "accepted graph")
+    envelope = _json_object(trusted_envelope_bytes, "trusted source-role envelope")
+    if trusted_envelope_bytes != canonical_public_source_role_projection_bytes(envelope):
+        raise PublicSourceRoleProjectionError(
+            "trusted source-role envelope is not the canonical serialization"
+        )
+    public_map = _json_object(public_source_map_bytes, "public source map")
+    display = _json_object(public_display_manifest_bytes, "public display manifest")
+    expected_top_fields = {
+        "acceptance_credential",
+        "accepted_graph_sha256",
+        "bindings_by_source_item",
+        "paper",
+        "private_role_material_included",
+        "private_source_map_material_sha256",
+        "private_source_map_sha256",
+        "projection_contract_sha256",
+        "public_display_manifest_material_sha256",
+        "public_display_manifest_sha256",
+        "public_source_map_material_sha256",
+        "public_source_map_sha256",
+        "raw_private_approval_material_included",
+        "schema",
+    }
+    if set(envelope) != expected_top_fields:
+        raise PublicSourceRoleProjectionError("trusted source-role envelope fields are malformed")
+    if (
+        envelope.get("schema") != PUBLIC_SOURCE_ROLE_PROJECTION_SCHEMA
+        or envelope.get("acceptance_credential") is not False
+        or envelope.get("paper") != paper
+        or envelope.get("accepted_graph_sha256") != graph_sha256
+        or envelope.get("projection_contract_sha256")
+        != PUBLIC_SOURCE_ROLE_PROJECTION_CONTRACT_SHA256
+        or envelope.get("private_role_material_included") is not False
+        or envelope.get("raw_private_approval_material_included") is not False
+    ):
+        raise PublicSourceRoleProjectionError(
+            "trusted source-role envelope authority or paper identity is stale"
+        )
+    for field in (
+        "private_source_map_material_sha256",
+        "private_source_map_sha256",
+        "public_display_manifest_material_sha256",
+        "public_display_manifest_sha256",
+        "public_source_map_material_sha256",
+        "public_source_map_sha256",
+    ):
+        _sha256(envelope.get(field), f"trusted source-role envelope {field}")
+    expected_hashes = {
+        "public_source_map_sha256": _sha256_bytes(public_source_map_bytes),
+        "public_source_map_material_sha256": _material_sha256(
+            "public_source_map", public_map
+        ),
+        "public_display_manifest_sha256": _sha256_bytes(public_display_manifest_bytes),
+        "public_display_manifest_material_sha256": _material_sha256(
+            "public_display_manifest", display
+        ),
+    }
+    for field, expected in expected_hashes.items():
+        if envelope.get(field) != expected:
+            raise PublicSourceRoleProjectionError(
+                f"trusted source-role envelope {field} does not match current public material"
+            )
+    _validate_public_map_and_display(
+        paper=paper,
+        public_source_map=public_map,
+        public_source_map_bytes=public_source_map_bytes,
+        public_display_manifest=display,
+        public_display_manifest_bytes=public_display_manifest_bytes,
+        private_source_map_bytes=None,
+    )
+    accepted_roles = _accepted_roles(accepted_role_sha256s_by_source_item)
+    public_items = _items(public_map, label="public source map")
+    bindings = envelope.get("bindings_by_source_item")
+    if not isinstance(bindings, Mapping) or set(bindings) != set(accepted_roles):
+        raise PublicSourceRoleProjectionError(
+            "trusted source-role envelope does not cover the exact accepted source routes"
+        )
+    result: dict[str, str] = {}
+    for item_id, accepted_role in sorted(accepted_roles.items()):
+        binding = bindings.get(item_id)
+        item = public_items.get(item_id)
+        if not isinstance(binding, Mapping) or not isinstance(item, Mapping):
+            raise PublicSourceRoleProjectionError(
+                f"trusted source-role binding {item_id!r} is malformed"
+            )
+        expected_binding_fields = {
+            "accepted_source_role_contract_sha256",
+            "public_source_role_projection_sha256",
+            "schema",
+            "withheld_field_paths",
+        }
+        paths = binding.get("withheld_field_paths")
+        if (
+            set(binding) != expected_binding_fields
+            or binding.get("schema") != PUBLIC_SOURCE_ROLE_PROJECTION_BINDING_SCHEMA
+            or binding.get("accepted_source_role_contract_sha256") != accepted_role
+            or not isinstance(paths, list)
+            or paths != sorted(set(paths))
+            or any(
+                path not in PUBLIC_SOURCE_ROLE_PROJECTION_CONTRACT[
+                    "allowed_withheld_field_paths"
+                ]
+                for path in paths
+            )
+        ):
+            raise PublicSourceRoleProjectionError(
+                f"trusted source-role binding {item_id!r} is stale or malformed"
+            )
+        current_public_role = public_source_role_projection_sha256(item)
+        if binding.get("public_source_role_projection_sha256") != current_public_role:
+            raise PublicSourceRoleProjectionError(
+                f"public source item {item_id!r} does not match its trusted projected role"
+            )
+        if current_public_role != accepted_role and not paths:
+            raise PublicSourceRoleProjectionError(
+                f"public source item {item_id!r} changed role without an authenticated withholding"
+            )
+        result[item_id] = current_public_role
+    return result
+
+
+def public_source_role_projection_envelope_sha256(envelope: Mapping[str, Any]) -> str:
+    """Return an external registry key; never accept it from the envelope itself."""
+
+    return portable_evidence_sha256(
+        {"schema": 1, "public_source_role_projection": dict(envelope)}
+    )

--- a/scripts/terminal_lean_semantic_revalidation.py
+++ b/scripts/terminal_lean_semantic_revalidation.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import json
 import re
+import subprocess
 import sys
 from collections.abc import Mapping
 from pathlib import Path
@@ -55,6 +56,10 @@ from scripts.obligation_preflight import ObligationStructuralPreflight
 from scripts.obligation_routes import EvidenceRoute, EvidenceRouteSet, RouteKind
 from scripts.semantic_review_binding import (
     unique_reusable_judgment_bindings,
+)
+from scripts.public_source_role_projection import (
+    PUBLIC_SOURCE_ROLE_PROJECTION_FILE,
+    validate_runtime_public_source_role_projection,
 )
 
 
@@ -152,6 +157,54 @@ def _current_review_import_module(
     return module
 
 
+def _trusted_public_source_role_envelope(paper_dir: Path) -> bytes:
+    """Read release authority from a fetched canonical public main Git tree.
+
+    A contributor's working file or branch cannot issue this bridge. CI checks
+    out the canonical repository with full remote history; offline readers
+    must likewise have fetched its main ref. The private release guard checks
+    issuance against private inputs before the public maintainer merges it.
+    """
+
+    paper_dir = paper_dir.resolve()
+    root = paper_dir.parents[1]
+    if paper_dir.parent.name != "papers" or not re.fullmatch(
+        r"[A-Za-z0-9][A-Za-z0-9_-]*", paper_dir.name
+    ):
+        raise ValueError("public source-role envelope has an invalid paper path")
+    relative = f"papers/{paper_dir.name}/{PUBLIC_SOURCE_ROLE_PROJECTION_FILE}"
+
+    def git(*args: str) -> bytes:
+        result = subprocess.run(
+            ["git", "-C", str(root), *args], capture_output=True, timeout=30
+        )
+        if result.returncode:
+            raise ValueError("canonical public Git source-role authority is unavailable")
+        return result.stdout
+
+    canonical = re.compile(
+        r"(?:https://github\.com/|git@github\.com:|ssh://git@github\.com/)"
+        r"nikhgarg/(?:AppliedModelingLib|EconCSLib)(?:\.git)?"
+    )
+    candidates = []
+    for remote in git("remote").decode().splitlines():
+        urls = git("remote", "get-url", "--all", remote).decode().splitlines()
+        if len(urls) == 1 and canonical.fullmatch(urls[0]):
+            try:
+                candidates.append(git("show", f"refs/remotes/{remote}/main:{relative}"))
+            except ValueError:
+                continue
+    try:
+        current = (root / relative).read_bytes()
+    except OSError as exc:
+        raise ValueError("public source-role envelope is unavailable") from exc
+    if current not in candidates:
+        raise ValueError(
+            "public source-role envelope is not authenticated by canonical public main"
+        )
+    return current
+
+
 def _validate_current_source_routes(
     loaded: object,
     source_map: Mapping[str, Any],
@@ -193,18 +246,23 @@ def _validate_current_source_routes(
             if "source_text_file" in source_map:
                 raise ValueError("public source recovery requires a withheld source locator")
             items = source_map.get("items", {})
-            withheld_roles = {
+            corrected_roles = {
                 key for key, item in items.items()
                 if isinstance(item, Mapping) and item.get("corrected_target") is not None
             }
-            if withheld_roles:
+            withheld_roles = corrected_roles | {
+                key for key, item in items.items()
+                if isinstance(item, Mapping)
+                and item.get("user_approved_scope_exclusion") is not None
+            }
+            if corrected_roles:
                 if source_map.get("publication_corrected_target_projection") != {
                     "schema": 1, "approval_material_included": False
                 }:
                     raise ValueError("public corrected targets lack their withholding declaration")
-                # Approval provenance participates in the private role digest.
-                # Public transport checks the retained clauses and current Lean
-                # meanings; it cannot attest to withheld approval provenance.
+                # The private corrected-target parser requires the withheld
+                # approval. Project its atoms without that object; the trusted
+                # bridge below independently binds every retained target field.
                 projected_source_map = dict(source_map, items={
                     key: {k: v for k, v in item.items() if k != "corrected_target"}
                     for key, item in items.items()
@@ -266,6 +324,30 @@ def _validate_current_source_routes(
         accepted_bundles[str(source_item_id)] = set()
 
     if allow_withheld_source_material:
+        if withheld_roles:
+            try:
+                map_payload, map_bytes = _json_bytes(
+                    paper_dir / "audit/paper_statement_map.json", "public source map"
+                )
+                if map_payload != source_map:
+                    raise ValueError("public source map changed during revalidation")
+                _, display_bytes = _json_bytes(
+                    paper_dir / "audit/public_source_display_projection.json",
+                    "public source display manifest",
+                )
+                validate_runtime_public_source_role_projection(
+                    trusted_envelope_bytes=_trusted_public_source_role_envelope(paper_dir),
+                    paper=paper_dir.name,
+                    public_source_map_bytes=map_bytes,
+                    public_display_manifest_bytes=display_bytes,
+                    accepted_graph_sha256=getattr(graph, "graph_sha256", ""),
+                    accepted_role_sha256s_by_source_item={
+                        key: tuple(atom[2] for atom in entry["source_atoms"])
+                        for key, entry in accepted_entries.items()
+                    },
+                )
+            except (ValueError, OSError, subprocess.SubprocessError) as exc:
+                raise TerminalLeanSemanticRevalidationError(str(exc)) from exc
         # Public exports cannot replay private verbatim/approval bundles. Keep
         # their exact route names and semantic source atoms fixed instead;
         # subsequent Lean checks still validate every target and dependency.

--- a/scripts/tests/test_public_release_artifact_policy.py
+++ b/scripts/tests/test_public_release_artifact_policy.py
@@ -21,6 +21,7 @@ class PublicReleaseArtifactPolicyTests(unittest.TestCase):
     def test_canonical_current_audit_artifacts_are_allowed(self) -> None:
         paths = [
             "papers/Fixture/audit/paper_statement_map.json",
+            "papers/Fixture/audit/public_source_role_projection.json",
             "papers/Fixture/audit/source_record_audit.json",
             "papers/Fixture/audit/source_record_match_llm.json",
             "papers/Fixture/audit/source_proof_fidelity.json",
@@ -65,6 +66,7 @@ class PublicReleaseArtifactPolicyTests(unittest.TestCase):
             "papers/Fixture/audit/manual_review_template.json",
             "papers/Fixture/audit/semantic_review_noncanonical_draft.json",
             "papers/Fixture/audit/receipt_reissue_action_scaffold.json",
+            "papers/Fixture/audit/public_source_role_projection.draft.json",
         ]
 
         issues = public_release_artifact_issues(paths)

--- a/scripts/tests/test_public_release_candidate_guard.py
+++ b/scripts/tests/test_public_release_candidate_guard.py
@@ -11,6 +11,7 @@ import subprocess
 import sys
 import tempfile
 import unittest
+from dataclasses import replace
 from pathlib import Path
 from unittest import mock
 
@@ -20,6 +21,8 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from scripts import public_release_candidate_guard as guard  # noqa: E402
+from scripts import public_source_role_projection as role_projection  # noqa: E402
+from scripts.obligation_evidence_projection import _source_role_contract  # noqa: E402
 from scripts.corrected_target_identity import (  # noqa: E402
     CORRECTED_TARGET_RECORD_SHA256_FIELD,
     CORRECTED_TARGET_REVIEW_SHA256_FIELD,
@@ -800,6 +803,7 @@ class PublicReleaseCandidateGuardTests(unittest.TestCase):
             ),
         }
         private_map = {
+            "paper": "Fixture",
             "source_artifact_path": ".audit_source/Fixture.txt",
             "source_artifact_sha256": "a" * 64,
             "source_coverage_mode": "named_theoretical_statements",
@@ -1002,6 +1006,23 @@ class PublicReleaseCandidateGuardTests(unittest.TestCase):
                 candidate, retained_path_commit, [entry], private_repo=private
             )
 
+            # A saved manifest cannot be used to authenticate an unmarked map.
+            private_blob = subprocess.run(
+                ["git", "show", f"{entry.source_commit}:{entry.path}"],
+                cwd=private,
+                check=True,
+                stdout=subprocess.PIPE,
+            ).stdout
+            unmarked_blob = guard.project_bytes(entry.path, private_blob)
+            (candidate / entry.path).write_bytes(unmarked_blob)
+            (candidate / "papers/Fixture/audit/public_source_display_projection.json").write_bytes(
+                manifest_blob
+            )
+            unmarked_commit = self.commit(candidate, "remove display marker")
+            unmarked_issues = guard.public_source_display_projection_issues(
+                candidate, unmarked_commit, [entry], private_repo=private
+            )
+
         self.assertTrue(any("missing" in issue for issue in missing_manifest_issues), missing_manifest_issues)
         self.assertTrue(
             any("public_source_map_sha256" in issue for issue in tampered_map_issues),
@@ -1022,6 +1043,143 @@ class PublicReleaseCandidateGuardTests(unittest.TestCase):
         self.assertTrue(
             any("retains a source path" in issue for issue in retained_path_issues),
             retained_path_issues,
+        )
+        self.assertTrue(
+            any("requires the exact display-projection marker" in issue
+                for issue in unmarked_issues),
+            unmarked_issues,
+        )
+
+    def test_public_role_projection_requires_pinned_map_and_exact_private_graph(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            (
+                private,
+                candidate,
+                source_commit,
+                _candidate_commit,
+                entry,
+                public_blob,
+                manifest_blob,
+            ) = self._display_projection_fixture(root)
+            graph_sha256 = "9" * 64
+            pointer_path = (
+                "papers/Fixture/audit/obligation_evidence/current_accepted_graph.json"
+            )
+            pack_path = (
+                "papers/Fixture/audit/obligation_evidence/accepted_graphs/sha256/"
+                f"{graph_sha256[:2]}/{graph_sha256}.json"
+            )
+            pointer_bytes = (
+                json.dumps(
+                    {"schema": 2, "graph_sha256": graph_sha256}, sort_keys=True
+                )
+                + "\n"
+            ).encode("utf-8")
+            pack_bytes = b'{"fixture":"accepted graph bytes"}\n'
+            for path, raw in ((pointer_path, pointer_bytes), (pack_path, pack_bytes)):
+                destination = private / path
+                destination.parent.mkdir(parents=True, exist_ok=True)
+                destination.write_bytes(raw)
+            pinned_commit = self.commit(private, "pin selected accepted graph")
+            private_blob = subprocess.run(
+                ["git", "show", f"{pinned_commit}:{entry.path}"],
+                cwd=private,
+                check=True,
+                stdout=subprocess.PIPE,
+            ).stdout
+            entry = replace(entry, source_commit=pinned_commit)
+            private_map = json.loads(private_blob)
+            accepted_roles = {
+                "fixture_definition": _source_role_contract(
+                    private_map["items"]["fixture_definition"]
+                )
+            }
+            envelope = role_projection.build_public_source_role_projection_envelope(
+                paper="Fixture",
+                private_source_map_bytes=private_blob,
+                public_source_map_bytes=public_blob,
+                public_display_manifest_bytes=manifest_blob,
+                accepted_graph_sha256=graph_sha256,
+                accepted_role_sha256s_by_source_item=accepted_roles,
+            )
+            envelope_path = (
+                candidate / "papers/Fixture/audit/public_source_role_projection.json"
+            )
+            envelope_path.write_bytes(
+                role_projection.canonical_public_source_role_projection_bytes(envelope)
+            )
+            candidate_commit = self.commit(candidate, "add public role projection")
+            accepted_material = (
+                graph_sha256,
+                accepted_roles,
+                pointer_bytes,
+                pack_bytes,
+                pack_path,
+            )
+
+            with mock.patch.object(
+                guard,
+                "_accepted_source_role_material",
+                return_value=accepted_material,
+            ):
+                issues = guard.public_source_role_projection_issues(
+                    candidate,
+                    candidate_commit,
+                    [entry],
+                    private_repo=private,
+                    public_base_ref=None,
+                )
+                missing_provenance = guard.public_source_role_projection_issues(
+                    candidate,
+                    candidate_commit,
+                    [],
+                    private_repo=private,
+                    public_base_ref=None,
+                )
+                wrong_graph_material = (
+                    graph_sha256,
+                    accepted_roles,
+                    b"different pointer bytes\n",
+                    pack_bytes,
+                    pack_path,
+                )
+            with mock.patch.object(
+                guard,
+                "_accepted_source_role_material",
+                return_value=wrong_graph_material,
+            ):
+                wrong_graph = guard.public_source_role_projection_issues(
+                    candidate,
+                    candidate_commit,
+                    [entry],
+                    private_repo=private,
+                    public_base_ref=None,
+                )
+            with mock.patch.object(
+                guard,
+                "_accepted_source_role_material",
+                return_value=accepted_material,
+            ):
+                unchanged = guard.public_source_role_projection_issues(
+                    candidate,
+                    candidate_commit,
+                    [],
+                    private_repo=private,
+                    public_base_ref=candidate_commit,
+                )
+
+        self.assertEqual(issues, [])
+        self.assertEqual(unchanged, [])
+        self.assertTrue(
+            any("private_projection allowlist provenance" in issue
+                for issue in missing_provenance),
+            missing_provenance,
+        )
+        self.assertTrue(
+            any("differs from the pinned private source commit" in issue
+                for issue in wrong_graph),
+            wrong_graph,
         )
 
     def test_packet_pdf_and_tex_private_workflow_scan_is_committed_and_bounded(self) -> None:

--- a/scripts/tests/test_public_source_role_projection.py
+++ b/scripts/tests/test_public_source_role_projection.py
@@ -1,0 +1,362 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import unittest
+
+from scripts.corrected_target_identity import (
+    CORRECTED_TARGET_RECORD_SHA256_FIELD,
+    CORRECTED_TARGET_REVIEW_SHA256_FIELD,
+    corrected_target_record_digest,
+    corrected_target_review_digest,
+)
+from scripts.obligation_evidence_projection import _source_role_contract
+from scripts.public_release_projection import (
+    PUBLIC_CORRECTED_TARGET_PROJECTION_FIELD,
+    project_bytes,
+)
+from scripts.source_display_projection import (
+    PUBLIC_SOURCE_DISPLAY_PROJECTION_FIELD,
+    PUBLIC_SOURCE_DISPLAY_PROJECTION_GENERATOR,
+    PUBLIC_SOURCE_DISPLAY_PROJECTION_MANIFEST,
+    PUBLIC_SOURCE_DISPLAY_PROJECTION_SCHEMA,
+)
+from scripts import public_source_role_projection as projection
+
+
+def _sha256(value: str | bytes) -> str:
+    raw = value.encode("utf-8") if isinstance(value, str) else value
+    return hashlib.sha256(raw).hexdigest()
+
+
+def _corrected_target() -> dict[str, object]:
+    statement = "Every feasible allocation has welfare at most the displayed benchmark."
+    excerpt = (
+        "Private approval record expressly approves this corrected mathematical target "
+        "for the bounded formalization and contains local material that stays private."
+    )
+    approval = {
+        "artifact_path": "docs/PRIVATE_APPROVAL_MEMO.md",
+        "artifact_protocol": "unique_normalized_artifact_excerpt_v1",
+        "artifact_excerpt": excerpt,
+        "artifact_excerpt_sha256": _sha256(excerpt),
+        "kind": "recorded_user_direction",
+        "recorded_at": "2026-09-07",
+        "reference": "/home/reviewer/private approval notes",
+        "target_statement_sha256": _sha256(statement),
+    }
+    target: dict[str, object] = {
+        "schema": 1,
+        "statement": statement,
+        "archival_equivalence_claimed": False,
+        "archival_source_locator": "Fixture.txt:1-2",
+        "archival_source_quote_sha256": "a" * 64,
+        "governing_defect_ids": ["D1"],
+        "approval": approval,
+    }
+    target[CORRECTED_TARGET_RECORD_SHA256_FIELD] = corrected_target_record_digest(target)
+    target[CORRECTED_TARGET_REVIEW_SHA256_FIELD] = corrected_target_review_digest(target)
+    return target
+
+
+class PublicSourceRoleProjectionTests(unittest.TestCase):
+    paper = "Fixture"
+    graph_sha256 = "9" * 64
+
+    def setUp(self) -> None:
+        quote = "Theorem 1. Every fixture satisfies the displayed claim."
+        self.private_map = {
+            "schema": 1,
+            "paper": self.paper,
+            "source_artifact_path": ".audit_source/Fixture.txt",
+            "source_artifact_sha256": "b" * 64,
+            "items": {
+                "scope_item": {
+                    "source_kind": "theorem",
+                    "coverage_status": "user_approved_scope_exclusion",
+                    "scope_disposition": "user_approved_scope_exclusion",
+                    "source_anchor_evidence": [
+                        {
+                            "path": ".audit_source/Fixture.txt",
+                            "line_start": 1,
+                            "line_end": 1,
+                            "quoted_text": quote,
+                            "quoted_text_sha256": _sha256(quote),
+                        }
+                    ],
+                    "user_approved_scope_exclusion": {
+                        "schema": 1,
+                        "approval_kind": "explicit_user_instruction",
+                        "approval_reference": (
+                            "User direction recorded privately for this exact boundary."
+                        ),
+                        "approved_at": "2026-09-07",
+                        "reason": "The exact source result remains outside this bounded closeout.",
+                        "source_locator": ".audit_source/Fixture.txt:1",
+                        "source_evidence": (
+                            "The cited result at Fixture.txt:1 is visible and remains uncredited."
+                        ),
+                        "source_anchor_quote_sha256": _sha256(quote),
+                    },
+                },
+                "corrected_item": {
+                    "source_kind": "theorem",
+                    "coverage_status": "formalized",
+                    "corrected_target": _corrected_target(),
+                },
+            },
+        }
+        self.private_bytes = self._bytes(self.private_map)
+        self.public_bytes = project_bytes(
+            f"papers/{self.paper}/audit/paper_statement_map.json",
+            self.private_bytes,
+            include_source_display_marker=True,
+        )
+        self.public_map = json.loads(self.public_bytes)
+        self.display = {
+            "schema": 1,
+            "generator": "python3 scripts/public_source_display_projection.py",
+            "paper_id": self.paper,
+            "private_source_map_sha256": _sha256(self.private_bytes),
+            "public_source_map_sha256": _sha256(self.public_bytes),
+            "public_manifest_path": (
+                f"papers/{self.paper}/audit/public_source_display_projection.json"
+            ),
+            "raw_source_artifact_included": False,
+        }
+        self.display_bytes = self._bytes(self.display)
+        self.accepted_roles = {
+            item_id: _source_role_contract(item)
+            for item_id, item in self.private_map["items"].items()
+        }
+
+    def test_wire_constants_match_lightweight_display_and_release_owners(self) -> None:
+        self.assertEqual(
+            projection.PUBLIC_SOURCE_DISPLAY_PROJECTION_FIELD,
+            PUBLIC_SOURCE_DISPLAY_PROJECTION_FIELD,
+        )
+        self.assertEqual(
+            projection.PUBLIC_SOURCE_DISPLAY_PROJECTION_SCHEMA,
+            PUBLIC_SOURCE_DISPLAY_PROJECTION_SCHEMA,
+        )
+        self.assertEqual(
+            projection.PUBLIC_SOURCE_DISPLAY_PROJECTION_MANIFEST,
+            PUBLIC_SOURCE_DISPLAY_PROJECTION_MANIFEST,
+        )
+        self.assertEqual(
+            projection.PUBLIC_SOURCE_DISPLAY_PROJECTION_GENERATOR,
+            PUBLIC_SOURCE_DISPLAY_PROJECTION_GENERATOR,
+        )
+        self.assertEqual(
+            projection.PUBLIC_CORRECTED_TARGET_PROJECTION_FIELD,
+            PUBLIC_CORRECTED_TARGET_PROJECTION_FIELD,
+        )
+
+    @staticmethod
+    def _bytes(value: object) -> bytes:
+        return (
+            json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+        ).encode("utf-8")
+
+    def _build(self) -> dict[str, object]:
+        return projection.build_public_source_role_projection_envelope(
+            paper=self.paper,
+            private_source_map_bytes=self.private_bytes,
+            public_source_map_bytes=self.public_bytes,
+            public_display_manifest_bytes=self.display_bytes,
+            accepted_graph_sha256=self.graph_sha256,
+            accepted_role_sha256s_by_source_item=self.accepted_roles,
+        )
+
+    def _runtime(
+        self,
+        envelope: dict[str, object],
+        *,
+        public_bytes: bytes | None = None,
+        display_bytes: bytes | None = None,
+    ) -> dict[str, str]:
+        return projection.validate_runtime_public_source_role_projection(
+            trusted_envelope_bytes=(
+                projection.canonical_public_source_role_projection_bytes(envelope)
+            ),
+            paper=self.paper,
+            public_source_map_bytes=public_bytes or self.public_bytes,
+            public_display_manifest_bytes=display_bytes or self.display_bytes,
+            accepted_graph_sha256=self.graph_sha256,
+            accepted_role_sha256s_by_source_item=self.accepted_roles,
+        )
+
+    def _changed_public_material(self, mutate) -> tuple[bytes, bytes]:
+        public_map = json.loads(self.public_bytes)
+        mutate(public_map)
+        public_bytes = self._bytes(public_map)
+        display = dict(self.display)
+        display["public_source_map_sha256"] = _sha256(public_bytes)
+        return public_bytes, self._bytes(display)
+
+    def test_guard_builds_one_bridge_for_scope_and_corrected_target(self) -> None:
+        envelope = self._build()
+        bindings = envelope["bindings_by_source_item"]
+        self.assertEqual(
+            bindings["scope_item"]["withheld_field_paths"],
+            [
+                "user_approved_scope_exclusion.approval_reference",
+                "user_approved_scope_exclusion.source_evidence",
+                "user_approved_scope_exclusion.source_locator",
+            ],
+        )
+        self.assertEqual(
+            bindings["corrected_item"]["withheld_field_paths"],
+            [
+                "corrected_target.approval",
+                "corrected_target.archival_source_locator",
+            ],
+        )
+        self.assertNotEqual(
+            bindings["scope_item"]["accepted_source_role_contract_sha256"],
+            bindings["scope_item"]["public_source_role_projection_sha256"],
+        )
+        self.assertEqual(set(self._runtime(envelope)), set(self.accepted_roles))
+
+    def test_private_role_must_match_exact_accepted_graph_atom_role(self) -> None:
+        wrong = dict(self.accepted_roles, scope_item="0" * 64)
+        with self.assertRaisesRegex(
+            projection.PublicSourceRoleProjectionError, "accepted role digest"
+        ):
+            projection.build_public_source_role_projection_envelope(
+                paper=self.paper,
+                private_source_map_bytes=self.private_bytes,
+                public_source_map_bytes=self.public_bytes,
+                public_display_manifest_bytes=self.display_bytes,
+                accepted_graph_sha256=self.graph_sha256,
+                accepted_role_sha256s_by_source_item=wrong,
+            )
+
+    def test_marker_is_mandatory(self) -> None:
+        unmarked = project_bytes(
+            f"papers/{self.paper}/audit/paper_statement_map.json",
+            self.private_bytes,
+        )
+        display = dict(self.display, public_source_map_sha256=_sha256(unmarked))
+        with self.assertRaisesRegex(
+            projection.PublicSourceRoleProjectionError, "marker-bearing"
+        ):
+            projection.build_public_source_role_projection_envelope(
+                paper=self.paper,
+                private_source_map_bytes=self.private_bytes,
+                public_source_map_bytes=unmarked,
+                public_display_manifest_bytes=self._bytes(display),
+                accepted_graph_sha256=self.graph_sha256,
+                accepted_role_sha256s_by_source_item=self.accepted_roles,
+            )
+
+    def test_mismatched_display_manifest_is_rejected(self) -> None:
+        changed = dict(self.display, public_source_map_sha256="0" * 64)
+        with self.assertRaisesRegex(
+            projection.PublicSourceRoleProjectionError,
+            "display manifest public_source_map_sha256",
+        ):
+            projection.build_public_source_role_projection_envelope(
+                paper=self.paper,
+                private_source_map_bytes=self.private_bytes,
+                public_source_map_bytes=self.public_bytes,
+                public_display_manifest_bytes=self._bytes(changed),
+                accepted_graph_sha256=self.graph_sha256,
+                accepted_role_sha256s_by_source_item=self.accepted_roles,
+            )
+
+    def test_trusted_envelope_rejects_reason_status_and_anchor_edits(self) -> None:
+        envelope = self._build()
+        mutations = (
+            lambda value: value["items"]["scope_item"][
+                "user_approved_scope_exclusion"
+            ].__setitem__("reason", "Edited public reason."),
+            lambda value: value["items"]["scope_item"].__setitem__(
+                "coverage_status", "formalized"
+            ),
+            lambda value: value["items"]["scope_item"]["source_anchor_evidence"][
+                0
+            ].__setitem__("quoted_text", "Invented anchor."),
+        )
+        for mutate in mutations:
+            with self.subTest(mutate=mutate):
+                public_bytes, display_bytes = self._changed_public_material(mutate)
+                with self.assertRaisesRegex(
+                    projection.PublicSourceRoleProjectionError,
+                    "trusted source-role envelope public_source_map",
+                ):
+                    self._runtime(
+                        envelope,
+                        public_bytes=public_bytes,
+                        display_bytes=display_bytes,
+                    )
+
+    def test_trusted_envelope_rejects_corrected_target_edit(self) -> None:
+        envelope = self._build()
+        public_bytes, display_bytes = self._changed_public_material(
+            lambda value: value["items"]["corrected_item"]["corrected_target"].__setitem__(
+                "statement", "A branch-only corrected target."
+            )
+        )
+        with self.assertRaises(projection.PublicSourceRoleProjectionError):
+            self._runtime(
+                envelope,
+                public_bytes=public_bytes,
+                display_bytes=display_bytes,
+            )
+
+    def test_tampered_envelope_cannot_rebind_an_accepted_role(self) -> None:
+        envelope = self._build()
+        envelope["bindings_by_source_item"]["scope_item"][
+            "accepted_source_role_contract_sha256"
+        ] = "0" * 64
+        with self.assertRaisesRegex(
+            projection.PublicSourceRoleProjectionError, "stale or malformed"
+        ):
+            self._runtime(envelope)
+
+    def test_branch_only_envelope_is_not_a_substitute_for_trusted_bytes(self) -> None:
+        trusted = self._build()
+        branch = json.loads(json.dumps(trusted))
+        branch["bindings_by_source_item"]["scope_item"][
+            "public_source_role_projection_sha256"
+        ] = "0" * 64
+        # Runtime succeeds with canonical bytes and rejects the branch-only
+        # bytes. Canonical-remote/ref selection belongs to the caller.
+        self._runtime(trusted)
+        with self.assertRaises(projection.PublicSourceRoleProjectionError):
+            self._runtime(branch)
+
+    def test_wrong_graph_and_incomplete_route_set_fail_closed(self) -> None:
+        envelope = self._build()
+        with self.assertRaisesRegex(
+            projection.PublicSourceRoleProjectionError, "authority or paper identity"
+        ):
+            projection.validate_runtime_public_source_role_projection(
+                trusted_envelope_bytes=(
+                    projection.canonical_public_source_role_projection_bytes(envelope)
+                ),
+                paper=self.paper,
+                public_source_map_bytes=self.public_bytes,
+                public_display_manifest_bytes=self.display_bytes,
+                accepted_graph_sha256="8" * 64,
+                accepted_role_sha256s_by_source_item=self.accepted_roles,
+            )
+        incomplete = {"scope_item": self.accepted_roles["scope_item"]}
+        with self.assertRaisesRegex(
+            projection.PublicSourceRoleProjectionError, "exact accepted source routes"
+        ):
+            projection.validate_runtime_public_source_role_projection(
+                trusted_envelope_bytes=(
+                    projection.canonical_public_source_role_projection_bytes(envelope)
+                ),
+                paper=self.paper,
+                public_source_map_bytes=self.public_bytes,
+                public_display_manifest_bytes=self.display_bytes,
+                accepted_graph_sha256=self.graph_sha256,
+                accepted_role_sha256s_by_source_item=incomplete,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_terminal_lean_semantic_revalidation.py
+++ b/scripts/tests/test_terminal_lean_semantic_revalidation.py
@@ -4,6 +4,7 @@ import hashlib
 import json
 import subprocess
 import sys
+import tempfile
 import unittest
 from contextlib import ExitStack
 from pathlib import Path
@@ -21,6 +22,89 @@ from scripts.obligation_evidence_graph import (
 
 
 class TerminalLeanSemanticRevalidationTests(unittest.TestCase):
+    def test_public_projection_authority_requires_canonical_main_and_exact_bytes(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            paper = root / "papers/Fixture"
+            envelope = paper / terminal.PUBLIC_SOURCE_ROLE_PROJECTION_FILE
+            envelope.parent.mkdir(parents=True)
+            envelope.write_bytes(b"trusted envelope\n")
+
+            def git(*args):
+                subprocess.run(["git", "-C", directory, *args], check=True,
+                               capture_output=True)
+
+            git("init", "-b", "main")
+            git("config", "user.name", "Fixture")
+            git("config", "user.email", "fixture@example.invalid")
+            git("add", "papers")
+            git("commit", "-m", "Fixture envelope")
+            git("remote", "add", "origin", "https://github.com/untrusted/AppliedModelingLib.git")
+            git("update-ref", "refs/remotes/origin/main", "HEAD")
+            with self.assertRaisesRegex(ValueError, "not authenticated"):
+                terminal._trusted_public_source_role_envelope(paper)
+            for url in ("https://github.com/nikhgarg/AppliedModelingLib.git",
+                        "git@github.com:nikhgarg/EconCSLib.git"):
+                git("remote", "set-url", "origin", url)
+                self.assertEqual(terminal._trusted_public_source_role_envelope(paper),
+                                 b"trusted envelope\n")
+            envelope.write_bytes(b"branch-only replacement\n")
+            git("add", "papers")
+            git("commit", "-m", "Unreleased replacement")
+            with self.assertRaisesRegex(ValueError, "not authenticated"):
+                terminal._trusted_public_source_role_envelope(paper)
+            git("update-ref", "-d", "refs/remotes/origin/main")
+            with self.assertRaisesRegex(ValueError, "not authenticated"):
+                terminal._trusted_public_source_role_envelope(paper)
+
+    def test_projected_roles_require_authenticated_bridge_before_atom_comparison(self) -> None:
+        original = source_atom_leaf(
+            contract_sha256="1" * 64, source_artifact_sha256="2" * 64,
+            source_quote_sha256="3" * 64, source_component_sha256="4" * 64,
+            source_role_contract_sha256="5" * 64,
+        )
+        changed_role = source_atom_leaf(
+            contract_sha256="1" * 64, source_artifact_sha256="2" * 64,
+            source_quote_sha256="3" * 64, source_component_sha256="4" * 64,
+            source_role_contract_sha256="6" * 64,
+        )
+        loaded = SimpleNamespace(
+            paper_index=SimpleNamespace(
+                route_leaf_sha256s_by_source_item={
+                    "claim": {"source_atom": (original.leaf_sha256,)}},
+                prerequisite_leaf_sha256s_by_declaration={}),
+            graph=SimpleNamespace(graph_sha256="9" * 64,
+                                  leaves={original.leaf_sha256: original}))
+        for role_field in ("corrected_target", "user_approved_scope_exclusion"):
+            source = {"items": {"claim": {role_field: {}}},
+                      "publication_corrected_target_projection": {
+                          "schema": 1, "approval_material_included": False}}
+            with self.subTest(role_field=role_field), \
+                 mock.patch.object(terminal, "project_source_route_leaf_material_from_validated_inputs",
+                                   return_value=({changed_role.leaf_sha256: changed_role},
+                                                 {"claim": (changed_role.leaf_sha256,)})), \
+                 mock.patch.object(terminal, "_json_bytes",
+                                   side_effect=lambda path, label: (source, b"map")
+                                   if label == "public source map" else ({}, b"display")), \
+                 mock.patch.object(terminal, "_trusted_public_source_role_envelope",
+                                   return_value=b"trusted") as trusted, \
+                 mock.patch.object(terminal, "validate_runtime_public_source_role_projection") as validate:
+                call = lambda: terminal._validate_current_source_routes(
+                    loaded, source, SimpleNamespace(),
+                    paper_dir=Path("/repo/papers/Fixture"), allow_withheld_source_material=True)
+                self.assertEqual(call(), {"claim": "claim"})
+                self.assertEqual(validate.call_args.kwargs["accepted_role_sha256s_by_source_item"],
+                                 {"claim": ("5" * 64,)})
+                validate.side_effect = ValueError("retained public role changed")
+                with self.assertRaisesRegex(terminal.TerminalLeanSemanticRevalidationError,
+                                            "retained public role changed"):
+                    call()
+                validate.side_effect = None
+                trusted.side_effect = ValueError("unreleased envelope")
+                with self.assertRaisesRegex(terminal.TerminalLeanSemanticRevalidationError,
+                                            "unreleased envelope"):
+                    call()
+
     def test_public_source_recovery_requires_exact_routes_and_atoms(self) -> None:
         def atom(quote):
             return source_atom_leaf(


### PR DESCRIPTION
Public recovery failed when the release projection withheld private scope-approval references. This change binds each existing accepted private role to the exact public role, source map, and display manifest. The public reader requires that binding to match canonical public main; unreleased or modified metadata fails closed.

The release guard derives every new binding from a pinned private map and the unchanged accepted graph. All 36 existing public papers receive display markers and non-accepting projection metadata; six stale display manifests are regenerated from the current byte-verified sources and coverage selector. No paper is newly published, and no Lean statement, accepted graph, source judgment, or private source artifact is changed.

Validation: 161 focused tests passed and the canonical private release guard passed. The broader isolated suite passed 215 of 221 modules; six native fixture modules initially lacked dependencies and are being rerun using the existing compiled public dependencies. Hosted main CI remains in progress. The exact candidate will pass the authoritative merge guard before merge under the maintainer's standing authorization.
