### PR TITLE
Use the accepting graph identity for public role recovery

### DIFF
--- a/config/formalization_engine_revisions.json
+++ b/config/formalization_engine_revisions.json
@@ -1000,6 +1000,15 @@
       "verification": [
         "59 focused terminal and source-role projection tests pass; deterministic metadata generated for the same 36 public papers without modifying accepted graphs or claims."
       ]
+    },
+    {
+      "engine_tree_sha256": "10bb1970338f03cdd944339977c79ce1e3375cec32389dda505c8783b4dca038",
+      "formalization_review_protocol_sha256": "ca5ffddd01335d26b9b44d361eeaea34261ea281d4fed0eb4f8d38d85a6c4e70",
+      "rationale": "Use the complete accepted credential identity when authenticating public source-role projection metadata.",
+      "sequence": 84,
+      "verification": [
+        "59 focused tests pass; actual accepted-credential regression distinguishes its semantic graph from its accepting graph."
+      ]
     }
   ],
   "schema": 2

--- a/scripts/terminal_lean_semantic_revalidation.py
+++ b/scripts/terminal_lean_semantic_revalidation.py
@@ -340,7 +340,10 @@ def _validate_current_source_routes(
                     paper=paper_dir.name,
                     public_source_map_bytes=map_bytes,
                     public_display_manifest_bytes=display_bytes,
-                    accepted_graph_sha256=getattr(graph, "graph_sha256", ""),
+                    # The credential's graph property exposes only its inner
+                    # semantic DAG. The release bridge pins the accepting DAG,
+                    # whose identity belongs to the credential itself.
+                    accepted_graph_sha256=getattr(loaded, "graph_sha256", ""),
                     accepted_role_sha256s_by_source_item={
                         key: tuple(atom[2] for atom in entry["source_atoms"])
                         for key, entry in accepted_entries.items()

--- a/scripts/tests/test_terminal_lean_semantic_revalidation.py
+++ b/scripts/tests/test_terminal_lean_semantic_revalidation.py
@@ -12,6 +12,7 @@ from types import SimpleNamespace
 from unittest import mock
 
 from scripts import terminal_lean_semantic_revalidation as terminal
+from scripts.accepted_obligation_graph import AcceptedObligationGraphCredential
 from scripts.lean_review_surface import (
     lean_owned_semantic_review_display_surface_from_inventory,
 )
@@ -68,13 +69,15 @@ class TerminalLeanSemanticRevalidationTests(unittest.TestCase):
             source_quote_sha256="3" * 64, source_component_sha256="4" * 64,
             source_role_contract_sha256="6" * 64,
         )
-        loaded = SimpleNamespace(
+        loaded = AcceptedObligationGraphCredential(
+            accepted_graph=SimpleNamespace(graph_sha256="9" * 64),
             paper_index=SimpleNamespace(
                 route_leaf_sha256s_by_source_item={
                     "claim": {"source_atom": (original.leaf_sha256,)}},
                 prerequisite_leaf_sha256s_by_declaration={}),
-            graph=SimpleNamespace(graph_sha256="9" * 64,
-                                  leaves={original.leaf_sha256: original}))
+            semantic_graph=SimpleNamespace(graph_sha256="8" * 64,
+                                           leaves={original.leaf_sha256: original}),
+            closure_leaf=None)
         for role_field in ("corrected_target", "user_approved_scope_exclusion"):
             source = {"items": {"claim": {role_field: {}}},
                       "publication_corrected_target_projection": {
@@ -95,6 +98,7 @@ class TerminalLeanSemanticRevalidationTests(unittest.TestCase):
                 self.assertEqual(call(), {"claim": "claim"})
                 self.assertEqual(validate.call_args.kwargs["accepted_role_sha256s_by_source_item"],
                                  {"claim": ("5" * 64,)})
+                self.assertEqual(validate.call_args.kwargs["accepted_graph_sha256"], "9" * 64)
                 validate.side_effect = ValueError("retained public role changed")
                 with self.assertRaisesRegex(terminal.TerminalLeanSemanticRevalidationError,
                                             "retained public role changed"):


### PR DESCRIPTION
Public recovery passed the inner semantic graph's identity to metadata that pins the complete accepted graph, causing valid envelopes to fail. Pass the identity from the authenticated accepting credential instead, and exercise the actual credential type with distinct inner and outer identities in the regression test.

Only the reader, its regression test, and the independent public engine registration change. The public set remains 36 papers; paper files and accepted evidence are unchanged.

Validation: 59 focused tests and both canonical private release guards, including the authoritative merge check, pass. The full candidate evidence audit passed for 35 papers; KR21 reached the audit's ten-minute build timeout. Its focused build then completed successfully (3,810 jobs), and its evidence retry passed with zero errors. All 36 papers therefore pass across the full run and focused retry; only existing incomplete human-review warnings remain. Hosted full Lean CI is still running.
