### PR TITLE
Repair public audit dispatch and existing support-module builds

### DIFF
--- a/.github/workflows/lean_action_ci.yml
+++ b/.github/workflows/lean_action_ci.yml
@@ -240,6 +240,13 @@ jobs:
         # defaultTargets intentionally excludes some private/new paper targets.
         # Integration must still compile every registered lean_lib.
         run: python3 scripts/paper_target_registration.py build-all
+      - name: Save trusted main project build cache
+        # Persist successful compilation independently of later audit results.
+        if: success() && github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.change-scope.outputs.mode != 'docs'
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: .lake/build
+          key: ${{ runner.os }}-aml-project-v1-${{ hashFiles('lean-toolchain', 'lake-manifest.json') }}-${{ github.sha }}
       - name: Test semantic provenance audits
         if: steps.change-scope.outputs.mode == 'integration'
         run: python3 scripts/run_isolated_audit_tests.py
@@ -285,9 +292,3 @@ jobs:
           SOURCE_FLAG=()
           if [[ "$PUBLIC_SOURCE_MODE" == "true" ]]; then SOURCE_FLAG+=(--allow-missing-source-bytes); fi
           python3 scripts/audit_repository.py --include-active --library-premise-audit --info-limit 0 "${SOURCE_FLAG[@]}"
-      - name: Save trusted main project build cache
-        if: success() && github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.change-scope.outputs.mode != 'docs'
-        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
-        with:
-          path: .lake/build
-          key: ${{ runner.os }}-aml-project-v1-${{ hashFiles('lean-toolchain', 'lake-manifest.json') }}-${{ github.sha }}

--- a/config/formalization_engine_revisions.json
+++ b/config/formalization_engine_revisions.json
@@ -1027,6 +1027,16 @@
       "verification": [
         "94 focused regressions pass; public file, launcher, heading, and diagnostic checks pass; no mathematical Lean changes"
       ]
+    },
+    {
+      "engine_tree_sha256": "93c9256fcee9e597437ed064ec7a555054d579ba7ff4b4315854a0c200e827a9",
+      "formalization_review_protocol_sha256": "ca5ffddd01335d26b9b44d361eeaea34261ea281d4fed0eb4f8d38d85a6c4e70",
+      "rationale": "Ordinary CI uses canonical accepted-graph validation before legacy consumers; public checks retain report and packet requirements without withheld private inputs",
+      "sequence": 87,
+      "verification": [
+        "234 graph-dispatch, source-route, document, and strict-closeout regressions pass; defaults preserve private source requirements and unfinished-paper checks",
+        "Full isolated regression suite: 4,333 tests across 225 modules, zero failed modules"
+      ]
     }
   ],
   "schema": 2

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -96,6 +96,8 @@ srcDir = "papers"
 [[lean_lib]]
 name = "FalahatgarEtAl2017MaxingRanking"
 srcDir = "papers"
+# These already-published support modules are transitive imports of this paper.
+globs = ["FalahatgarEtAl2017MaxingRanking", "ZhouChenLi2014OptimalPACMultipleArm.+"]
 
 [[lean_lib]]
 name = "FreundSchapire1997Hedge"

