### PR TITLE
Document published report and CI maintenance

### DIFF
--- a/docs/RELEASE_LOG.md
+++ b/docs/RELEASE_LOG.md
@@ -3,6 +3,25 @@
 This log highlights changes that affect what readers can rely on. Reports retain
 the precise result-by-result statements and qualifications.
 
+## September 8, 2026 — Reports and CI maintenance
+
+- **Documentation:** removed obsolete generated audit summaries from the reports for
+  [DGD26](https://gargnikhil.com/AppliedModelingLib/artifacts/papers/DGD26AdmissionsPredictability/FINAL_VALIDATION_REPORT.html),
+  [GCG24](https://gargnikhil.com/AppliedModelingLib/artifacts/papers/GCG24UserItemFairness/FINAL_VALIDATION_REPORT.html),
+  [GHKR22](https://gargnikhil.com/AppliedModelingLib/artifacts/papers/GHKR22BiasBounties/FINAL_VALIDATION_REPORT.html),
+  [GHW01](https://gargnikhil.com/AppliedModelingLib/artifacts/papers/GHW01DigitalGoods/FINAL_VALIDATION_REPORT.html),
+  [GKGMM19](https://gargnikhil.com/AppliedModelingLib/artifacts/papers/GKGMM19IterativeLocalVoting/FINAL_VALIDATION_REPORT.html),
+  [GS62](https://gargnikhil.com/AppliedModelingLib/artifacts/papers/GS62CollegeAdmissions/FINAL_VALIDATION_REPORT.html),
+  [Ge et al. (2024)](https://gargnikhil.com/AppliedModelingLib/artifacts/papers/GeEtAl2024AlignmentAxioms/FINAL_VALIDATION_REPORT.html),
+  [KR21](https://gargnikhil.com/AppliedModelingLib/artifacts/papers/KR21Monoculture/FINAL_VALIDATION_REPORT.html),
+  [LBG24](https://gargnikhil.com/AppliedModelingLib/artifacts/papers/LBG24SpatialUnderreporting/FINAL_VALIDATION_REPORT.html),
+  [LG21](https://gargnikhil.com/AppliedModelingLib/artifacts/papers/LG21TestOptionalPolicies/FINAL_VALIDATION_REPORT.html),
+  [PKG25](https://gargnikhil.com/AppliedModelingLib/artifacts/papers/PKG25NoFreeLunch/FINAL_VALIDATION_REPORT.html). Detailed result statements and qualifications are retained.
+- **Proofs and coverage:** the maintenance updates retain the same 36 papers and mathematical claims. The LG21 Lean edits only guard existing diagnostic commands.
+- **Validation tooling:** updated public evidence readers and review launchers, and registered already-published support modules used by Falahatgar et al. (2017), PG23 and PG24.
+
+[Maintenance changes, PRs #46–54](https://github.com/nikhgarg/AppliedModelingLib/compare/12bf6330436b1e6e718f8beba0d7fdfb55d2c487...8c9bfda5db334096e92952c79681e020c3b06f2a) · [Report cleanup](https://github.com/nikhgarg/AppliedModelingLib/pull/53).
+
 ## September 7, 2026 — Accuracy–diversity and website follow-up
 
 - **Proofs and coverage — PRPKG24, Reconciling the Accuracy–Diversity Trade-off


### PR DESCRIPTION
The release log now covers the report cleanup and CI maintenance shipped in PRs #46–54. It links the eleven updated reports and distinguishes documentation and validation-tooling changes from unchanged mathematical claims and coverage.

Only `docs/RELEASE_LOG.md` changes. The same 36 papers remain public.

Validation: canonical private release guard passed, public status synchronization passed, and `git diff --check` passed. All linked reports were verified on the deployed site.
