### PR TITLE
Build existing shared matching support modules

### DIFF
--- a/lakefile.toml
+++ b/lakefile.toml
@@ -202,6 +202,8 @@ srcDir = "papers"
 [[lean_lib]]
 name = "PG23MonocultureMatching"
 srcDir = "papers"
+# Existing matching support modules are shared by this paper and PG24.
+globs = ["PG23MonocultureMatching", "AL16SupplyDemandMatching.+"]
 
 [[lean_lib]]
 name = "PG24NoisyMatchingMarkets"


### PR DESCRIPTION
PG23 and PG24 import six AL16 support modules that were already tracked publicly but had no Lake build registration. Cached interfaces hid the missing-module failure on developer machines. This two-line configuration change selects those existing modules under PG23 so Lake builds them for both papers.

No Lean source, paper status, library target, default target, or accepted evidence is changed or added; the public paper set remains 36.

Validation: the source-only import-registration diagnostic inspected 1,873 repository modules and 6,239 import edges; these six modules were its only findings and are all covered by the new glob. Removing their cached interfaces reproduced the missing-prefix failure. The cold support-module and PG23/PG24 build passed (3,743 jobs), the full integration build passed for all 38 registered Lean libraries, and both canonical release guards passed.