--- a/papers/DGD26AdmissionsPredictability/FINAL_VALIDATION_REPORT.md
+++ b/papers/DGD26AdmissionsPredictability/FINAL_VALIDATION_REPORT.md
@@ -107,14 +107,6 @@ or optimal assignment totals tie. [Tie rules](docs/SOURCE_CLARIFICATIONS.md#scor
 
 The [appendix corrections](docs/SOURCE_CLARIFICATIONS.md#exact-appendix-corrections) replace the removable-set self-equality, tightly-even parameter, and local set/index expressions. Capacity restrictions are discussed in Section 6.
 
-<!-- BEGIN GENERATED SETTLED REVIEW CONTEXT -->
-<!-- settled-review-context-sha256: 961644235c93d72dbcbdd10a964fb2c2b6b0650d91470bbd0b6bb5d73d5073c6 -->
-<!-- settled-review-context-presentation-sha256: 26b3fa2eafa8d4897ddff237dcc861668656033a6749f28c86b86bec5d9cce22 -->
-### Source readings and additional assumptions
-
-- The result-specific conditions and corrections are stated in the [clarification memo](docs/SOURCE_CLARIFICATIONS.md).
-<!-- END GENERATED SETTLED REVIEW CONTEXT -->
-
 ## 11. Paper Issues or Caveats
 
 None.

--- a/papers/GCG24UserItemFairness/FINAL_VALIDATION_REPORT.md
+++ b/papers/GCG24UserItemFairness/FINAL_VALIDATION_REPORT.md
@@ -55,14 +55,6 @@ No additional generalization is established here.
 
 Theorem 4's cold-start population mass changes from `1-beta` to `1-2 beta` so the three masses sum to one. Appendix E Lemma 15's center equation includes both mirrored types, giving `lambda=1/(1+L_t)`. See the [population note](docs/SOURCE_CLARIFICATIONS.md#theorem-4-population-masses-and-positive-tolerance-section-5-p-7-appendix-e-p-39) and [center-equation note](docs/APPENDIX_E_LEMMA15_SOURCE_NOTE.md#appendix-e-lemma-15-source-clarification).
 
-<!-- BEGIN GENERATED SETTLED REVIEW CONTEXT -->
-<!-- settled-review-context-sha256: 7ed2f7d51f011de1d6e6651cdaa68aa3c867bc958182e40f5c13bf14a0c1dc0a -->
-<!-- settled-review-context-presentation-sha256: 0685128706672e74e3977463dbd8a0e2b2a1323f04cb2d5c2d4b7cd0997fd00c -->
-### Source readings and additional assumptions
-
-- For Theorem 4, the normalized three-type construction uses masses beta, beta, and 1 - 2 beta; the stated beta range keeps all three masses positive.
-<!-- END GENERATED SETTLED REVIEW CONTEXT -->
-
 ## 11. Paper Issues or Caveats
 
 None.

--- a/papers/GHKR22BiasBounties/FINAL_VALIDATION_REPORT.md
+++ b/papers/GHKR22BiasBounties/FINAL_VALIDATION_REPORT.md
@@ -93,14 +93,6 @@ for other prediction models.
 
 Observation 4 becomes an almost-everywhere equivalence for arbitrary laws. Algorithms 4–5 make the shared checker/restart and fresh-block operations explicit; Lemma 15 changes `g_p` to `g`. See the [source memo](docs/SOURCE_CLARIFICATIONS.md) and [compact companion](docs/PUBLIC_FORMALIZATION_NOTE.pdf). Sections 6–7 discuss the other changes.
 
-<!-- BEGIN GENERATED SETTLED REVIEW CONTEXT -->
-<!-- settled-review-context-sha256: 1f0db158e7c8e947434d021d0381e0bded62a619d016e1fd43d2e4d160b77595 -->
-<!-- settled-review-context-presentation-sha256: d3295c9ee0ac3c8e3696ee11edd691c0839961d19a9ec23ddc405edeadc1d403 -->
-### Source readings and additional assumptions
-
-- The mass-weighted group-loss numerator is the total primitive; conditional group loss is totalized to zero at mass zero, and every divided source display is recovered on positive-mass groups.
-<!-- END GENERATED SETTLED REVIEW CONTEXT -->
-
 ## 11. Paper Issues or Caveats
 
 The statement readings and positive-initialization scope are in Sections 6 and 10; the changed proof arguments are in Section 7.

--- a/papers/GHW01DigitalGoods/FINAL_VALIDATION_REPORT.md
+++ b/papers/GHW01DigitalGoods/FINAL_VALIDATION_REPORT.md
@@ -77,14 +77,6 @@ No additional generalization is claimed by this closeout.
 - [Lemma 8.1 and Theorem 8.2](docs/SOURCE_CLARIFICATIONS.md#lemma-81-and-theorem-82): replace the preliminary truthfulness inference by the journal monotone-offer condition.
 - [Logarithmic bounds](docs/SOURCE_CLARIFICATIONS.md#logarithmic-domains): state the denominator domains and distinguish them from the narrower checked range.
 
-<!-- BEGIN GENERATED SETTLED REVIEW CONTEXT -->
-<!-- settled-review-context-sha256: fbbb1f03659f1ee73e2b3ce439ce6b066dbfd1e438d48d11dfd19646f16e6376 -->
-<!-- settled-review-context-presentation-sha256: 6ae044c383931feffe6d5cfd5b8adb27451dbdd819d4a2b0d4a2cb70e4987eab -->
-### Source readings and additional assumptions
-
-- The result-specific conditions and corrections are stated in the [clarification memo](docs/SOURCE_CLARIFICATIONS.md).
-<!-- END GENERATED SETTLED REVIEW CONTEXT -->
-
 ## 11. Paper Issues or Caveats
 
 Section 5 records the randomization and parameter coverage gaps. The journal monotone-offer correction is separate from those formalization limits.

--- a/papers/GKGMM19IterativeLocalVoting/FINAL_VALIDATION_REPORT.md
+++ b/papers/GKGMM19IterativeLocalVoting/FINAL_VALIDATION_REPORT.md
@@ -92,18 +92,6 @@ The memo also specifies the
 Proposition 2's extra geometric condition is in Section 6; the Appendix C.6
 event repair is in Section 7; the deterministic-bias specialization is in Section 5.
 
-<!-- BEGIN GENERATED SETTLED REVIEW CONTEXT -->
-<!-- settled-review-context-sha256: a5bfeaf5393a333e870284a9c971b67402ac669beec9114f7d2155c88d3b8e9e -->
-<!-- settled-review-context-presentation-sha256: 90124902293868ed5af1ed307f5fc72c65c891bf89d33dd0efa2e81be9dbfd70 -->
-### Source readings and additional assumptions
-
-- The checked Appendix Theorem 5 is specialized to a deterministic summable bias sequence. This suffices for the zero-bias main-text application; the broader adapted-bias statement is not established by this specialization.
-- When the displayed Model B gradient is zero, the voter remains at the current point.
-- For Proposition 2 with a Linfinity neighborhood, Model B moves every non-tied decomposition coordinate by the full current radius toward that coordinate of the sampled voter's ideal; tied coordinates do not move.
-- The checked Proposition 2 assumes that replacing one coordinate of a feasible point by that of another feasible point preserves feasibility. This is stronger than C1’s closed convex domain; it is the current statement scope, not a proved necessary condition for the conclusion.
-- The checked Theorem 3 zero-field result uses an explicit full-space condition; the constrained-space result gives zero field or no feasible aggregate direction. The printed theorem invokes C1–C3, including bounded convex X; these results alone do not prove or refute zero field on every such X.
-<!-- END GENERATED SETTLED REVIEW CONTEXT -->
-
 ## 11. Paper Issues or Caveats
 
 The statement scopes and proof replacements have their respective explanations in Sections 6, 7, and 9; the memo linked in Section 10 supplies the details.

--- a/papers/GS62CollegeAdmissions/FINAL_VALIDATION_REPORT.md
+++ b/papers/GS62CollegeAdmissions/FINAL_VALIDATION_REPORT.md
@@ -76,14 +76,6 @@ vacancy blocks and mutual acceptability. Page 10's replacement-pair definition
 remains a separate literal claim. The [memo](docs/SOURCE_CLARIFICATIONS.md#reading-used-for-theorem-2)
 explains the distinction.
 
-<!-- BEGIN GENERATED SETTLED REVIEW CONTEXT -->
-<!-- settled-review-context-sha256: aa8087a4dfdf0d5e9c6df25e751cee64b2500ecc917f94b494bb0bc7faa6c79a -->
-<!-- settled-review-context-presentation-sha256: 1d96adc5888518e89d45d4268b1d84b158cfc02d6a2a0e67980b4d80b6cff309 -->
-### Source readings and additional assumptions
-
-- The result-specific conditions and corrections are stated in the [clarification memo](docs/SOURCE_CLARIFICATIONS.md).
-<!-- END GENERATED SETTLED REVIEW CONTEXT -->
-
 ## 11. Paper Issues or Caveats
 
 None within the reviewed named theoretical surface. The distinct scope of the

--- a/papers/GeEtAl2024AlignmentAxioms/FINAL_VALIDATION_REPORT.md
+++ b/papers/GeEtAl2024AlignmentAxioms/FINAL_VALIDATION_REPORT.md
@@ -93,15 +93,6 @@ paper-local constructions retain their exact feature tables and profiles.
 
 Footnote 7's six-candidate ranking uses parameter `(delta,2)` in place of `(1,1)`; see the [witness note](docs/SOURCE_CLARIFICATIONS_AND_CORRECTIONS.md#six-candidate-feasibility-witness). Sections 6–7 cover the other statement scopes and proof changes.
 
-<!-- BEGIN GENERATED SETTLED REVIEW CONTEXT -->
-<!-- settled-review-context-sha256: 52f17d07ecede417d7ae6c3e8a2855c496150759993ce0571f176b498302ddeb -->
-<!-- settled-review-context-presentation-sha256: cdd1947c589bccfc799d482410690a59004dc3e30f3666949882a5bf3aa76c4f -->
-### Source readings and additional assumptions
-
-- The checked C.5 counterexample retains the source proof’s local choice of v1 on its first profile as an explicit premise. Recording that premise does not itself prove a reduction from every Pareto-Kemeny selector.
-- The checked C.6 rule uses a fixed profile-independent tie key for the sequential highest-plurality prescription. Strict plurality comparisons are unchanged; the theorem has this specified rule-family scope.
-<!-- END GENERATED SETTLED REVIEW CONTEXT -->
-
 ## 11. Paper Issues or Caveats
 
 Section 7 explains the proof replacements and misplaced example attribution. Section 6 states the rule-selection scope; Section 10 links the exact local corrections.

--- a/papers/KR21Monoculture/FINAL_VALIDATION_REPORT.md
+++ b/papers/KR21Monoculture/FINAL_VALIDATION_REPORT.md
@@ -62,14 +62,6 @@ scope is described in the [source note](docs/SOURCE_CLARIFICATIONS.md#representa
   finite first moments, measurable ranking probabilities, and well-defined
   conditional and payoff expectations. [Details](docs/SOURCE_CLARIFICATIONS.md#representation-boundaries).
 
-<!-- BEGIN GENERATED SETTLED REVIEW CONTEXT -->
-<!-- settled-review-context-sha256: 6ae32f599d7c6805a0db1854e0586e8fa4276d8aeaee501756447b5629a75785 -->
-<!-- settled-review-context-presentation-sha256: 451017f402148b8476e86669a1ba8eb09b323afff4ee29d9b706551faf116e5b -->
-### Source readings and additional assumptions
-
-- **Additional assumptions.** Equation (6)'s total-family regularity inputs are discussed in Section 6; the [memo](docs/SOURCE_CLARIFICATIONS.md#representation-boundaries) distinguishes them from source-model conditions.
-<!-- END GENERATED SETTLED REVIEW CONTEXT -->
-
 ## 7. Proof-Strategy Deviations
 
 Appendix C.1's derivative-to-limit step is replaced by direct strict comparisons

--- a/papers/LBG24SpatialUnderreporting/FINAL_VALIDATION_REPORT.md
+++ b/papers/LBG24SpatialUnderreporting/FINAL_VALIDATION_REPORT.md
@@ -103,15 +103,6 @@ separation once their process laws and definedness conditions are supplied.
 
 The [memo](docs/SOURCE_CLARIFICATIONS.md) specifies calendar-time first reports and Equation (3)’s nonnegative-rate endpoint. Section 6 states Proposition 1’s positive-rate scope, and Section 7 links the two likelihood-algebra corrections.
 
-<!-- BEGIN GENERATED SETTLED REVIEW CONTEXT -->
-<!-- settled-review-context-sha256: d1e306b2b8f6bb3d93ebfaf3f886bc4e4b4b7111955cad3935d5102cd37b6066 -->
-<!-- settled-review-context-presentation-sha256: 2b6c571267628ce0df39723bfe0208580453ab292e44fa0a3dd8d0231e8a2257 -->
-### Source readings and additional assumptions
-
-- **Additional assumptions.** The additional conditions have their main discussion in Section 6 and the [clarification memo](docs/SOURCE_CLARIFICATIONS.md).
-- The result-specific conditions and corrections are stated in the [clarification memo](docs/SOURCE_CLARIFICATIONS.md).
-<!-- END GENERATED SETTLED REVIEW CONTEXT -->
-
 ## 11. Paper Issues or Caveats
 
 Section 5 records the formalization gap in Lemma 2 and Appendix D.8.2.

--- a/papers/LG21TestOptionalPolicies/FINAL_VALIDATION_REPORT.md
+++ b/papers/LG21TestOptionalPolicies/FINAL_VALIDATION_REPORT.md
@@ -65,16 +65,6 @@ The [memo](docs/SOURCE_CLARIFICATIONS.md) gives the nonreport-mixture and
 [cutoff correction](docs/SOURCE_CLARIFICATIONS.md#lemma-41-and-proposition-43-calculations), the randomized-policy example and checked operational
 blankness conclusion, and the unconditional Gaussian variance calculation.
 
-<!-- BEGIN GENERATED SETTLED REVIEW CONTEXT -->
-<!-- settled-review-context-sha256: 768fc111179d3b42af7bcea57fdef0e1cd204d98f2a965bd531c03f8c5dd66a3 -->
-<!-- settled-review-context-presentation-sha256: fdee972c1b72c7867956c878ff28a320eca6dc4553e08c766891aaacad4f11ee -->
-### Source readings and additional assumptions
-
-- **Formalization gap:** the [Section 4 explanation](docs/SOURCE_CLARIFICATIONS.md#equilibrium-timing-population-laws-and-active-branches) records the added maximal active-branch selection, which has not been derived from the source equilibrium definition.
-- The [access-law explanation](docs/SOURCE_CLARIFICATIONS.md#equilibrium-timing-population-laws-and-active-branches) distinguishes the source's uncorrelated-access wording from the independence used by the current law.
-- The [equilibrium-timing explanation](docs/SOURCE_CLARIFICATIONS.md#equilibrium-timing-population-laws-and-active-branches) states the local recalibration refinement separately for optional and required reporting.
-<!-- END GENERATED SETTLED REVIEW CONTEXT -->
-
 ## 11. Paper Issues or Caveats
 
 The equilibrium coverage gaps are in Section 5. Section 6 distinguishes the supported randomized-output obstruction from conditions whose necessity is unknown.

--- a/papers/PKG25NoFreeLunch/FINAL_VALIDATION_REPORT.md
+++ b/papers/PKG25NoFreeLunch/FINAL_VALIDATION_REPORT.md
@@ -80,14 +80,6 @@ conditional-expectation infrastructure and is outside this paper's proof.
 
 The memo gives the [loss/accuracy correction](docs/SOURCE_CLARIFICATIONS.md#loss-correctness-and-calibration), [component-weight typo and null-cell completion](docs/SOURCE_CLARIFICATIONS.md#mixtures-and-finite-partitions), and [Proposition 9 parameter/denominator fixes](docs/SOURCE_CLARIFICATIONS.md#proposition-9s-two-settings).
 
-<!-- BEGIN GENERATED SETTLED REVIEW CONTEXT -->
-<!-- settled-review-context-sha256: 908c66a18323f2577411dc8eec37a35e314fe673eefa40bc69c61257bd1e7fd9 -->
-<!-- settled-review-context-presentation-sha256: 6d01ddf4fae5fae3315dbd54c89379fc93464fee062afaa9fb810c243f449df4 -->
-### Source readings and additional assumptions
-
-- The result-specific conditions and corrections are stated in the [clarification memo](docs/SOURCE_CLARIFICATIONS.md).
-<!-- END GENERATED SETTLED REVIEW CONTEXT -->
-
 ## 11. Paper Issues or Caveats
 
 None beyond the specific qualifications in Section 10.

--- a/scripts/audit_repository.py
+++ b/scripts/audit_repository.py
@@ -1908,6 +1908,42 @@ def check_final_report_human_facing_front_matter(
     return findings
 
 
+def check_graph_native_paper_closure(
+    include_active: bool,
+    *,
+    paper_filter: str | None,
+    require_source_bytes: bool,
+    selected_papers: set[str],
+) -> list[Finding]:
+    """Validate the canonical graph once before ordinary audit consumers run.
+
+    The selected set is execution-local routing, never acceptance evidence.
+    Failed credentials remain errors and do not launch a legacy producer.
+    Papers without graph credentials retain their existing checks.
+    """
+
+    from scripts.audit_evidence_integrity import graph_native_closure_fast_path_findings
+
+    selected_papers.clear()
+    findings: list[Finding] = []
+    for folder in paper_dirs():
+        if paper_filter is not None and folder.name != paper_filter:
+            continue
+        if folder.name in ACTIVE_PAPERS and not include_active:
+            continue
+        graph_findings = graph_native_closure_fast_path_findings(
+            folder, release=False, require_source_bytes=require_source_bytes,
+        )
+        if graph_findings is None:
+            continue
+        selected_papers.add(folder.name)
+        findings.extend(
+            Finding(finding.severity, ROOT / finding.path, finding.message)
+            for finding in graph_findings
+        )
+    return findings
+
+
 def check_dag_and_validation_report_closeout(
     include_active: bool,
     paper_filter: str | None = None,
@@ -1916,6 +1952,7 @@ def check_dag_and_validation_report_closeout(
     final_holistic_surface_sha256: str = "",
     all_selected_semantic_review_sha256: str | None = None,
     final_holistic_review_policy_assurance: Mapping[str, object] | None = None,
+    public_graph_papers: Iterable[str] = (),
 ) -> list[Finding]:
     """Ensure completed paper closeout audits include DAG/report evidence."""
 
@@ -1941,8 +1978,11 @@ def check_dag_and_validation_report_closeout(
         dag_tex = paper_relative_file(folder, DEPENDENCY_DAG_TEX_FILE, "DependencyDAG.tex")
         dag_pdf = paper_relative_file(folder, DEPENDENCY_DAG_PDF_FILE, "DependencyDAG.pdf")
         agent_source_audit = folder / AGENT_SOURCE_AUDIT_FILE
-        corrected_scope_current = current_author_approved_corrected_scope(
-            folder, status_payload
+        recorded_public_graph = folder.name in public_graph_papers
+        corrected_scope_current = (
+            False if recorded_public_graph else current_author_approved_corrected_scope(
+                folder, status_payload
+            )
         )
         final_holistic_required = explicit_raw_source_spec_screening_requested(
             status_payload
@@ -1951,7 +1991,13 @@ def check_dag_and_validation_report_closeout(
             folder,
             corrected_scope_current=corrected_scope_current,
             final_holistic_required=final_holistic_required,
+            # Public graph validation authenticates the recorded review and
+            # current Lean inputs without the withheld private approval/cache
+            # records. Ordinary CI still checks the published report surface;
+            # the strict paper-closeout caller retains every terminal gate.
             require_visual_dag_inspection=True,
+            check_private_review_artifacts=not recorded_public_graph,
+            check_final_holistic=not recorded_public_graph,
             final_holistic_surface_sha256=final_holistic_surface_sha256,
             all_selected_semantic_review_sha256=(
                 all_selected_semantic_review_sha256
@@ -18342,7 +18388,9 @@ def check_paper_facing_ledgers(include_active: bool) -> list[Finding]:
     return findings
 
 
-def check_post_paper_audit_interfaces(include_active: bool) -> list[Finding]:
+def check_post_paper_audit_interfaces(
+    include_active: bool, *, graph_native_papers: Iterable[str] = (),
+) -> list[Finding]:
     findings: list[Finding] = []
     interface_required = {
         folder.name
@@ -18384,13 +18432,17 @@ def check_post_paper_audit_interfaces(include_active: bool) -> list[Finding]:
         if interface.exists():
             text = interface.read_text(encoding="utf-8")
             if folder.name in interface_required and aggregator.exists():
-                import_line = f"import {folder.name}.PaperInterface"
-                if import_line not in aggregator.read_text(encoding="utf-8"):
+                from scripts.lean_signature_manifest import repository_module_names_in_import_closure
+
+                # This is an export-hygiene diagnostic, not Lean acceptance.
+                # A ProofInterface carrier can reach PaperInterface transitively.
+                imported = repository_module_names_in_import_closure(ROOT, folder.name)
+                if f"{folder.name}.PaperInterface" not in imported:
                     findings.append(
                         Finding(
                             "ERROR",
                             aggregator,
-                            "completed/formalized paper root should import `PaperInterface.lean`",
+                            "completed/formalized paper root should reach `PaperInterface.lean` through its imports",
                         )
                     )
             if "PProd" in text:
@@ -18404,7 +18456,10 @@ def check_post_paper_audit_interfaces(include_active: bool) -> list[Finding]:
                     Finding("ERROR", human_interface, "human-facing interface should not use tuple witnesses")
                 )
             tuple_witness_decls = interface_tuple_witness_declarations(text)
-            if tuple_witness_decls:
+            # A validated graph checks exact typed source targets. Products can
+            # be intentional source definitions or factors inside an equation;
+            # the older tuple-wrapper heuristic is not a second adjudicator.
+            if tuple_witness_decls and folder.name not in graph_native_papers:
                 sample_line, sample_name = tuple_witness_decls[0]
                 findings.append(
                     Finding(
@@ -19242,6 +19297,7 @@ def check_machine_paper_status(
     run_context: PaperCloseoutRunContext | None = None,
     phase_timings: MutableMapping[str, float] | None = None,
     phase_progress_callback: Callable[[Mapping[str, object]], None] | None = None,
+    graph_native_papers: Iterable[str] = (),
 ) -> list[Finding]:
     findings: list[Finding] = []
     using_paper_local_fallback = False
@@ -19477,6 +19533,13 @@ def check_machine_paper_status(
                 findings.append(
                     Finding("ERROR", PAPER_STATUS_FILE, f"`{paper_id}` has reviewed_rows greater than total_rows")
                 )
+
+        if not paper_closeout and paper_id in graph_native_papers:
+            # Basic status and human-review metadata above still apply. The
+            # earlier canonical graph validator owns source roles, proof routes,
+            # and material dependencies; legacy reconstruction cannot add or
+            # revoke acceptance and can write obsolete source-record outputs.
+            continue
 
         interface = entry.get("paper_interface")
         if not isinstance(interface, dict):

--- a/scripts/closeout_document_gates.py
+++ b/scripts/closeout_document_gates.py
@@ -159,6 +159,7 @@ def closeout_document_hard_errors(
     final_holistic_required: bool = False,
     check_final_holistic: bool = True,
     require_visual_dag_inspection: bool = False,
+    check_private_review_artifacts: bool = True,
     final_holistic_surface_sha256: str = "",
     all_selected_semantic_review_sha256: str | None = None,
     final_holistic_review_policy_assurance: Mapping[str, object] | None = None,
@@ -178,6 +179,11 @@ def closeout_document_hard_errors(
     at the terminal-document boundary, after the semantic graph and focused
     build are current; it must not make draft documentation an early audit
     prerequisite.
+
+    ``check_private_review_artifacts=False`` is reserved for ordinary public
+    transport validation after the caller validates the canonical recorded
+    graph. It preserves published report and packet checks; strict paper
+    closeout always keeps the default and verifies its private review inputs.
     """
 
     errors: list[CloseoutDocumentHardError] = []
@@ -233,7 +239,7 @@ def closeout_document_hard_errors(
                     )
                 )
 
-    if require_visual_dag_inspection:
+    if require_visual_dag_inspection and check_private_review_artifacts:
         semantic_basis = (
             all_selected_semantic_review_sha256
             if final_holistic_required
@@ -256,6 +262,17 @@ def closeout_document_hard_errors(
                     "human-review packet: " + packet_error,
                 )
             )
+
+    if require_visual_dag_inspection and not check_private_review_artifacts:
+        # Ordinary public CI has already authenticated the immutable recorded
+        # graph and current Lean inputs. Private review/cache records are not
+        # exported, but the published human packet must still be available.
+        for suffix in ("tex", "pdf"):
+            packet_path = folder / "docs" / f"{PACKET_NAME}.{suffix}"
+            if not packet_path.is_file() or not packet_path.stat().st_size:
+                errors.append(CloseoutDocumentHardError(
+                    packet_path, "missing or empty published human-review packet artifact",
+                ))
 
     if post_audit.is_file():
         try:

--- a/scripts/repository_check_registry.py
+++ b/scripts/repository_check_registry.py
@@ -106,6 +106,10 @@ def ordinary_repository_checks(
 ) -> tuple[RegisteredCheck[Any], ...]:
     """Return the complete ordinary non-closeout repository check registry."""
 
+    # This selection belongs to one ordered audit execution. The graph check
+    # fills it only after invoking the canonical validator; errors stay in the
+    # result and selected graphs never fall back to legacy evidence producers.
+    graph_native_papers: set[str] = set()
     checks: list[RegisteredCheck[Any]] = [
         *(
             _bound(name, function, include_active)
@@ -129,6 +133,14 @@ def ordinary_repository_checks(
         ),
         _bound("paper_contract", audit.check_paper_contract, include_active),
         _bound(
+            "graph_native_paper_closure",
+            audit.check_graph_native_paper_closure,
+            include_active,
+            paper_filter=paper_filter,
+            require_source_bytes=require_source_bytes,
+            selected_papers=graph_native_papers,
+        ),
+        _bound(
             "final_report_status_alignment",
             audit.check_final_report_status_alignment,
             include_active,
@@ -145,11 +157,15 @@ def ordinary_repository_checks(
             audit.check_dag_and_validation_report_closeout,
             include_active=include_active,
             paper_filter=paper_filter,
+            public_graph_papers=graph_native_papers if not require_source_bytes else (),
         ),
         _bound("review_launcher_readiness", audit.check_review_launcher_readiness, include_active),
         _bound("dag_status_styles", audit.check_dag_status_styles),
         _bound("paper_facing_ledgers", audit.check_paper_facing_ledgers, include_active),
-        _bound("post_paper_audit_interfaces", audit.check_post_paper_audit_interfaces, include_active),
+        _bound(
+            "post_paper_audit_interfaces", audit.check_post_paper_audit_interfaces,
+            include_active, graph_native_papers=graph_native_papers,
+        ),
         _bound(
             "machine_paper_status",
             audit.check_machine_paper_status,
@@ -158,6 +174,7 @@ def ordinary_repository_checks(
             paper_closeout=False,
             require_source_bytes=require_source_bytes,
             deep_paper_prose=deep_paper_prose,
+            graph_native_papers=graph_native_papers,
         ),
         *(
             _bound(name, function)

--- a/scripts/tests/test_audit_repository_review_item_reuse.py
+++ b/scripts/tests/test_audit_repository_review_item_reuse.py
@@ -1646,6 +1646,7 @@ class PaperCloseoutRunContextTests(unittest.TestCase):
             "check_library_source_hygiene",
             "check_generic_source_reference_hygiene",
             "check_paper_contract",
+            "check_graph_native_paper_closure",
             "check_final_report_status_alignment",
             "check_final_report_human_facing_front_matter",
             "check_dag_and_validation_report_closeout",

--- a/scripts/tests/test_ordinary_graph_audit_dispatch.py
+++ b/scripts/tests/test_ordinary_graph_audit_dispatch.py
@@ -1,0 +1,162 @@
+"""Ordinary CI validates recorded graphs without replaying private producers."""
+
+import json
+import tempfile
+import unittest
+from contextlib import ExitStack
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from scripts import audit_evidence_integrity as evidence
+from scripts import audit_repository as audit
+from scripts import closeout_document_gates as documents
+from scripts.repository_check_registry import ordinary_repository_checks
+
+
+class OrdinaryGraphAuditTests(unittest.TestCase):
+    def setUp(self):
+        self.stack = ExitStack()
+        self.addCleanup(self.stack.close)
+        self.root = Path(self.stack.enter_context(tempfile.TemporaryDirectory()))
+        self.folder = self.root / "papers" / "AB24Example"
+        self.folder.mkdir(parents=True)
+        self.stack.enter_context(patch.object(audit, "ROOT", self.root))
+        self.stack.enter_context(patch.object(audit, "PAPERS", self.root / "papers"))
+        self.stack.enter_context(patch.object(audit, "PAPER_STATUS_FILE", self.root / "papers/status.json"))
+        self.stack.enter_context(patch.object(audit, "paper_dirs", return_value=[self.folder]))
+        self.stack.enter_context(patch.object(audit, "ACTIVE_PAPERS", set()))
+
+    def registry(self, require_source_bytes=True):
+        return {check.name: check for check in ordinary_repository_checks(
+            audit, include_active=True, strict_style=False,
+            library_premise_audit=False, paper_filter=None,
+            require_source_bytes=require_source_bytes, deep_paper_prose=False,
+        )}
+
+    def status(self, **updates):
+        entry = {
+            "id": self.folder.name, "title": "Example", "source_version": "v1",
+            "build_target": self.folder.name, "status": "formalized",
+            "review_entrypoint": "review-dashboard.sh",
+            "human_review": {"reviewed_rows": 0, "total_rows": 1, "stale_rows": 0, "mismatch_rows": 0},
+        }
+        entry.update(updates)
+        (self.folder / "status.json").write_text(json.dumps(entry), encoding="utf-8")
+        audit.PAPER_STATUS_FILE.write_text(json.dumps({"schema": 1, "papers": [entry]}), encoding="utf-8")
+        return entry
+
+    def test_canonical_errors_block_and_selected_graphs_never_fall_back(self):
+        error = evidence.Finding("ERROR", self.folder.name, "papers/AB24Example/audit/receipt.json", "invalid current graph")
+        for require_source in (True, False):
+            with self.subTest(require_source=require_source), patch.object(
+                evidence, "graph_native_closure_fast_path_findings", return_value=[error],
+            ) as validator, patch.object(audit, "check_machine_paper_status", return_value=[]) as machine:
+                checks = self.registry(require_source)
+                findings = checks["graph_native_paper_closure"].run()
+                self.assertEqual([(f.severity, f.message) for f in findings], [("ERROR", "invalid current graph")])
+                checks["machine_paper_status"].run()
+                self.assertEqual(machine.call_args.kwargs["graph_native_papers"], {self.folder.name})
+                validator.assert_called_once_with(self.folder, release=False, require_source_bytes=require_source)
+
+    def test_legacy_papers_are_not_selected_and_selection_does_not_leak_between_runs(self):
+        with patch.object(evidence, "graph_native_closure_fast_path_findings", return_value=[]), patch.object(
+            audit, "check_machine_paper_status", return_value=[],
+        ) as machine:
+            first = self.registry()
+            first["graph_native_paper_closure"].run()
+            first["machine_paper_status"].run()
+            self.assertEqual(machine.call_args.kwargs["graph_native_papers"], {self.folder.name})
+            with patch.object(evidence, "graph_native_closure_fast_path_findings", return_value=None):
+                first["graph_native_paper_closure"].run()
+            first["machine_paper_status"].run()
+            self.assertEqual(machine.call_args.kwargs["graph_native_papers"], set())
+            second = self.registry()
+            with patch.object(evidence, "graph_native_closure_fast_path_findings", return_value=None):
+                second["graph_native_paper_closure"].run()
+            second["machine_paper_status"].run()
+            self.assertEqual(machine.call_args.kwargs["graph_native_papers"], set())
+
+    def test_only_explicit_public_mode_uses_recorded_public_document_inputs(self):
+        for require_source in (True, False):
+            with self.subTest(require_source=require_source), patch.object(
+                evidence, "graph_native_closure_fast_path_findings", return_value=[],
+            ), patch.object(audit, "check_dag_and_validation_report_closeout", return_value=[]) as document_check:
+                checks = self.registry(require_source)
+                checks["graph_native_paper_closure"].run()
+                checks["dag_and_validation_report_closeout"].run()
+                selected = document_check.call_args.kwargs["public_graph_papers"]
+                self.assertEqual(set(selected), set() if require_source else {self.folder.name})
+
+    def test_selected_graph_skips_legacy_reconstruction_but_keeps_basic_status_validation(self):
+        self.status()
+        with patch.object(audit, "current_author_approved_corrected_scope", side_effect=AssertionError("legacy replay")):
+            self.assertEqual(audit.check_machine_paper_status(graph_native_papers={self.folder.name}), [])
+            self.status(title="")
+            findings = audit.check_machine_paper_status(graph_native_papers={self.folder.name})
+            self.assertTrue(any(f.severity == "ERROR" and "missing `title`" in f.message for f in findings))
+            self.status(human_summary_review={"status": "human_approved"})
+            findings = audit.check_machine_paper_status(graph_native_papers={self.folder.name})
+            self.assertTrue(any(f.severity == "ERROR" and "no `human_summary`" in f.message for f in findings))
+
+    def test_unfinished_papers_keep_existing_validation(self):
+        self.status(status="in progress", paper_interface={}, review_surface={})
+        with patch.object(audit, "current_author_approved_corrected_scope", side_effect=RuntimeError("legacy gate reached")):
+            with self.assertRaisesRegex(RuntimeError, "legacy gate reached"):
+                audit.check_machine_paper_status(graph_native_papers=set())
+
+    def test_transitive_interface_import_is_allowed_but_missing_export_still_blocks(self):
+        self.status()
+        (self.folder / "PaperInterface.lean").write_text("def exampleSpec : Prop := True\n", encoding="utf-8")
+        (self.folder / "ProofInterface.lean").write_text("import AB24Example.PaperInterface\n", encoding="utf-8")
+        self.folder.with_suffix(".lean").write_text("import AB24Example.ProofInterface\n", encoding="utf-8")
+        findings = audit.check_post_paper_audit_interfaces(True)
+        self.assertFalse(any(f.severity == "ERROR" for f in findings), findings)
+        (self.folder / "ProofInterface.lean").write_text("-- import AB24Example.PaperInterface\n", encoding="utf-8")
+        findings = audit.check_post_paper_audit_interfaces(True)
+        self.assertTrue(any(f.severity == "ERROR" and "through its imports" in f.message for f in findings))
+
+    def test_authenticated_source_definitions_are_not_rejected_by_legacy_tuple_heuristic(self):
+        self.status()
+        (self.folder / "PaperInterface.lean").write_text("def exampleSpec : (Nat → Prop) × (Nat → Prop) := (fun _ => True, fun _ => True)\n", encoding="utf-8")
+        self.folder.with_suffix(".lean").write_text("import AB24Example.PaperInterface\n", encoding="utf-8")
+        self.assertTrue(any("tuple/prod" in f.message for f in audit.check_post_paper_audit_interfaces(True)))
+        self.assertFalse(any("tuple/prod" in f.message for f in audit.check_post_paper_audit_interfaces(True, graph_native_papers={self.folder.name})))
+
+    def test_public_documents_still_require_packet_artifacts_and_valid_report_sections(self):
+        docs = self.folder / "docs"
+        docs.mkdir()
+        (self.folder / "FINAL_VALIDATION_REPORT.md").write_text("# Report\n", encoding="utf-8")
+        with patch.object(documents, "final_report_section_errors", return_value=["required report section absent"]), patch.object(
+            documents, "reader_facing_result_label_errors", return_value=[],
+        ), patch.object(documents, "current_approved_review_context_report_errors", return_value=[]), patch.object(
+            documents, "report_memo_coverage_errors", side_effect=AssertionError("private memo evidence"),
+        ), patch.object(documents, "current_human_review_packet_errors", side_effect=AssertionError("private cache")):
+            errors = documents.closeout_document_hard_errors(
+                self.folder, corrected_scope_current=False, check_final_holistic=False,
+                require_visual_dag_inspection=True, check_private_review_artifacts=False,
+            )
+            self.assertTrue(any("required report section absent" in error.message for error in errors))
+            self.assertEqual(sum("published human-review packet" in error.message for error in errors), 2)
+            for suffix in ("pdf", "tex"):
+                (docs / f"HUMAN_REVIEW_PACKET.{suffix}").write_text("published artifact", encoding="utf-8")
+            errors = documents.closeout_document_hard_errors(
+                self.folder, corrected_scope_current=False, check_final_holistic=False,
+                require_visual_dag_inspection=True, check_private_review_artifacts=False,
+            )
+            self.assertFalse(any("published human-review packet" in error.message for error in errors))
+
+    def test_default_document_gate_still_checks_private_review_inputs(self):
+        with patch.object(documents, "report_memo_coverage_errors", return_value=["missing private coverage"]) as coverage, patch.object(
+            documents, "current_human_review_packet_errors", return_value=["missing private cache"],
+        ) as packet, patch.object(documents, "final_holistic_audit_hard_errors", return_value=[]) as holistic:
+            errors = documents.closeout_document_hard_errors(self.folder, corrected_scope_current=False, require_visual_dag_inspection=True)
+            self.assertTrue(any("missing private coverage" in error.message for error in errors))
+            self.assertTrue(any("missing private cache" in error.message for error in errors))
+            coverage.assert_called_once()
+            packet.assert_called_once()
+            holistic.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_repository_check_registry.py
+++ b/scripts/tests/test_repository_check_registry.py
@@ -121,6 +121,7 @@ class RepositoryCheckRegistryTests(unittest.TestCase):
                 "library_source_hygiene",
                 "generic_source_reference_hygiene",
                 "paper_contract",
+                "graph_native_paper_closure",
                 "final_report_status_alignment",
                 "final_report_human_facing_front_matter",
                 "dag_and_validation_report_closeout",


### PR DESCRIPTION
Ordinary repository CI now validates canonical accepted graphs before legacy audit consumers and checks the published report and packet surfaces without requiring withheld review records. Invalid graphs and incomplete paper checks remain blocking. The patch also removes retired generated blocks from 11 existing reports while preserving their remaining text.

Falahatgar's existing public Zhou dependency modules are registered for compilation, fixing the missing-module failure on a clean runner. Successful main builds save their cache before later audit steps. No paper, Lean source, status, accepted graph, or private review artifact is added.

Validation: 4,333 tests across 225 isolated modules passed; 234 focused audit regressions and 28 workflow/registration tests passed; Falahatgar and its support modules rebuilt successfully after preserving and removing their cached interfaces (3,679 jobs). Both canonical release guards passed. The full public ordinary audit passed with 0 errors, 984 warnings and 1,204 informational findings; aggregate status is synchronized. The broader local all-target build and hosted Actions run remain in progress, so full CI success is not claimed.
